### PR TITLE
fix: add asyncio.Lock to WebSocket pool for thread safety

### DIFF
--- a/tools/websh_tools.py
+++ b/tools/websh_tools.py
@@ -150,15 +150,16 @@ async def get_or_create_channel(
                         )
                         await ws.ping()
 
-                        # Store in pools under lock
+                        # Store in pools under lock (copy to avoid leaking metadata)
                         async with _pool_lock:
                             websocket_pool[channel_id] = {
                                 'websocket': ws,
                                 'url': websocket_url,
                                 'session_id': session_id,
                             }
-                            session_detail['_created_at'] = time.monotonic()
-                            session_pool[pool_key] = session_detail
+                            pool_entry = dict(session_detail)
+                            pool_entry['_created_at'] = time.monotonic()
+                            session_pool[pool_key] = pool_entry
 
                         return channel_id, session_detail
                 except Exception:  # noqa: S112
@@ -185,15 +186,16 @@ async def get_or_create_channel(
 
     ws = await websockets.connect(websocket_url, user_agent_header=MCP_USER_AGENT)
 
-    # Store in pools under lock
+    # Store in pools under lock (copy to avoid leaking metadata)
     async with _pool_lock:
         websocket_pool[channel_id] = {
             'websocket': ws,
             'url': websocket_url,
             'session_id': session_id,
         }
-        result['_created_at'] = time.monotonic()
-        session_pool[pool_key] = result
+        pool_entry = dict(result)
+        pool_entry['_created_at'] = time.monotonic()
+        session_pool[pool_key] = pool_entry
 
     return channel_id, result
 
@@ -308,7 +310,7 @@ async def websh_session_create(
                 websocket_url, user_agent_header=MCP_USER_AGENT
             )
 
-            # Store in pools under lock
+            # Store in pools under lock (copy to avoid leaking metadata)
             async with _pool_lock:
                 websocket_pool[channel_id] = {
                     'websocket': websocket,
@@ -317,8 +319,9 @@ async def websh_session_create(
                 }
 
                 pool_key = f'{region}:{workspace}:{server_id}'
-                result['_created_at'] = time.monotonic()
-                session_pool[pool_key] = result
+                pool_entry = dict(result)
+                pool_entry['_created_at'] = time.monotonic()
+                session_pool[pool_key] = pool_entry
 
             result['websocket_connected'] = True
             result['mcp_note'] = 'WebSocket connected with MCP user-agent'


### PR DESCRIPTION
## Summary
- Add `asyncio.Lock` (`_pool_lock`) to guard all `websocket_pool` and `session_pool` accesses in `tools/websh_tools.py`, preventing race conditions under concurrent MCP tool calls
- Add TTL-based stale session cleanup (1 hour) with opportunistic eviction on `get_or_create_channel()`
- Replace bare `del` with `.pop()` to avoid `KeyError` on concurrent delete

## Changes
- **`_pool_lock`**: Single `asyncio.Lock` for both pools (they are always modified together, avoids deadlock complexity)
- **`_cleanup_stale_sessions()`**: New helper that removes entries older than 1 hour and closes their WebSocket connections
- **`get_or_create_channel()`**: Entire check-then-create sequence under lock, with stale session cleanup
- **`execute_command_via_channel()`**: Pool read under lock, WebSocket I/O outside lock, pool delete under lock on error
- **`websh_session_create()`**: Pool writes under lock after WebSocket connect
- **`websh_channel_connect()`**: Double-checked locking pattern (check → connect outside → re-check + store)
- **`websh_channels_list()`**: Snapshot under lock, ping outside lock
- **`websh_channel_disconnect()`**: Pop under lock, close outside lock
- **`websh_channel_execute()`**: Pool read under lock, all I/O outside lock, pool delete under lock on error

## Testing
- [x] All 235 existing tests pass (`pytest --tb=short -q`)
- [x] ruff lint: passed
- [x] ruff format: passed
- [x] Manual review: every `websocket_pool`/`session_pool` access is inside `async with _pool_lock`
- [x] No deadlock risk: single lock, no nested acquisition

Closes #5 

---
Generated with AlpacaX Claude Plugin