### PR TITLE
fix(oauth): route callback through MCP server instead of direct localhost

### DIFF
--- a/tests/test_oauth.py
+++ b/tests/test_oauth.py
@@ -475,14 +475,15 @@ class TestOAuthCallback:
         assert response.json()['error'] == 'access_denied'
 
     def test_callback_handles_invalid_state_gracefully(self, oauth_app):
-        """Invalid composite state should not crash — falls back to JSON."""
+        """Invalid composite state should not crash — echoes raw state back."""
         response = oauth_app.get(
             '/oauth/callback',
-            params={'code': 'auth-code', 'state': 'not-base64-json'},
+            params={'code': 'auth-code', 'state': 'opaque-state-value'},
         )
         assert response.status_code == 200
         data = response.json()
         assert data['code'] == 'auth-code'
+        assert data['state'] == 'opaque-state-value'
 
     def test_callback_does_not_redirect_to_non_localhost_uri(self, oauth_app):
         """Callback must not redirect to a non-localhost redirect_uri from state."""

--- a/utils/oauth.py
+++ b/utils/oauth.py
@@ -453,6 +453,9 @@ def register_oauth_routes(mcp_server):
                 original_state = state_data.get('state', '')
             except (json.JSONDecodeError, UnicodeDecodeError, base64.binascii.Error) as e:
                 logger.warning(f'Failed to decode composite state: {e}')
+                # Fall back to treating the raw state as the original opaque state
+                # so it can be echoed back to the client per OAuth spec.
+                original_state = composite_state
 
         # Defense-in-depth: re-validate redirect_uri from state is a localhost URL.
         # The authorize endpoint already validates this, but an attacker could craft


### PR DESCRIPTION
## Summary
- OAuth authorize flow now routes Auth0 callback to the MCP server's own `/oauth/callback` endpoint instead of passing the client's localhost URL directly to Auth0
- The callback endpoint decodes the composite state and redirects back to the MCP client with the authorization code
- Adds open redirect protection by rejecting non-localhost redirect_uris

## Changes
- **`/oauth/authorize`**: Stores client's `redirect_uri` + `state` in base64-encoded composite state, overrides `redirect_uri` to `{server}/oauth/callback`
- **`/oauth/callback`**: Decodes composite state, redirects to client's original `redirect_uri` with code and state
- **`/oauth/token`**: Always sets server callback URL as `redirect_uri` for `authorization_code` grants (Auth0 requires exact match)
- **Security**: Validates `redirect_uri` is localhost/127.0.0.1 only to prevent open redirect attacks
- **Cleanup**: Removed redundant inline `import json` statements

## Testing
- [x] 35 OAuth tests pass (4 new tests added)
- [x] Authorize: redirect_uri override, composite state encoding, localhost validation
- [x] Token: redirect_uri override for auth_code grant, works even when client omits it
- [x] Callback: redirects to client, JSON fallback, error forwarding, invalid state handling

## Note
Auth0 Dashboard needs `{ALPACON_MCP_RESOURCE_URL}/oauth/callback` added to Allowed Callback URLs.