### PR TITLE
fix(oauth): add dynamic client registration endpoint for MCP auth flow

### DIFF
--- a/tests/test_oauth.py
+++ b/tests/test_oauth.py
@@ -240,8 +240,8 @@ class TestOAuthRegister:
         assert response.status_code == 201
         data = response.json()
         assert data['client_id'] == TEST_CLIENT_ID
-        assert 'client_id_issued_at' in data
         assert data['token_endpoint_auth_method'] == 'none'
+        assert 'client_id_issued_at' not in data
 
     def test_register_echoes_redirect_uris(self, oauth_app):
         uris = ['http://localhost:3000/callback']

--- a/utils/oauth.py
+++ b/utils/oauth.py
@@ -270,14 +270,19 @@ def register_oauth_routes(mcp_server):
         plans, so this endpoint returns the server's pre-configured client_id
         to satisfy the MCP SDK's registration requirement.
         """
-        import time
-
         from starlette.responses import JSONResponse
 
         try:
             config = _get_oauth_config()
         except ValueError as e:
-            return JSONResponse({'error': str(e)}, status_code=500)
+            logger.error(f'OAuth config error in /oauth/register: {e}')
+            return JSONResponse(
+                {
+                    'error': 'server_error',
+                    'error_description': 'OAuth configuration is incomplete',
+                },
+                status_code=500,
+            )
 
         # Parse and validate client metadata from request body (RFC 7591)
         body = await request.body()
@@ -328,7 +333,6 @@ def register_oauth_routes(mcp_server):
         # Return pre-configured client_id with metadata echoed back
         response_data = {
             'client_id': config['client_id'],
-            'client_id_issued_at': int(time.time()),
             'token_endpoint_auth_method': 'none',
         }
 


### PR DESCRIPTION
## Summary
- MCP SDK(Claude Code)에서 OAuth 인증 시 RFC 7591 Dynamic Client Registration이 필수로 요구되지만, Auth0 Free/Professional 플랜에서는 이를 지원하지 않아 인증이 실패하는 문제 수정
- `/oauth/register` 엔드포인트를 추가하여 서버에 설정된 `client_id`를 반환하도록 구현
- OAuth metadata discovery 응답에 `registration_endpoint` 필드 추가

## Changes
- `utils/oauth.py`: OAuth metadata에 `registration_endpoint` 추가
- `utils/oauth.py`: `/oauth/register` POST 엔드포인트 추가 (RFC 7591 호환 응답)

## Root Cause
Claude Code MCP 클라이언트의 OAuth flow:
1. Discovery 성공 (`/.well-known/oauth-authorization-server`)
2. 저장된 client info 없음 → Dynamic Client Registration 시도
3. `/register` 엔드포인트 없음 → **auth flow 즉시 실패** (`SDK auth error: vu`)

## Testing
- [ ] `/oauth/register` 엔드포인트가 `client_id`를 정상 반환하는지 확인
- [ ] Claude Code에서 authenticate 버튼 클릭 시 Auth0 로그인 페이지로 이동하는지 확인
- [ ] 전체 OAuth flow (register → authorize → token) 정상 동작 확인

---
Generated with AlpacaX Claude Plugin