### PR TITLE
fix(oauth): use MCP server URL as issuer for OAuth discovery

### DIFF
--- a/server.py
+++ b/server.py
@@ -106,8 +106,6 @@ def _create_mcp_server() -> FastMCP:
             logger.error(message)
             raise RuntimeError(message)
 
-        issuer_url_str = f'https://{auth0_domain}/'
-
         # Validate resource_url with proper URL parsing before passing to AnyHttpUrl
         from urllib.parse import urlparse
 
@@ -125,8 +123,14 @@ def _create_mcp_server() -> FastMCP:
             f'{parsed_url.scheme}://{parsed_url.netloc}{parsed_url.path}'.rstrip('/')
         )
 
+        # Use the MCP server's own URL as issuer_url so that clients discover
+        # our OAuth proxy endpoints (authorize, token, register) instead of
+        # going directly to Auth0 — which doesn't support Dynamic Client
+        # Registration on non-Enterprise plans.
+        # JWT token verification still validates against Auth0's issuer
+        # independently via Auth0TokenVerifier.
         auth_settings = AuthSettings(
-            issuer_url=AnyHttpUrl(issuer_url_str),
+            issuer_url=AnyHttpUrl(resource_url),
             resource_server_url=AnyHttpUrl(resource_url),
         )
         token_verifier = Auth0TokenVerifier()

--- a/tests/test_oauth.py
+++ b/tests/test_oauth.py
@@ -80,7 +80,7 @@ class TestOAuthMetadata:
         assert response.status_code == 200
         data = response.json()
 
-        assert data['issuer'] == f'https://{TEST_AUTH0_DOMAIN}/'
+        assert data['issuer'] == f'{TEST_RESOURCE_URL}/'
         assert data['authorization_endpoint'] == f'{TEST_RESOURCE_URL}/oauth/authorize'
         assert data['token_endpoint'] == f'{TEST_RESOURCE_URL}/oauth/token'
         assert data['registration_endpoint'] == f'{TEST_RESOURCE_URL}/oauth/register'
@@ -231,10 +231,12 @@ class TestOAuthRegister:
     def test_register_returns_configured_client_id(self, oauth_app):
         response = oauth_app.post(
             '/oauth/register',
-            content=json.dumps({
-                'client_name': 'test-client',
-                'redirect_uris': ['http://localhost:3000/callback'],
-            }).encode(),
+            content=json.dumps(
+                {
+                    'client_name': 'test-client',
+                    'redirect_uris': ['http://localhost:3000/callback'],
+                }
+            ).encode(),
             headers={'content-type': 'application/json'},
         )
         assert response.status_code == 201

--- a/utils/oauth.py
+++ b/utils/oauth.py
@@ -67,7 +67,7 @@ def register_oauth_routes(mcp_server):
             server_url = f'{request.url.scheme}://{request.url.netloc}'
 
         metadata = {
-            'issuer': f'{config["auth0_base_url"]}/',
+            'issuer': f'{server_url}/',
             'authorization_endpoint': f'{server_url}/oauth/authorize',
             'token_endpoint': f'{server_url}/oauth/token',
             'registration_endpoint': f'{server_url}/oauth/register',


### PR DESCRIPTION
## Summary

OAuth 인증 플로우에서 클라이언트가 Auth0로 직접 연결되어 DCR(Dynamic Client Registration)을 찾지 못하는 버그를 수정합니다.

### 문제
- `AuthSettings.issuer_url`이 Auth0 도메인을 가리키고 있어서, `/.well-known/oauth-protected-resource`의 `authorization_servers`가 Auth0를 직접 참조
- 클라이언트(Claude Code/Desktop)가 Auth0에서 `/.well-known/oauth-authorization-server`를 요청하지만, Auth0는 non-Enterprise 플랜에서 DCR을 지원하지 않음
- MCP 서버에 구현된 OAuth proxy endpoints(`/oauth/register`, `/oauth/authorize`, `/oauth/token`)가 발견되지 않음

### 수정
- `issuer_url`을 MCP 서버 자체 URL(`ALPACON_MCP_RESOURCE_URL`)로 변경
- OAuth metadata의 `issuer` 필드도 MCP 서버 URL로 변경
- JWT 토큰 검증은 기존대로 `Auth0TokenVerifier`가 Auth0 JWKS로 독립적으로 수행 (영향 없음)

## Changes
- `server.py`: `AuthSettings.issuer_url`을 Auth0 → MCP 서버 URL로 변경
- `utils/oauth.py`: `/.well-known/oauth-authorization-server` metadata의 `issuer`를 MCP 서버 URL로 변경
- `tests/test_oauth.py`: issuer assertion 업데이트

## Testing
- [x] 전체 테스트 348개 통과
- [x] OAuth 테스트 27개 통과
- [x] Auth 테스트 19개 통과

---
Generated with AlpacaX Claude Plugin