### PR TITLE
feat(oauth): allow trusted redirect domains for cloud MCP clients

### DIFF
--- a/tests/test_oauth.py
+++ b/tests/test_oauth.py
@@ -247,6 +247,17 @@ class TestOAuthAuthorize:
             )
             assert response.status_code == 400
 
+    def test_authorize_rejects_http_trusted_domain(self, oauth_app):
+        """Trusted domains must use https to prevent code leakage over plaintext."""
+        response = oauth_app.get(
+            '/oauth/authorize',
+            params={
+                'response_type': 'code',
+                'redirect_uri': 'http://claude.ai/api/mcp/auth_callback',
+            },
+        )
+        assert response.status_code == 400
+
     def test_authorize_allows_127_0_0_1_redirect_uri(self, oauth_app):
         response = oauth_app.get(
             '/oauth/authorize',

--- a/utils/oauth.py
+++ b/utils/oauth.py
@@ -57,7 +57,9 @@ def _get_allowed_redirect_domains() -> tuple[str, ...]:
 def _is_allowed_redirect_url(url: str) -> bool:
     """Validate that a redirect URL is allowed.
 
-    Allows localhost URLs and URLs from trusted redirect domains.
+    Allows localhost URLs (http/https) and trusted redirect domains (https only).
+    Non-loopback domains must use https to prevent authorization code leakage
+    over plaintext connections.
     """
     from urllib.parse import urlparse
 
@@ -67,9 +69,13 @@ def _is_allowed_redirect_url(url: str) -> bool:
 
     hostname = parsed.hostname or ''
 
-    # Always allow localhost
+    # Allow localhost with http or https (for local development)
     if hostname in _ALLOWED_LOOPBACK_HOSTS:
         return True
+
+    # Trusted domains must use https to prevent code leakage via plaintext
+    if parsed.scheme != 'https':
+        return False
 
     # Allow trusted redirect domains (exact match)
     allowed_domains = _get_allowed_redirect_domains()


### PR DESCRIPTION
## Summary
- Replace localhost-only `redirect_uri` validation with a configurable domain allowlist
- Cloud-based MCP clients (Claude web, ChatGPT) send their own server URLs as `redirect_uri`, which was previously blocked
- Default trusted domains: `claude.ai`, `chatgpt.com`, `chat.openai.com`

## Changes
- Add `ALLOWED_REDIRECT_DOMAINS` env var support (comma-separated, overrides defaults)
- Update `_is_localhost_url` → `_is_allowed_redirect_url` in both `/oauth/authorize` and `/oauth/callback`
- Add tests for Claude web, ChatGPT redirect URIs, custom domain override, and callback redirect to trusted domains

## Testing
- [x] All 46 OAuth tests pass
- [x] Untrusted domains (e.g. `evil.com`) still rejected
- [x] Localhost still allowed (backward compatible)
- [x] Custom `ALLOWED_REDIRECT_DOMAINS` env var overrides defaults

---
Generated with AlpacaX Claude Plugin