### PR TITLE
ci: revert dockerhub-login wrapper to inline action

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -29,9 +29,10 @@ jobs:
         uses: docker/setup-buildx-action@v3
 
       - name: Log in to Docker Hub
-        uses: alpacax/shared-ci/common/dockerhub-login@v1
+        uses: docker/login-action@v4
         with:
-          token: ${{ secrets.DOCKERHUB_PUSH_TOKEN }}
+          username: alpacax
+          password: ${{ secrets.DOCKERHUB_PUSH_TOKEN }}
 
       - name: Extract metadata (tags, labels)
         id: meta

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -31,7 +31,7 @@ jobs:
       - name: Log in to Docker Hub
         uses: docker/login-action@v4
         with:
-          username: alpacax
+          username: ${{ secrets.DOCKERHUB_USERNAME }}
           password: ${{ secrets.DOCKERHUB_PUSH_TOKEN }}
 
       - name: Extract metadata (tags, labels)


### PR DESCRIPTION
## Summary
The Docker workflow started failing with `Unable to resolve action 'alpacax/shared-ci', not found` after PR #92 migrated the Docker Hub login step to `alpacax/shared-ci/common/dockerhub-login@v1`. GitHub Actions does not allow a public repository to consume an action that lives in an internal repository, so the migration cannot apply here while `shared-ci` stays internal.

This PR inlines `docker/login-action@v4` directly while keeping the `DOCKERHUB_PUSH_TOKEN` migration from PR #92 intact.

## Changes
### `.github/workflows/docker.yml`
- Replace `alpacax/shared-ci/common/dockerhub-login@v1` with `docker/login-action@v4`
- Keep `username: alpacax` + `password: ${{ secrets.DOCKERHUB_PUSH_TOKEN }}` (matches the wrapper defaults)

## Test plan
- [ ] After merge, confirm the Docker workflow run on `main` reaches the build & push step successfully