### PR TITLE
fix(oauth): normalize issuer URL and update docstring

### DIFF
--- a/server.py
+++ b/server.py
@@ -129,8 +129,12 @@ def _create_mcp_server() -> FastMCP:
         # Registration on non-Enterprise plans.
         # JWT token verification still validates against Auth0's issuer
         # independently via Auth0TokenVerifier.
+        # Ensure issuer_url has a trailing slash to match the issuer value
+        # in /.well-known/oauth-authorization-server metadata (RFC 8414
+        # requires exact string match for issuer identifiers).
+        issuer_url = resource_url.rstrip('/') + '/'
         auth_settings = AuthSettings(
-            issuer_url=AnyHttpUrl(resource_url),
+            issuer_url=AnyHttpUrl(issuer_url),
             resource_server_url=AnyHttpUrl(resource_url),
         )
         token_verifier = Auth0TokenVerifier()

--- a/utils/oauth.py
+++ b/utils/oauth.py
@@ -47,8 +47,9 @@ def register_oauth_routes(mcp_server):
     async def oauth_metadata(request):
         """OAuth 2.0 Authorization Server Metadata (RFC 8414).
 
-        Returns metadata that points to Auth0 as the authorization server,
-        with token and authorization endpoints proxied through this server.
+        Returns metadata advertising this MCP server as the OAuth
+        authorization server. The authorize, token, and register
+        endpoints proxy to Auth0; only jwks_uri points to Auth0 directly.
         """
         from starlette.responses import JSONResponse
 


### PR DESCRIPTION
## Summary

PR #22의 Copilot 리뷰 코멘트 2건을 반영합니다.

## Changes

1. **Trailing slash 불일치 수정** (`server.py`)
   - `AuthSettings.issuer_url`에 trailing slash를 추가하여 `/.well-known/oauth-authorization-server` metadata의 `issuer` 값과 정확히 일치하도록 정규화
   - RFC 8414는 issuer identifier의 exact string match를 요구

2. **Docstring 업데이트** (`utils/oauth.py`)
   - `oauth_metadata` docstring이 "Auth0를 authorization server로 가리킨다"고 되어 있었으나, 실제로는 MCP 서버 자체가 issuer
   - `jwks_uri`만 Auth0를 직접 참조한다는 점을 명확히 기술

## Testing
- [x] OAuth 테스트 27개 통과
- [x] Auth 테스트 19개 통과

---
Generated with AlpacaX Claude Plugin