### PR TITLE
style: apply ruff format to tests/test_health.py

### DIFF
--- a/tests/test_health.py
+++ b/tests/test_health.py
@@ -155,6 +155,7 @@ class TestGetHealthInfoLocal:
         assert result['http_client']['pool_active'] is False
         assert result['http_client']['cache_size'] == 0
 
+
 class TestGetHealthInfoRemote:
     """Tests for get_health_info in remote (streamable-http) mode."""
 


### PR DESCRIPTION
## Summary

- `tests/test_health.py` was missing one blank line between two top-level class definitions, so `ruff format --check` reports a formatting hit on every new branch cut from `main`.
- Apply `ruff format` to fix it (single blank line added between `TestGetHealthInfoLocal` and `TestGetHealthInfoRemote`).
- Logic untouched; lint (`ruff check`) was already passing.

## Test plan

- [x] `uvx ruff format --check tests/test_health.py` → already formatted
- [x] `uvx ruff check tests/test_health.py` → all checks passed