### PR TITLE
fix: push dev builds to alpacon-mcp-dev, prod builds to alpacon-mcp

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -38,7 +38,7 @@ jobs:
         id: meta
         uses: docker/metadata-action@v5
         with:
-          images: ${{ vars.DOCKER_IMAGE }}
+          images: ${{ github.event_name == 'workflow_run' && format('{0}-dev', vars.DOCKER_IMAGE) || vars.DOCKER_IMAGE }}
           tags: |
             type=raw,value=${{ github.event.workflow_run.head_sha }},enable=${{ github.event_name == 'workflow_run' }}
             type=ref,event=tag,enable=${{ github.event_name == 'push' }}


### PR DESCRIPTION
## Summary
Dev/prod 빌드를 서로 다른 Docker Hub 저장소에 push하도록 수정.

- dev (`workflow_run`): `alpacax/alpacon-mcp-dev`
- prod (tag push): `alpacax/alpacon-mcp`

## Changes
`vars.DOCKER_IMAGE`(`alpacax/alpacon-mcp`)를 기반으로 dev 빌드 시 `-dev` suffix 자동 추가.

## Root Cause
ArgoCD values-us-west-2.yaml이 `alpacax/alpacon-mcp-dev`를 참조하는데, 워크플로우가 `alpacax/alpacon-mcp`에만 push하고 있어 `ImagePullBackOff` 발생.