### PR TITLE
ci: add Docker image build and push workflow

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -65,7 +65,7 @@ jobs:
         uses: benc-uk/workflow-dispatch@v1
         with:
           workflow: image-tag-update-pr.yaml
-          repo: alpacax/iac-aws
+          repo: alpacax/alpacon-gitops
           token: ${{ secrets.DEPLOY_ACTIONS_TRIGGER_TOKEN }}
           inputs: '{"image_tag": "${{ github.event.workflow_run.head_sha }}", "service": "alpacon-mcp", "environment": "dev"}'
 
@@ -79,6 +79,6 @@ jobs:
         uses: benc-uk/workflow-dispatch@v1
         with:
           workflow: image-tag-update-pr.yaml
-          repo: alpacax/iac-aws
+          repo: alpacax/alpacon-gitops
           token: ${{ secrets.DEPLOY_ACTIONS_TRIGGER_TOKEN }}
           inputs: '{"image_tag": "${{ github.ref_name }}", "service": "alpacon-mcp", "environment": "prod"}'


### PR DESCRIPTION
## Summary
Add GitHub Actions workflow for building and pushing Docker images to Docker Hub, with GitOps deployment via iac-aws for both dev and prod environments.

## Changes
- Add `.github/workflows/docker.yml` for Docker image build, push, and deployment
- Dev builds (main push) tagged with commit SHA, auto-deployed to dev
- Prod builds (semver tag push) tagged with version and latest, auto-deployed to prod
- Uses Docker Hub registry (matching internal service conventions)
- GitOps deployment via `benc-uk/workflow-dispatch` to `iac-aws`
- GHA build cache for faster builds

## Required Setup
- `vars.DOCKER_IMAGE`: Docker Hub image name (repo variable)
- `secrets.DEPLOY_ACTIONS_TRIGGER_TOKEN`: GitOps deployment PAT (repo secret)
- `secrets.DOCKER_USERNAME` / `secrets.DOCKER_PASSWORD`: Already available via org secrets

## Testing
- [ ] Workflow syntax validated
- [ ] Trigger conditions verified (push to main, tag push)

## Stack Checklist
- [ ] Workflow uses `docker/setup-buildx-action@v3`
- [ ] Docker Hub login uses org-level secrets
- [ ] Tag strategy matches alpacax convention (SHA for dev, version+latest for prod)
- [ ] GitOps deployment triggers match iac-aws workflow interface

---
Generated with AlpacaX Claude Plugin