### PR TITLE
feat(webftp): support remote mode with presigned URLs and content-based upload

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -227,6 +227,9 @@ export ALPACON_MCP_LOG_LEVEL=ERROR   # For production
 
 # Debug mode
 export DEBUG=true        # Enable debug logging
+
+# WebFTP configuration
+export ALPACON_MCP_WEBFTP_DOWNLOAD_TIMEOUT=60   # Seconds to poll for S3 staging in remote-mode downloads (default: 60). Raise for large folder ZIPs.
 ```
 
 #### Configuration examples

--- a/tests/test_webftp_tools.py
+++ b/tests/test_webftp_tools.py
@@ -1171,6 +1171,7 @@ class TestUploadContent:
         )
 
         assert result['status'] == 'error'
+        assert result.get('field') == 'remote_file_path'
         mock_http_client.post.assert_not_called()
 
 

--- a/tests/test_webftp_tools.py
+++ b/tests/test_webftp_tools.py
@@ -1101,6 +1101,92 @@ class TestWebFtpBulkDownload:
         assert 'processing in progress' in result['message']
 
 
+class TestRemoteModeUnsupported:
+    """Test that file-transfer tools return a clear error in remote mode."""
+
+    SERVER_ID = '550e8400-e29b-41d4-a716-446655440001'
+
+    @pytest.mark.asyncio
+    async def test_upload_file_remote_mode(self, mock_http_client, mock_token_manager):
+        """webftp_upload_file returns remote_mode_unsupported error in remote mode.
+
+        The decorator's auth check is bypassed (auth disabled) so the function
+        body's _is_remote_mode check is what we're exercising here.
+        """
+        with (
+            patch('utils.decorators._is_auth_enabled', return_value=False),
+            patch('tools.webftp_tools._is_remote_mode', return_value=True),
+        ):
+            result = await webftp_upload_file(
+                server_id=self.SERVER_ID,
+                local_file_path='/local/test.txt',
+                remote_file_path='/remote/test.txt',
+                workspace='ws',
+                region='ap1',
+            )
+        assert result['status'] == 'error'
+        assert 'remote mode' in result['message']
+        assert result.get('code') == 'remote_mode_unsupported'
+        mock_http_client.post.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_download_file_remote_mode(self, mock_http_client, mock_token_manager):
+        """webftp_download_file returns remote_mode_unsupported error in remote mode."""
+        with (
+            patch('utils.decorators._is_auth_enabled', return_value=False),
+            patch('tools.webftp_tools._is_remote_mode', return_value=True),
+        ):
+            result = await webftp_download_file(
+                server_id=self.SERVER_ID,
+                remote_file_path='/remote/test.txt',
+                local_file_path='/local/test.txt',
+                workspace='ws',
+                region='ap1',
+            )
+        assert result['status'] == 'error'
+        assert 'remote mode' in result['message']
+        assert result.get('code') == 'remote_mode_unsupported'
+        mock_http_client.post.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_bulk_upload_remote_mode(self, mock_http_client, mock_token_manager):
+        """webftp_bulk_upload returns remote_mode_unsupported error in remote mode."""
+        with (
+            patch('utils.decorators._is_auth_enabled', return_value=False),
+            patch('tools.webftp_tools._is_remote_mode', return_value=True),
+        ):
+            result = await webftp_bulk_upload(
+                server_id=self.SERVER_ID,
+                local_file_paths=['/local/a.txt', '/local/b.txt'],
+                remote_directory='/remote/',
+                workspace='ws',
+                region='ap1',
+            )
+        assert result['status'] == 'error'
+        assert 'remote mode' in result['message']
+        assert result.get('code') == 'remote_mode_unsupported'
+        mock_http_client.post.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_bulk_download_remote_mode(self, mock_http_client, mock_token_manager):
+        """webftp_bulk_download returns remote_mode_unsupported error in remote mode."""
+        with (
+            patch('utils.decorators._is_auth_enabled', return_value=False),
+            patch('tools.webftp_tools._is_remote_mode', return_value=True),
+        ):
+            result = await webftp_bulk_download(
+                server_id=self.SERVER_ID,
+                remote_paths=['/remote/a.txt'],
+                local_file_path='/local/out.zip',
+                workspace='ws',
+                region='ap1',
+            )
+        assert result['status'] == 'error'
+        assert 'remote mode' in result['message']
+        assert result.get('code') == 'remote_mode_unsupported'
+        mock_http_client.post.assert_not_called()
+
+
 class TestAiterFile:
     """Test the _aiter_file streaming-upload helper."""
 

--- a/tests/test_webftp_tools.py
+++ b/tests/test_webftp_tools.py
@@ -1200,24 +1200,6 @@ class TestRemoteModeUnsupported:
         mock_http_client.post.assert_not_called()
 
     @pytest.mark.asyncio
-    async def test_download_file_remote_mode(
-        self, mock_http_client, mock_token_manager
-    ):
-        """webftp_download_file returns remote_mode_unsupported error in remote mode."""
-        with patch('tools.webftp_tools._is_auth_enabled', return_value=True):
-            result = await webftp_download_file(
-                server_id=self.SERVER_ID,
-                remote_file_path='/remote/test.txt',
-                local_file_path='/local/test.txt',
-                workspace='ws',
-                region='ap1',
-            )
-        assert result['status'] == 'error'
-        assert 'remote mode' in result['message']
-        assert result.get('code') == 'remote_mode_unsupported'
-        mock_http_client.post.assert_not_called()
-
-    @pytest.mark.asyncio
     async def test_bulk_upload_remote_mode(self, mock_http_client, mock_token_manager):
         """webftp_bulk_upload returns remote_mode_unsupported error in remote mode."""
         with patch('tools.webftp_tools._is_auth_enabled', return_value=True):
@@ -1250,6 +1232,110 @@ class TestRemoteModeUnsupported:
         assert 'remote mode' in result['message']
         assert result.get('code') == 'remote_mode_unsupported'
         mock_http_client.post.assert_not_called()
+
+
+class TestRemoteModeDownload:
+    """Test webftp_download_file remote mode — returns presigned URL instead of saving locally."""
+
+    SERVER_ID = '550e8400-e29b-41d4-a716-446655440001'
+
+    @pytest.mark.asyncio
+    async def test_download_remote_mode_immediate_url(
+        self, mock_http_client, mock_token_manager
+    ):
+        """When POST response already contains download_url, return it immediately."""
+        mock_http_client.post.return_value = {
+            'id': 'dl-abc',
+            'download_url': 'https://s3.example.com/file?sig=abc',
+        }
+
+        with patch('tools.webftp_tools._is_auth_enabled', return_value=True):
+            result = await webftp_download_file(
+                server_id=self.SERVER_ID,
+                remote_file_path='/remote/file.txt',
+                workspace='ws',
+                region='ap1',
+            )
+
+        assert result['status'] == 'success'
+        assert result['download_url'] == 'https://s3.example.com/file?sig=abc'
+        mock_http_client.post.assert_called_once()
+        mock_http_client.get.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_download_remote_mode_polling(
+        self, mock_http_client, mock_token_manager
+    ):
+        """When download_url is absent, poll status until success=True then return URL."""
+        mock_http_client.post.return_value = {'id': 'dl-abc', 'download_url': None}
+        mock_http_client.get.side_effect = [
+            {'success': None},
+            {'success': True, 'download_url': 'https://s3.example.com/file?sig=abc'},
+        ]
+
+        with (
+            patch('tools.webftp_tools._is_auth_enabled', return_value=True),
+            patch('asyncio.sleep', new_callable=AsyncMock),
+        ):
+            result = await webftp_download_file(
+                server_id=self.SERVER_ID,
+                remote_file_path='/remote/file.txt',
+                workspace='ws',
+                region='ap1',
+            )
+
+        assert result['status'] == 'success'
+        assert result['download_url'] == 'https://s3.example.com/file?sig=abc'
+        assert mock_http_client.get.call_count == 2
+
+    @pytest.mark.asyncio
+    async def test_download_remote_mode_timeout(
+        self, mock_http_client, mock_token_manager
+    ):
+        """Polling that exceeds _REMOTE_DOWNLOAD_TIMEOUT returns download_timeout error."""
+        mock_http_client.post.return_value = {'id': 'dl-abc', 'download_url': None}
+        mock_http_client.get.return_value = {'success': None}
+
+        with (
+            patch('tools.webftp_tools._is_auth_enabled', return_value=True),
+            patch('asyncio.sleep', new_callable=AsyncMock),
+            patch('tools.webftp_tools._REMOTE_DOWNLOAD_TIMEOUT', 2),
+        ):
+            result = await webftp_download_file(
+                server_id=self.SERVER_ID,
+                remote_file_path='/remote/file.txt',
+                workspace='ws',
+                region='ap1',
+            )
+
+        assert result['status'] == 'error'
+        assert result.get('code') == 'download_timeout'
+        assert result.get('file_id') == 'dl-abc'
+
+    @pytest.mark.asyncio
+    async def test_download_remote_mode_server_failure(
+        self, mock_http_client, mock_token_manager
+    ):
+        """When server reports success=False, return error with the server message."""
+        mock_http_client.post.return_value = {'id': 'dl-abc', 'download_url': None}
+        mock_http_client.get.return_value = {
+            'success': False,
+            'message': 'file not found on server',
+        }
+
+        with (
+            patch('tools.webftp_tools._is_auth_enabled', return_value=True),
+            patch('asyncio.sleep', new_callable=AsyncMock),
+        ):
+            result = await webftp_download_file(
+                server_id=self.SERVER_ID,
+                remote_file_path='/remote/file.txt',
+                workspace='ws',
+                region='ap1',
+            )
+
+        assert result['status'] == 'error'
+        assert 'file not found' in result['message']
 
 
 class TestAiterFile:

--- a/tests/test_webftp_tools.py
+++ b/tests/test_webftp_tools.py
@@ -1113,10 +1113,7 @@ class TestRemoteModeUnsupported:
         The decorator's auth check is bypassed (auth disabled) so the function
         body's _is_remote_mode check is what we're exercising here.
         """
-        with (
-            patch('utils.decorators._is_auth_enabled', return_value=False),
-            patch('tools.webftp_tools._is_remote_mode', return_value=True),
-        ):
+        with patch('tools.webftp_tools._is_auth_enabled', return_value=True):
             result = await webftp_upload_file(
                 server_id=self.SERVER_ID,
                 local_file_path='/local/test.txt',
@@ -1132,10 +1129,7 @@ class TestRemoteModeUnsupported:
     @pytest.mark.asyncio
     async def test_download_file_remote_mode(self, mock_http_client, mock_token_manager):
         """webftp_download_file returns remote_mode_unsupported error in remote mode."""
-        with (
-            patch('utils.decorators._is_auth_enabled', return_value=False),
-            patch('tools.webftp_tools._is_remote_mode', return_value=True),
-        ):
+        with patch('tools.webftp_tools._is_auth_enabled', return_value=True):
             result = await webftp_download_file(
                 server_id=self.SERVER_ID,
                 remote_file_path='/remote/test.txt',
@@ -1151,10 +1145,7 @@ class TestRemoteModeUnsupported:
     @pytest.mark.asyncio
     async def test_bulk_upload_remote_mode(self, mock_http_client, mock_token_manager):
         """webftp_bulk_upload returns remote_mode_unsupported error in remote mode."""
-        with (
-            patch('utils.decorators._is_auth_enabled', return_value=False),
-            patch('tools.webftp_tools._is_remote_mode', return_value=True),
-        ):
+        with patch('tools.webftp_tools._is_auth_enabled', return_value=True):
             result = await webftp_bulk_upload(
                 server_id=self.SERVER_ID,
                 local_file_paths=['/local/a.txt', '/local/b.txt'],
@@ -1170,10 +1161,7 @@ class TestRemoteModeUnsupported:
     @pytest.mark.asyncio
     async def test_bulk_download_remote_mode(self, mock_http_client, mock_token_manager):
         """webftp_bulk_download returns remote_mode_unsupported error in remote mode."""
-        with (
-            patch('utils.decorators._is_auth_enabled', return_value=False),
-            patch('tools.webftp_tools._is_remote_mode', return_value=True),
-        ):
+        with patch('tools.webftp_tools._is_auth_enabled', return_value=True):
             result = await webftp_bulk_download(
                 server_id=self.SERVER_ID,
                 remote_paths=['/remote/a.txt'],

--- a/tests/test_webftp_tools.py
+++ b/tests/test_webftp_tools.py
@@ -5,6 +5,7 @@ Tests WebFTP functionality including session management, file uploads,
 file downloads, and file transfer history.
 """
 
+import base64
 from pathlib import Path
 from unittest.mock import AsyncMock, MagicMock, patch
 
@@ -23,6 +24,7 @@ from tools.webftp_tools import (
     webftp_downloads_list,
     webftp_session_create,
     webftp_sessions_list,
+    webftp_upload_content,
     webftp_upload_file,
     webftp_uploads_list,
 )
@@ -1101,6 +1103,77 @@ class TestWebFtpBulkDownload:
         assert 'processing in progress' in result['message']
 
 
+class TestUploadContent:
+    """Test webftp_upload_content — content-based upload for remote and local modes."""
+
+    SERVER_ID = '550e8400-e29b-41d4-a716-446655440001'
+
+    @pytest.mark.asyncio
+    async def test_upload_content_success(
+        self, mock_http_client, mock_token_manager, mock_httpx
+    ):
+        """Happy path: base64 content is decoded, PUT to S3, server is triggered."""
+        file_bytes = b'hello remote world'
+        encoded = base64.b64encode(file_bytes).decode()
+
+        mock_http_client.post.return_value = {
+            'id': 'upload-abc',
+            'upload_url': 'https://s3.example.com/put?sig=abc',
+            'download_url': 'https://s3.example.com/get?sig=abc',
+        }
+        mock_http_client.get.return_value = {}
+
+        put_resp = AsyncMock()
+        put_resp.status_code = 200
+        mock_httpx.put.return_value = put_resp
+
+        result = await webftp_upload_content(
+            server_id=self.SERVER_ID,
+            file_content=encoded,
+            remote_file_path='/remote/hello.txt',
+            workspace='ws',
+            region='ap1',
+        )
+
+        assert result['status'] == 'success'
+        assert result['file_size'] == len(file_bytes)
+        mock_http_client.post.assert_called_once()
+        mock_httpx.put.assert_called_once()
+
+    @pytest.mark.asyncio
+    async def test_upload_content_invalid_base64(
+        self, mock_http_client, mock_token_manager
+    ):
+        """Invalid base64 input returns error with code='invalid_content' before any API call."""
+        result = await webftp_upload_content(
+            server_id=self.SERVER_ID,
+            file_content='not-valid-base64!!!',
+            remote_file_path='/remote/test.txt',
+            workspace='ws',
+            region='ap1',
+        )
+
+        assert result['status'] == 'error'
+        assert result.get('code') == 'invalid_content'
+        mock_http_client.post.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_upload_content_invalid_path(
+        self, mock_http_client, mock_token_manager
+    ):
+        """Path traversal in remote_file_path returns validation error before any API call."""
+        result = await webftp_upload_content(
+            server_id=self.SERVER_ID,
+            file_content=base64.b64encode(b'data').decode(),
+            remote_file_path='../etc/passwd',
+            workspace='ws',
+            region='ap1',
+        )
+
+        assert result['status'] == 'error'
+        mock_http_client.post.assert_not_called()
+
+
 class TestRemoteModeUnsupported:
     """Test that file-transfer tools return a clear error in remote mode."""
 
@@ -1127,7 +1200,9 @@ class TestRemoteModeUnsupported:
         mock_http_client.post.assert_not_called()
 
     @pytest.mark.asyncio
-    async def test_download_file_remote_mode(self, mock_http_client, mock_token_manager):
+    async def test_download_file_remote_mode(
+        self, mock_http_client, mock_token_manager
+    ):
         """webftp_download_file returns remote_mode_unsupported error in remote mode."""
         with patch('tools.webftp_tools._is_auth_enabled', return_value=True):
             result = await webftp_download_file(
@@ -1159,7 +1234,9 @@ class TestRemoteModeUnsupported:
         mock_http_client.post.assert_not_called()
 
     @pytest.mark.asyncio
-    async def test_bulk_download_remote_mode(self, mock_http_client, mock_token_manager):
+    async def test_bulk_download_remote_mode(
+        self, mock_http_client, mock_token_manager
+    ):
         """webftp_bulk_download returns remote_mode_unsupported error in remote mode."""
         with patch('tools.webftp_tools._is_auth_enabled', return_value=True):
             result = await webftp_bulk_download(

--- a/tools/webftp_tools.py
+++ b/tools/webftp_tools.py
@@ -38,7 +38,7 @@ _API_DOWNLOAD_STATUS = _API_DOWNLOADS + '{}/status/'
 _CHUNK_SIZE = 65536
 _UPLOAD_CONCURRENCY = 10
 _BULK_DOWNLOAD_TIMEOUT = 60.0
-_REMOTE_DOWNLOAD_TIMEOUT = 60
+_REMOTE_DOWNLOAD_TIMEOUT = int(os.getenv('ALPACON_MCP_WEBFTP_DOWNLOAD_TIMEOUT', '60'))
 _S3_SUCCESS_CODES = (HTTPStatus.OK, HTTPStatus.CREATED)
 
 # Result statuses
@@ -209,7 +209,7 @@ async def _download_remote_mode(
         resource_type=resource_type,
         download_url=download_url,
         expires_in='24 hours',
-        tip=f'curl -o {shlex.quote(file_name)} {shlex.quote(download_url)}',
+        tip=f'curl -o {shlex.quote(file_name)} {shlex.quote(cast(str, download_url))}',
         region=region,
         workspace=workspace,
     )
@@ -568,7 +568,8 @@ async def webftp_download_file(
         Download response with file saved locally
     """
     token = kwargs.get('token')
-    assert isinstance(token, str) and token, 'token must be injected by mcp_tool_handler'
+    if not isinstance(token, str) or not token:
+        raise RuntimeError('token must be injected by mcp_tool_handler')
 
     if not validate_file_path(remote_file_path):
         return format_validation_error('remote_file_path', remote_file_path)

--- a/tools/webftp_tools.py
+++ b/tools/webftp_tools.py
@@ -37,6 +37,7 @@ _API_DOWNLOAD_STATUS = _API_DOWNLOADS + '{}/status/'
 _CHUNK_SIZE = 65536
 _UPLOAD_CONCURRENCY = 10
 _BULK_DOWNLOAD_TIMEOUT = 60.0
+_REMOTE_DOWNLOAD_TIMEOUT = 60
 _S3_SUCCESS_CODES = (HTTPStatus.OK, HTTPStatus.CREATED)
 
 # Result statuses
@@ -136,6 +137,83 @@ async def _upload_bytes_to_s3(upload_url: str, data: bytes) -> str | None:
     if resp.status_code not in _S3_SUCCESS_CODES:
         return f'Failed to upload to S3: {resp.status_code} - {resp.text}'
     return None
+
+
+async def _download_remote_mode(
+    *,
+    server_id: str,
+    remote_file_path: str,
+    resource_type: str,
+    workspace: str,
+    region: str,
+    username: str | None,
+    token: str,
+) -> dict[str, Any]:
+    """Handle webftp_download_file in remote mode: poll until ready, return presigned URL."""
+    file_name = os.path.basename(remote_file_path)
+    if resource_type == 'folder':
+        file_name += '.zip'
+
+    download_data: dict[str, Any] = {
+        'server': server_id,
+        'path': remote_file_path,
+        'name': file_name,
+        'resource_type': resource_type,
+    }
+    if username:
+        download_data['username'] = username
+
+    result = await http_client.post(
+        region=region,
+        workspace=workspace,
+        endpoint=_API_DOWNLOADS,
+        token=token,
+        data=download_data,
+    )
+
+    file_id = result.get('id')
+    download_url = result.get('download_url')
+
+    if not download_url:
+        elapsed = 0
+        while elapsed < _REMOTE_DOWNLOAD_TIMEOUT:
+            await asyncio.sleep(1)
+            elapsed += 1
+            status = await http_client.get(
+                region=region,
+                workspace=workspace,
+                endpoint=_API_DOWNLOAD_STATUS.format(file_id),
+                token=token,
+            )
+            if status.get('success') is True:
+                download_url = status.get('download_url')
+                break
+            elif status.get('success') is False:
+                return error_response(
+                    f'Server failed to process download: {status.get("message", "unknown error")}',
+                    file_id=file_id,
+                )
+        else:
+            return error_response(
+                f'Download timed out waiting for server. '
+                f'Use webftp_check_status("{file_id}", "download") to poll manually.',
+                file_id=file_id,
+                code='download_timeout',
+            )
+
+    display_name = os.path.basename(remote_file_path)
+    return success_response(
+        message=f'File ready for download: {display_name}',
+        data=result,
+        server_id=server_id,
+        remote_file_path=remote_file_path,
+        resource_type=resource_type,
+        download_url=download_url,
+        expires_in='24 hours',
+        tip=f"curl -o '{display_name}' '{download_url}'",
+        region=region,
+        workspace=workspace,
+    )
 
 
 @mcp_tool_handler(
@@ -447,15 +525,26 @@ async def webftp_upload_content(
 
 
 @mcp_tool_handler(
-    description='Download a file or folder from a remote server and save it to a local path. For folders, the content is automatically packaged as a ZIP archive. When to use: retrieving a single file or folder from a server. Related: webftp_bulk_download (multiple files as ZIP), webftp_upload_file (upload to server), webftp_downloads_list (check download history). Note: Set resource_type="folder" for directories.',
+    description=(
+        'Download a file or folder from a remote server. '
+        'In local mode: saves to local_file_path. '
+        'In remote mode (streamable-http): polls until the file is ready on S3, '
+        'then returns a presigned download URL valid for 24 hours — '
+        'open it in a browser or run the curl command in the response. '
+        'For folders, content is packaged as a ZIP archive. '
+        'Related: webftp_bulk_download (multiple files as ZIP), '
+        'webftp_upload_file (upload to server), '
+        'webftp_downloads_list (check download history). '
+        'Note: Set resource_type="folder" for directories.'
+    ),
     annotations=ADDITIVE,
     meta={'anthropic/searchHint': 'file download transfer get retrieve server'},
 )
 async def webftp_download_file(
     server_id: str,
     remote_file_path: str,
-    local_file_path: str,
     workspace: str,
+    local_file_path: str | None = None,
     resource_type: str = 'file',
     username: str | None = None,
     region: str = '',
@@ -482,11 +571,23 @@ async def webftp_download_file(
     token = kwargs.get('token')
 
     if _is_auth_enabled():
-        return error_response(_REMOTE_MODE_ERROR, code='remote_mode_unsupported')
+        if not validate_file_path(remote_file_path):
+            return format_validation_error('remote_file_path', remote_file_path)
+        return await _download_remote_mode(
+            server_id=server_id,
+            remote_file_path=remote_file_path,
+            resource_type=resource_type,
+            workspace=workspace,
+            region=region,
+            username=username,
+            token=token or '',
+        )
 
     # Validate file paths
     if not validate_file_path(remote_file_path):
         return format_validation_error('remote_file_path', remote_file_path)
+    if local_file_path is None:
+        return error_response('local_file_path is required in local mode')
     if not validate_file_path(local_file_path):
         return format_validation_error('local_file_path', local_file_path)
 
@@ -517,10 +618,10 @@ async def webftp_download_file(
 
     # Step 3: Download file content from S3 using presigned URL
     if 'download_url' in result and result['download_url']:
+        # local_file_path is guaranteed non-None by the guard above
+        local_path: str = local_file_path  # type: ignore[assignment]
         try:
-            file_size = await _stream_s3_to_file(
-                result['download_url'], local_file_path
-            )
+            file_size = await _stream_s3_to_file(result['download_url'], local_path)
         except _S3DownloadError as e:
             return error_response(
                 f'Failed to download from S3: {e}',

--- a/tools/webftp_tools.py
+++ b/tools/webftp_tools.py
@@ -127,6 +127,15 @@ async def _aiter_file(path: str, chunk_size: int = _CHUNK_SIZE):
         await asyncio.to_thread(src_file.close)
 
 
+async def _upload_bytes_to_s3(upload_url: str, data: bytes) -> str | None:
+    """PUT bytes to a presigned S3 URL. Returns an error message on failure, None on success."""
+    async with httpx.AsyncClient() as client:
+        resp = await client.put(upload_url, content=data)
+    if resp.status_code not in _S3_SUCCESS_CODES:
+        return f'Failed to upload to S3: {resp.status_code} - {resp.text}'
+    return None
+
+
 @mcp_tool_handler(
     description='Create a new WebFTP file transfer session on a server. Returns session ID and connection details. When to use: advanced session management. For simple file transfers, use webftp_upload_file or webftp_download_file directly. Related: webftp_sessions_list (view sessions), webftp_upload_file, webftp_download_file.',
     annotations=ADDITIVE,
@@ -295,17 +304,9 @@ async def webftp_upload_file(
 
     # Step 4: Upload file content to S3 using presigned URL
     if 'upload_url' in result and result['upload_url']:
-        async with httpx.AsyncClient() as client:
-            upload_response = await client.put(
-                result['upload_url'],
-                content=file_content,
-            )
-
-            if upload_response.status_code not in _S3_SUCCESS_CODES:
-                return error_response(
-                    f'Failed to upload to S3: {upload_response.status_code} - {upload_response.text}',
-                    upload_url=result['upload_url'],
-                )
+        err = await _upload_bytes_to_s3(result['upload_url'], file_content)
+        if err:
+            return error_response(err, upload_url=result['upload_url'])
 
         # Step 5: Trigger server to process the uploaded file
         upload_trigger = await http_client.get(

--- a/tools/webftp_tools.py
+++ b/tools/webftp_tools.py
@@ -4,6 +4,7 @@ import asyncio
 import base64
 import binascii
 import os
+import shlex
 from http import HTTPStatus
 from pathlib import Path
 from typing import Any, cast
@@ -208,7 +209,7 @@ async def _download_remote_mode(
         resource_type=resource_type,
         download_url=download_url,
         expires_in='24 hours',
-        tip=f"curl -o '{file_name}' '{download_url}'",
+        tip=f'curl -o {shlex.quote(file_name)} {shlex.quote(download_url)}',
         region=region,
         workspace=workspace,
     )

--- a/tools/webftp_tools.py
+++ b/tools/webftp_tools.py
@@ -190,11 +190,12 @@ async def _download_remote_mode(
                 return error_response(
                     f'Server failed to process download: {status.get("message", "unknown error")}',
                     file_id=file_id,
+                    code='download_failed',
                 )
         else:
             return error_response(
                 f'Download timed out waiting for server. '
-                f'Use webftp_check_status("{file_id}", "download") to poll manually.',
+                f'Use webftp_check_status("{file_id}", "download", workspace="{workspace}", region="{region}") to poll manually.',
                 file_id=file_id,
                 code='download_timeout',
             )

--- a/tools/webftp_tools.py
+++ b/tools/webftp_tools.py
@@ -12,8 +12,16 @@ from server import mcp
 from utils.common import error_response, success_response
 from utils.decorators import mcp_tool_handler
 from utils.error_handler import format_validation_error, validate_file_path
+from utils.health import _is_remote_mode
 from utils.http_client import http_client
 from utils.tool_annotations import ADDITIVE, READ_ONLY
+
+# Error message returned when file transfer tools are called in remote mode.
+_REMOTE_MODE_ERROR = (
+    'WebFTP file transfer is not supported in remote mode. '
+    'The MCP server cannot access your local filesystem from a remote container. '
+    'Use local mode (stdio) for file transfers.'
+)
 
 # API endpoints
 _API_SESSIONS = '/api/webftp/sessions/'
@@ -249,6 +257,9 @@ async def webftp_upload_file(
     """
     token = kwargs.get('token')
 
+    if _is_remote_mode():
+        return error_response(_REMOTE_MODE_ERROR, code='remote_mode_unsupported')
+
     # Validate file paths
     if not validate_file_path(local_file_path):
         return format_validation_error('local_file_path', local_file_path)
@@ -366,6 +377,9 @@ async def webftp_download_file(
         Download response with file saved locally
     """
     token = kwargs.get('token')
+
+    if _is_remote_mode():
+        return error_response(_REMOTE_MODE_ERROR, code='remote_mode_unsupported')
 
     # Validate file paths
     if not validate_file_path(remote_file_path):
@@ -551,6 +565,9 @@ async def webftp_bulk_upload(
     """
     token = kwargs.get('token')
 
+    if _is_remote_mode():
+        return error_response(_REMOTE_MODE_ERROR, code='remote_mode_unsupported')
+
     # Validate non-empty file list
     if not local_file_paths:
         return error_response('local_file_paths must not be empty')
@@ -706,6 +723,9 @@ async def webftp_bulk_download(
         Bulk download response with file saved locally
     """
     token = kwargs.get('token')
+
+    if _is_remote_mode():
+        return error_response(_REMOTE_MODE_ERROR, code='remote_mode_unsupported')
 
     # Validate non-empty paths list
     if not remote_paths:

--- a/tools/webftp_tools.py
+++ b/tools/webftp_tools.py
@@ -6,7 +6,7 @@ import binascii
 import os
 from http import HTTPStatus
 from pathlib import Path
-from typing import Any
+from typing import Any, cast
 
 import httpx
 
@@ -175,10 +175,8 @@ async def _download_remote_mode(
     download_url = result.get('download_url')
 
     if not download_url:
-        elapsed = 0
-        while elapsed < _REMOTE_DOWNLOAD_TIMEOUT:
+        for _ in range(_REMOTE_DOWNLOAD_TIMEOUT):
             await asyncio.sleep(1)
-            elapsed += 1
             status = await http_client.get(
                 region=region,
                 workspace=workspace,
@@ -383,7 +381,7 @@ async def webftp_upload_file(
     )
 
     # Step 4: Upload file content to S3 using presigned URL
-    if 'upload_url' in result and result['upload_url']:
+    if result.get('upload_url'):
         err = await _upload_bytes_to_s3(result['upload_url'], file_content)
         if err:
             return error_response(err, upload_url=result['upload_url'])
@@ -404,7 +402,7 @@ async def webftp_upload_file(
             local_file_path=local_file_path,
             remote_file_path=remote_file_path,
             file_size=len(file_content),
-            upload_url=result.get('upload_url'),
+            upload_url=result['upload_url'],
             download_url=result.get('download_url'),
             region=region,
             workspace=workspace,
@@ -489,7 +487,7 @@ async def webftp_upload_content(
         data=upload_data,
     )
 
-    if 'upload_url' in result and result['upload_url']:
+    if result.get('upload_url'):
         err = await _upload_bytes_to_s3(result['upload_url'], raw_bytes)
         if err:
             return error_response(err, upload_url=result['upload_url'])
@@ -508,7 +506,7 @@ async def webftp_upload_content(
             server_id=server_id,
             remote_file_path=remote_file_path,
             file_size=len(raw_bytes),
-            upload_url=result.get('upload_url'),
+            upload_url=result['upload_url'],
             region=region,
             workspace=workspace,
         )
@@ -570,9 +568,10 @@ async def webftp_download_file(
     """
     token = kwargs.get('token')
 
+    if not validate_file_path(remote_file_path):
+        return format_validation_error('remote_file_path', remote_file_path)
+
     if _is_auth_enabled():
-        if not validate_file_path(remote_file_path):
-            return format_validation_error('remote_file_path', remote_file_path)
         return await _download_remote_mode(
             server_id=server_id,
             remote_file_path=remote_file_path,
@@ -583,9 +582,6 @@ async def webftp_download_file(
             token=token or '',
         )
 
-    # Validate file paths
-    if not validate_file_path(remote_file_path):
-        return format_validation_error('remote_file_path', remote_file_path)
     if local_file_path is None:
         return error_response('local_file_path is required in local mode')
     if not validate_file_path(local_file_path):
@@ -617,11 +613,11 @@ async def webftp_download_file(
     )
 
     # Step 3: Download file content from S3 using presigned URL
-    if 'download_url' in result and result['download_url']:
-        # local_file_path is guaranteed non-None by the guard above
-        local_path: str = local_file_path  # type: ignore[assignment]
+    if result.get('download_url'):
         try:
-            file_size = await _stream_s3_to_file(result['download_url'], local_path)
+            file_size = await _stream_s3_to_file(
+                result['download_url'], cast(str, local_file_path)
+            )
         except _S3DownloadError as e:
             return error_response(
                 f'Failed to download from S3: {e}',

--- a/tools/webftp_tools.py
+++ b/tools/webftp_tools.py
@@ -461,7 +461,7 @@ async def webftp_upload_content(
     token = kwargs.get('token')
 
     try:
-        raw_bytes = base64.b64decode(file_content)
+        raw_bytes = base64.b64decode(file_content, validate=True)
     except binascii.Error as exc:
         return error_response(f'Invalid base64 content: {exc}', code='invalid_content')
 

--- a/tools/webftp_tools.py
+++ b/tools/webftp_tools.py
@@ -15,7 +15,6 @@ from utils.error_handler import format_validation_error, validate_file_path
 from utils.http_client import http_client
 from utils.tool_annotations import ADDITIVE, READ_ONLY
 
-# Error message returned when file transfer tools are called in remote mode.
 _REMOTE_MODE_ERROR = (
     'WebFTP file transfer is not supported in remote mode. '
     'The MCP server cannot access your local filesystem from a remote container. '

--- a/tools/webftp_tools.py
+++ b/tools/webftp_tools.py
@@ -200,16 +200,15 @@ async def _download_remote_mode(
                 code='download_timeout',
             )
 
-    display_name = os.path.basename(remote_file_path)
     return success_response(
-        message=f'File ready for download: {display_name}',
+        message=f'File ready for download: {file_name}',
         data=result,
         server_id=server_id,
         remote_file_path=remote_file_path,
         resource_type=resource_type,
         download_url=download_url,
         expires_in='24 hours',
-        tip=f"curl -o '{display_name}' '{download_url}'",
+        tip=f"curl -o '{file_name}' '{download_url}'",
         region=region,
         workspace=workspace,
     )

--- a/tools/webftp_tools.py
+++ b/tools/webftp_tools.py
@@ -10,9 +10,8 @@ import httpx
 
 from server import mcp
 from utils.common import error_response, success_response
-from utils.decorators import mcp_tool_handler
+from utils.decorators import _is_auth_enabled, mcp_tool_handler
 from utils.error_handler import format_validation_error, validate_file_path
-from utils.health import _is_remote_mode
 from utils.http_client import http_client
 from utils.tool_annotations import ADDITIVE, READ_ONLY
 
@@ -257,7 +256,7 @@ async def webftp_upload_file(
     """
     token = kwargs.get('token')
 
-    if _is_remote_mode():
+    if _is_auth_enabled():
         return error_response(_REMOTE_MODE_ERROR, code='remote_mode_unsupported')
 
     # Validate file paths
@@ -378,7 +377,7 @@ async def webftp_download_file(
     """
     token = kwargs.get('token')
 
-    if _is_remote_mode():
+    if _is_auth_enabled():
         return error_response(_REMOTE_MODE_ERROR, code='remote_mode_unsupported')
 
     # Validate file paths
@@ -565,7 +564,7 @@ async def webftp_bulk_upload(
     """
     token = kwargs.get('token')
 
-    if _is_remote_mode():
+    if _is_auth_enabled():
         return error_response(_REMOTE_MODE_ERROR, code='remote_mode_unsupported')
 
     # Validate non-empty file list
@@ -724,7 +723,7 @@ async def webftp_bulk_download(
     """
     token = kwargs.get('token')
 
-    if _is_remote_mode():
+    if _is_auth_enabled():
         return error_response(_REMOTE_MODE_ERROR, code='remote_mode_unsupported')
 
     # Validate non-empty paths list

--- a/tools/webftp_tools.py
+++ b/tools/webftp_tools.py
@@ -568,6 +568,7 @@ async def webftp_download_file(
         Download response with file saved locally
     """
     token = kwargs.get('token')
+    assert isinstance(token, str) and token, 'token must be injected by mcp_tool_handler'
 
     if not validate_file_path(remote_file_path):
         return format_validation_error('remote_file_path', remote_file_path)
@@ -580,7 +581,7 @@ async def webftp_download_file(
             workspace=workspace,
             region=region,
             username=username,
-            token=token or '',
+            token=token,
         )
 
     if local_file_path is None:

--- a/tools/webftp_tools.py
+++ b/tools/webftp_tools.py
@@ -1,6 +1,8 @@
 """WebFTP (Web FTP) management tools for Alpacon MCP server."""
 
 import asyncio
+import base64
+import binascii
 import os
 from http import HTTPStatus
 from pathlib import Path
@@ -337,6 +339,108 @@ async def webftp_upload_file(
             server_id=server_id,
             local_file_path=local_file_path,
             remote_file_path=remote_file_path,
+            region=region,
+            workspace=workspace,
+        )
+
+
+@mcp_tool_handler(
+    description=(
+        'Upload file content to a remote server using base64-encoded bytes. '
+        'Use this when you have the file content directly rather than a local file path. '
+        'Suitable for: remote mode (streamable-http), Claude Desktop file attachments, '
+        'or when Claude Code reads a file with its Read tool. '
+        'file_content must be base64-encoded bytes. '
+        'Related: webftp_upload_file (local path), webftp_download_file.'
+    ),
+    annotations=ADDITIVE,
+    meta={'anthropic/searchHint': 'file upload content base64 remote mode attach'},
+)
+async def webftp_upload_content(
+    server_id: str,
+    file_content: str,
+    remote_file_path: str,
+    workspace: str,
+    file_name: str | None = None,
+    username: str | None = None,
+    region: str = '',
+    allow_overwrite: bool = True,
+    **kwargs,
+) -> dict[str, Any]:
+    """Upload base64-encoded file content to a server via WebFTP.
+
+    Args:
+        server_id: Server ID to upload file to
+        file_content: Base64-encoded file bytes
+        remote_file_path: Absolute path on the server (e.g., "/home/user/file.txt")
+        workspace: Workspace name. Required parameter
+        file_name: File name to use on the server. Inferred from remote_file_path if omitted
+        username: Optional username (uses authenticated user if not provided)
+        region: Region (ap1, us1, eu1). Auto-detected if not provided
+        allow_overwrite: Allow overwriting existing files (default: True)
+
+    Returns:
+        File upload response
+    """
+    token = kwargs.get('token')
+
+    try:
+        raw_bytes = base64.b64decode(file_content)
+    except binascii.Error as exc:
+        return error_response(f'Invalid base64 content: {exc}', code='invalid_content')
+
+    if not validate_file_path(remote_file_path):
+        return format_validation_error('remote_file_path', remote_file_path)
+
+    name = file_name or os.path.basename(remote_file_path)
+
+    upload_data: dict[str, Any] = {
+        'server': server_id,
+        'name': name,
+        'path': remote_file_path,
+        'allow_overwrite': allow_overwrite,
+    }
+    if username:
+        upload_data['username'] = username
+
+    result = await http_client.post(
+        region=region,
+        workspace=workspace,
+        endpoint=_API_UPLOADS,
+        token=token,
+        data=upload_data,
+    )
+
+    if 'upload_url' in result and result['upload_url']:
+        err = await _upload_bytes_to_s3(result['upload_url'], raw_bytes)
+        if err:
+            return error_response(err, upload_url=result['upload_url'])
+
+        upload_trigger = await http_client.get(
+            region=region,
+            workspace=workspace,
+            endpoint=f'{_API_UPLOADS}{result["id"]}/upload/',
+            token=token,
+        )
+
+        return success_response(
+            message='File content uploaded successfully and processed by server',
+            data=result,
+            upload_trigger=upload_trigger,
+            server_id=server_id,
+            remote_file_path=remote_file_path,
+            file_size=len(raw_bytes),
+            upload_url=result.get('upload_url'),
+            region=region,
+            workspace=workspace,
+        )
+    else:
+        return success_response(
+            message='File content uploaded successfully (direct upload)',
+            data=result,
+            server_id=server_id,
+            remote_file_path=remote_file_path,
+            file_size=len(raw_bytes),
             region=region,
             workspace=workspace,
         )


### PR DESCRIPTION
## Summary

WebFTP file transfer tools fail silently or with cryptic errors when the MCP server runs in remote/streamable-http mode (inside a container or cloud deployment) because the server cannot access the client's local filesystem. This PR addresses remote mode in three ways:

1. **Block local-path tools** — `webftp_upload_file`, `webftp_bulk_upload`, `webftp_bulk_download` return a clear `remote_mode_unsupported` error immediately, with a message explaining why and what to use instead.
2. **Enhance download** — `webftp_download_file` in remote mode polls until the file is staged on S3, then returns a presigned download URL (valid 24 hours) with a ready-to-run `curl` command instead of attempting a local save.
3. **New upload tool** — `webftp_upload_content` accepts base64-encoded bytes directly, enabling uploads from remote mode, Claude Desktop file attachments, or any context where the file is already in memory.

## Changes

- `tools/webftp_tools.py`:
  - Added `_is_auth_enabled()` guard to `webftp_upload_file`, `webftp_bulk_upload`, `webftp_bulk_download` — returns `remote_mode_unsupported` error immediately in remote mode
  - `webftp_download_file`: remote mode now routes to new `_download_remote_mode()` helper which polls the download status API and returns a presigned S3 URL; `local_file_path` changed from required to optional (required only in local mode)
  - Added `webftp_upload_content` tool: decodes base64 content, uploads bytes to S3 via presigned URL, triggers server processing — works in both local and remote mode
  - Extracted `_upload_bytes_to_s3(url, data)` helper shared by `webftp_upload_file` and `webftp_upload_content`
  - Added `_download_remote_mode()` helper and `_REMOTE_DOWNLOAD_TIMEOUT` constant (60 s)
  - Reused `_is_auth_enabled()` from `utils/decorators.py` instead of introducing a duplicate

- `tests/test_webftp_tools.py`:
  - `TestRemoteModeUnsupported`: verifies early bailout, correct error code, and no HTTP calls for the 3 blocked tools
  - `TestRemoteModeDownload`: 4 cases for `webftp_download_file` remote mode — immediate URL, polling success, timeout, server failure
  - `TestUploadContent`: happy path, invalid base64, path traversal rejection

## Testing

Verified end-to-end against the `alpacax` workspace (dev region) using the local MCP server with `config/token.json`:

**`webftp_upload_content`** — uploaded `"Hello from remote mode test!"` (base64-encoded) to `web-editor` server at `/tmp/mcp-remote-test.txt`:
```json
{
  "status": "success",
  "message": "File content uploaded successfully and processed by server",
  "file_size": 28,
  "server": "web-editor"
}
```

**`webftp_download_file`** — downloaded `/tmp/mcp-remote-test.txt` from `web-editor` to `/tmp/mcp-remote-test-downloaded.txt`:
```json
{
  "status": "success",
  "message": "File downloaded successfully from file: /tmp/mcp-remote-test.txt",
  "file_size": 28
}
```
File content verified locally: `Hello from remote mode test!`

**Unit tests**: 54 passed in 0.40 s (`pytest tests/test_webftp_tools.py`)

## Checklist

### Universal
- [x] Code follows project style guidelines
- [x] Self-reviewed the code
- [x] No hardcoded secrets or credentials

### Stack-specific (python)
- [x] Tests cover new functionality