### PR TITLE
ci: use shared-ci dockerhub-login wrapper

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -29,10 +29,9 @@ jobs:
         uses: docker/setup-buildx-action@v3
 
       - name: Log in to Docker Hub
-        uses: docker/login-action@v3
+        uses: alpacax/shared-ci/common/dockerhub-login@v1
         with:
-          username: ${{ secrets.DOCKER_USERNAME }}
-          password: ${{ secrets.DOCKER_PASSWORD }}
+          token: ${{ secrets.DOCKERHUB_PUSH_TOKEN }}
 
       - name: Extract metadata (tags, labels)
         id: meta


### PR DESCRIPTION
## Summary

Replace the inline `docker/login-action@v3` step in `docker.yml` with the shared composite action `alpacax/shared-ci/common/dockerhub-login@v1`.

The wrapper hardcodes `docker.io` as registry and `alpacax` as username (both overridable via inputs), so callers only need to pass the push token. This reduces caller surface from 3 inputs to 1, and centralizes future updates (docker/login-action version bumps, registry migrations, username changes) in a single place.

## Changes

### `.github/workflows/docker.yml`
- Replaced the inline `docker/login-action@v3` step with `alpacax/shared-ci/common/dockerhub-login@v1`.
- Migrated credentials from the legacy shared `DOCKER_USERNAME` / `DOCKER_PASSWORD` pair to the org-level `DOCKERHUB_PUSH_TOKEN` secret (backed by an AlpacaX org access token). This narrows blast radius if the token is ever compromised.
- The workflow no longer references `docker/login-action@v3` directly; the wrapper internally uses v4.

## Checklist

- [x] `DOCKERHUB_PUSH_TOKEN` secret available at org or repo level
- [ ] CI build job passes on this branch
- [ ] Image push works on next tag/main run

## Test plan

- [ ] PR Build Check passes (or whatever CI runs on PRs in this repo)
- [ ] After merge, the next `Docker` workflow run on `main` succeeds:
  - Log in to Docker Hub step uses the wrapper path
  - Build and push step succeeds
  - Image is published

## Notes

- The wrapper default `docker.io` / `alpacax` matches AlpacaX's existing Docker Hub setup. If this repo were using a different registry or username, the wrapper supports overriding via `with: registry: ...` / `with: username: ...`, but no override is expected here.
- This is part of an org-wide migration introduced by `alpacax/docs#242`. Same pattern will be applied to other Next.js / service repos in follow-up PRs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)