### PR TITLE
feat: complete server management tools

### DIFF
--- a/tests/test_server_tools.py
+++ b/tests/test_server_tools.py
@@ -16,7 +16,6 @@ from tools.server_tools import (
     delete_server_note,
     get_registration_guide,
     get_server,
-    get_server_access_policy,
     get_server_note,
     list_registration_tokens,
     list_server_notes,
@@ -712,50 +711,6 @@ class TestStarServer:
         assert result['status'] == 'error'
         assert 'No token found' in result['message']
         mock_http_client.post.assert_not_called()
-
-
-class TestGetServerAccessPolicy:
-    """Tests for get_server_access_policy tool."""
-
-    @pytest.mark.asyncio
-    async def test_get_server_access_policy_success(
-        self, mock_http_client, mock_token_manager
-    ):
-        """Returns access policy for a server."""
-        mock_http_client.get.return_value = {
-            'users': ['alice', 'bob'],
-            'groups': ['admins'],
-        }
-
-        result = await get_server_access_policy(
-            server_id='550e8400-e29b-41d4-a716-446655440123',
-            workspace='testworkspace',
-            region='ap1',
-        )
-
-        assert result['status'] == 'success'
-        mock_http_client.get.assert_called_once_with(
-            region='ap1',
-            workspace='testworkspace',
-            endpoint='/api/servers/servers/550e8400-e29b-41d4-a716-446655440123/access-policy/',
-            token='test-token',
-        )
-
-    @pytest.mark.asyncio
-    async def test_get_server_access_policy_no_token(
-        self, mock_http_client, mock_token_manager
-    ):
-        """Returns error when token is missing."""
-        mock_token_manager.get_token.return_value = None
-
-        result = await get_server_access_policy(
-            server_id='550e8400-e29b-41d4-a716-446655440123',
-            workspace='testworkspace',
-        )
-
-        assert result['status'] == 'error'
-        assert 'No token found' in result['message']
-        mock_http_client.get.assert_not_called()
 
 
 class TestListRegistrationTokens:

--- a/tests/test_server_tools.py
+++ b/tests/test_server_tools.py
@@ -10,7 +10,6 @@ import pytest
 
 from tools.server_tools import (
     create_registration_token,
-    create_server,
     create_server_note,
     delete_registration_token,
     delete_server,
@@ -19,7 +18,6 @@ from tools.server_tools import (
     get_server,
     get_server_access_policy,
     get_server_note,
-    get_server_sync,
     list_registration_tokens,
     list_server_notes,
     list_servers,
@@ -554,110 +552,6 @@ class TestServerNoteCRUD:
         )
 
 
-class TestCreateServer:
-    """Tests for create_server tool."""
-
-    @pytest.mark.asyncio
-    async def test_create_server_success(self, mock_http_client, mock_token_manager):
-        """Creates a server with required fields and returns success."""
-        created_server = {
-            'id': '550e8400-e29b-41d4-a716-446655440001',
-            'name': 'new-server',
-            'platform': 'debian',
-        }
-        mock_http_client.post.return_value = created_server
-
-        result = await create_server(
-            workspace='testworkspace',
-            name='new-server',
-            platform='debian',
-            region='ap1',
-        )
-
-        assert result['status'] == 'success'
-        assert result['data'] == created_server
-        mock_http_client.post.assert_called_once_with(
-            region='ap1',
-            workspace='testworkspace',
-            endpoint='/api/servers/servers/',
-            token='test-token',
-            data={'name': 'new-server', 'platform': 'debian'},
-        )
-
-    @pytest.mark.asyncio
-    async def test_create_server_with_description(
-        self, mock_http_client, mock_token_manager
-    ):
-        """Creates a server with optional description included in request body."""
-        mock_http_client.post.return_value = {
-            'id': '550e8400-e29b-41d4-a716-446655440001',
-            'name': 'new-server',
-            'platform': 'rhel',
-            'description': 'A production RHEL server',
-        }
-
-        result = await create_server(
-            workspace='testworkspace',
-            name='new-server',
-            platform='rhel',
-            description='A production RHEL server',
-            region='ap1',
-        )
-
-        assert result['status'] == 'success'
-        _, kwargs = mock_http_client.post.call_args
-        assert kwargs['data']['description'] == 'A production RHEL server'
-
-    @pytest.mark.asyncio
-    async def test_create_server_no_token(self, mock_http_client, mock_token_manager):
-        """Returns error when token is missing."""
-        mock_token_manager.get_token.return_value = None
-
-        result = await create_server(
-            workspace='testworkspace', name='new-server', platform='debian'
-        )
-
-        assert result['status'] == 'error'
-        assert 'No token found' in result['message']
-        mock_http_client.post.assert_not_called()
-
-    @pytest.mark.asyncio
-    async def test_create_server_invalid_platform(
-        self, mock_http_client, mock_token_manager
-    ):
-        """Returns validation error when platform is not a valid value."""
-        result = await create_server(
-            workspace='testworkspace',
-            name='new-server',
-            platform='ubuntu',
-            region='ap1',
-        )
-
-        assert result['status'] == 'error'
-        assert result['error_code'] == 'validation'
-        assert result['field'] == 'platform'
-        mock_http_client.post.assert_not_called()
-
-    @pytest.mark.asyncio
-    async def test_create_server_http_error(self, mock_http_client, mock_token_manager):
-        """Returns error when http_client returns an upstream error envelope."""
-        mock_http_client.post.return_value = {
-            'error': 'Bad Request',
-            'status_code': 400,
-            'message': 'Server name already exists',
-        }
-
-        result = await create_server(
-            workspace='testworkspace',
-            name='existing-server',
-            platform='debian',
-            region='ap1',
-        )
-
-        assert result['status'] == 'error'
-        assert result['message'] == 'Server name already exists'
-
-
 class TestUpdateServer:
     """Tests for update_server tool."""
 
@@ -785,8 +679,8 @@ class TestStarServer:
 
     @pytest.mark.asyncio
     async def test_star_server_success(self, mock_http_client, mock_token_manager):
-        """Posts to star endpoint with starred flag and returns success."""
-        mock_http_client.post.return_value = {'starred': True}
+        """Posts to star endpoint with status flag and returns success."""
+        mock_http_client.post.return_value = {'status': True}
 
         result = await star_server(
             server_id='550e8400-e29b-41d4-a716-446655440123',
@@ -818,46 +712,6 @@ class TestStarServer:
         assert result['status'] == 'error'
         assert 'No token found' in result['message']
         mock_http_client.post.assert_not_called()
-
-
-class TestGetServerSync:
-    """Tests for get_server_sync tool."""
-
-    @pytest.mark.asyncio
-    async def test_get_server_sync_success(self, mock_http_client, mock_token_manager):
-        """Returns sync status for a server."""
-        mock_http_client.get.return_value = {
-            'synced': True,
-            'last_sync': '2024-01-01T00:00:00Z',
-        }
-
-        result = await get_server_sync(
-            server_id='550e8400-e29b-41d4-a716-446655440123',
-            workspace='testworkspace',
-            region='ap1',
-        )
-
-        assert result['status'] == 'success'
-        mock_http_client.get.assert_called_once_with(
-            region='ap1',
-            workspace='testworkspace',
-            endpoint='/api/servers/servers/550e8400-e29b-41d4-a716-446655440123/sync/',
-            token='test-token',
-        )
-
-    @pytest.mark.asyncio
-    async def test_get_server_sync_no_token(self, mock_http_client, mock_token_manager):
-        """Returns error when token is missing."""
-        mock_token_manager.get_token.return_value = None
-
-        result = await get_server_sync(
-            server_id='550e8400-e29b-41d4-a716-446655440123',
-            workspace='testworkspace',
-        )
-
-        assert result['status'] == 'error'
-        assert 'No token found' in result['message']
-        mock_http_client.get.assert_not_called()
 
 
 class TestGetServerAccessPolicy:

--- a/tests/test_server_tools.py
+++ b/tests/test_server_tools.py
@@ -12,7 +12,6 @@ from tools.server_tools import (
     create_registration_token,
     create_server_note,
     delete_registration_token,
-    delete_server,
     delete_server_note,
     get_registration_guide,
     get_server,
@@ -21,6 +20,7 @@ from tools.server_tools import (
     list_server_notes,
     list_servers,
     star_server,
+    unregister_server,
     update_server,
     update_server_note,
 )
@@ -636,15 +636,15 @@ class TestUpdateServer:
         assert 'name' not in kwargs['data']
 
 
-class TestDeleteServer:
-    """Tests for delete_server tool."""
+class TestUnregisterServer:
+    """Tests for unregister_server tool."""
 
     @pytest.mark.asyncio
-    async def test_delete_server_success(self, mock_http_client, mock_token_manager):
-        """Deletes server by UUID and returns success."""
+    async def test_unregister_server_success(self, mock_http_client, mock_token_manager):
+        """Unregisters server by UUID and returns success."""
         mock_http_client.delete.return_value = {}
 
-        result = await delete_server(
+        result = await unregister_server(
             server_id='550e8400-e29b-41d4-a716-446655440123',
             workspace='testworkspace',
             region='ap1',
@@ -659,11 +659,11 @@ class TestDeleteServer:
         )
 
     @pytest.mark.asyncio
-    async def test_delete_server_no_token(self, mock_http_client, mock_token_manager):
+    async def test_unregister_server_no_token(self, mock_http_client, mock_token_manager):
         """Returns error when token is missing."""
         mock_token_manager.get_token.return_value = None
 
-        result = await delete_server(
+        result = await unregister_server(
             server_id='550e8400-e29b-41d4-a716-446655440123',
             workspace='testworkspace',
         )

--- a/tests/test_server_tools.py
+++ b/tests/test_server_tools.py
@@ -887,7 +887,7 @@ class TestListRegistrationTokens:
             workspace='testworkspace',
             endpoint='/api/servers/registration-tokens/',
             token='test-token',
-            params={'page': 1, 'page_size': 20},
+            params={},
         )
 
     @pytest.mark.asyncio
@@ -992,14 +992,16 @@ class TestDeleteRegistrationToken:
         mock_http_client.delete.return_value = {}
 
         result = await delete_registration_token(
-            token_id='tok-123', workspace='testworkspace', region='ap1'
+            token_id='a1b2c3d4-e5f6-7890-abcd-ef1234567890',
+            workspace='testworkspace',
+            region='ap1',
         )
 
         assert result['status'] == 'success'
         mock_http_client.delete.assert_called_once_with(
             region='ap1',
             workspace='testworkspace',
-            endpoint='/api/servers/registration-tokens/tok-123/',
+            endpoint='/api/servers/registration-tokens/a1b2c3d4-e5f6-7890-abcd-ef1234567890/',
             token='test-token',
         )
 
@@ -1011,7 +1013,7 @@ class TestDeleteRegistrationToken:
         mock_token_manager.get_token.return_value = None
 
         result = await delete_registration_token(
-            token_id='tok-123', workspace='testworkspace'
+            token_id='a1b2c3d4-e5f6-7890-abcd-ef1234567890', workspace='testworkspace'
         )
 
         assert result['status'] == 'error'
@@ -1042,9 +1044,10 @@ class TestGetRegistrationGuide:
         mock_http_client.post.assert_called_once_with(
             region='ap1',
             workspace='testworkspace',
-            endpoint='/api/servers/registration-methods/token-install/guide/?response_type=json',
+            endpoint='/api/servers/registration-methods/token-install/guide/',
             token='test-token',
             data={'platform': 'debian', 'token': 'tok-123'},
+            params={'response_type': 'json'},
         )
 
     @pytest.mark.asyncio

--- a/tests/test_server_tools.py
+++ b/tests/test_server_tools.py
@@ -667,6 +667,21 @@ class TestUpdateServer:
         mock_http_client.patch.assert_not_called()
 
     @pytest.mark.asyncio
+    async def test_update_server_no_fields_returns_error(
+        self, mock_http_client, mock_token_manager
+    ):
+        """Returns error when no update fields are provided and makes no API call."""
+        result = await update_server(
+            server_id='550e8400-e29b-41d4-a716-446655440123',
+            workspace='testworkspace',
+            region='ap1',
+        )
+
+        assert result['status'] == 'error'
+        assert 'No update data provided' in result['message']
+        mock_http_client.patch.assert_not_called()
+
+    @pytest.mark.asyncio
     async def test_update_server_partial_fields(
         self, mock_http_client, mock_token_manager
     ):

--- a/tests/test_server_tools.py
+++ b/tests/test_server_tools.py
@@ -785,11 +785,12 @@ class TestStarServer:
 
     @pytest.mark.asyncio
     async def test_star_server_success(self, mock_http_client, mock_token_manager):
-        """Posts to star endpoint with empty body and returns success."""
+        """Posts to star endpoint with starred flag and returns success."""
         mock_http_client.post.return_value = {'starred': True}
 
         result = await star_server(
             server_id='550e8400-e29b-41d4-a716-446655440123',
+            status=True,
             workspace='testworkspace',
             region='ap1',
         )
@@ -800,7 +801,7 @@ class TestStarServer:
             workspace='testworkspace',
             endpoint='/api/servers/servers/550e8400-e29b-41d4-a716-446655440123/star/',
             token='test-token',
-            data={},
+            data={'status': True},
         )
 
     @pytest.mark.asyncio
@@ -810,6 +811,7 @@ class TestStarServer:
 
         result = await star_server(
             server_id='550e8400-e29b-41d4-a716-446655440123',
+            status=True,
             workspace='testworkspace',
         )
 

--- a/tests/test_server_tools.py
+++ b/tests/test_server_tools.py
@@ -784,7 +784,10 @@ class TestGetServerSync:
     @pytest.mark.asyncio
     async def test_get_server_sync_success(self, mock_http_client, mock_token_manager):
         """Returns sync status for a server."""
-        mock_http_client.get.return_value = {'synced': True, 'last_sync': '2024-01-01T00:00:00Z'}
+        mock_http_client.get.return_value = {
+            'synced': True,
+            'last_sync': '2024-01-01T00:00:00Z',
+        }
 
         result = await get_server_sync(
             server_id='550e8400-e29b-41d4-a716-446655440123',
@@ -876,9 +879,7 @@ class TestListRegistrationTokens:
         }
         mock_http_client.get.return_value = token_list
 
-        result = await list_registration_tokens(
-            workspace='testworkspace', region='ap1'
-        )
+        result = await list_registration_tokens(workspace='testworkspace', region='ap1')
 
         assert result['status'] == 'success'
         assert result['data'] == token_list
@@ -1029,7 +1030,10 @@ class TestGetRegistrationGuide:
         self, mock_http_client, mock_token_manager
     ):
         """Returns installation guide for the specified platform and token."""
-        guide = {'platform': 'debian', 'commands': ['curl -s https://install.sh | bash']}
+        guide = {
+            'platform': 'debian',
+            'commands': ['curl -s https://install.sh | bash'],
+        }
         mock_http_client.post.return_value = guide
 
         result = await get_registration_guide(
@@ -1044,10 +1048,9 @@ class TestGetRegistrationGuide:
         mock_http_client.post.assert_called_once_with(
             region='ap1',
             workspace='testworkspace',
-            endpoint='/api/servers/registration-methods/token-install/guide/',
+            endpoint='/api/servers/registration-methods/token-install/guide/?response_type=json',
             token='test-token',
             data={'platform': 'debian', 'token': 'tok-123'},
-            params={'response_type': 'json'},
         )
 
     @pytest.mark.asyncio

--- a/tests/test_server_tools.py
+++ b/tests/test_server_tools.py
@@ -635,12 +635,39 @@ class TestUpdateServer:
         assert kwargs['data'] == {'description': 'Updated description'}
         assert 'name' not in kwargs['data']
 
+    @pytest.mark.asyncio
+    async def test_update_server_both_fields(
+        self, mock_http_client, mock_token_manager
+    ):
+        """Both name and description are sent in PATCH body when provided together."""
+        mock_http_client.patch.return_value = {
+            'id': '550e8400-e29b-41d4-a716-446655440123',
+            'name': 'renamed-server',
+            'description': 'Updated description',
+        }
+
+        await update_server(
+            server_id='550e8400-e29b-41d4-a716-446655440123',
+            workspace='testworkspace',
+            name='renamed-server',
+            description='Updated description',
+            region='ap1',
+        )
+
+        _, kwargs = mock_http_client.patch.call_args
+        assert kwargs['data'] == {
+            'name': 'renamed-server',
+            'description': 'Updated description',
+        }
+
 
 class TestUnregisterServer:
     """Tests for unregister_server tool."""
 
     @pytest.mark.asyncio
-    async def test_unregister_server_success(self, mock_http_client, mock_token_manager):
+    async def test_unregister_server_success(
+        self, mock_http_client, mock_token_manager
+    ):
         """Unregisters server by UUID and returns success."""
         mock_http_client.delete.return_value = {}
 
@@ -659,7 +686,9 @@ class TestUnregisterServer:
         )
 
     @pytest.mark.asyncio
-    async def test_unregister_server_no_token(self, mock_http_client, mock_token_manager):
+    async def test_unregister_server_no_token(
+        self, mock_http_client, mock_token_manager
+    ):
         """Returns error when token is missing."""
         mock_token_manager.get_token.return_value = None
 
@@ -950,7 +979,9 @@ class TestGetRegistrationGuide:
         mock_token_manager.get_token.return_value = None
 
         result = await get_registration_guide(
-            workspace='testworkspace', platform='debian', token_id='tok-123'
+            workspace='testworkspace',
+            platform='debian',
+            token_id='a1b2c3d4-e5f6-7890-abcd-ef1234567890',
         )
 
         assert result['status'] == 'error'

--- a/tests/test_server_tools.py
+++ b/tests/test_server_tools.py
@@ -1104,12 +1104,13 @@ class TestGetRegistrationGuide:
         mock_http_client.post.assert_called_once_with(
             region='ap1',
             workspace='testworkspace',
-            endpoint='/api/servers/registration-methods/token-install/guide/?response_type=json',
+            endpoint='/api/servers/registration-methods/token-install/guide/',
             token='test-token',
             data={
                 'platform': 'debian',
                 'token': 'a1b2c3d4-e5f6-7890-abcd-ef1234567890',
             },
+            params={'response_type': 'json'},
         )
 
     @pytest.mark.asyncio

--- a/tests/test_server_tools.py
+++ b/tests/test_server_tools.py
@@ -9,12 +9,22 @@ from unittest.mock import AsyncMock, patch
 import pytest
 
 from tools.server_tools import (
+    create_registration_token,
+    create_server,
     create_server_note,
+    delete_registration_token,
+    delete_server,
     delete_server_note,
+    get_registration_guide,
     get_server,
+    get_server_access_policy,
     get_server_note,
+    get_server_sync,
+    list_registration_tokens,
     list_server_notes,
     list_servers,
+    star_server,
+    update_server,
     update_server_note,
 )
 
@@ -542,6 +552,518 @@ class TestServerNoteCRUD:
             endpoint='/api/servers/notes/note-1/',
             token='test-token',
         )
+
+
+class TestCreateServer:
+    """Tests for create_server tool."""
+
+    @pytest.mark.asyncio
+    async def test_create_server_success(self, mock_http_client, mock_token_manager):
+        """Creates a server with required fields and returns success."""
+        created_server = {
+            'id': '550e8400-e29b-41d4-a716-446655440001',
+            'name': 'new-server',
+            'platform': 'debian',
+        }
+        mock_http_client.post.return_value = created_server
+
+        result = await create_server(
+            workspace='testworkspace',
+            name='new-server',
+            platform='debian',
+            region='ap1',
+        )
+
+        assert result['status'] == 'success'
+        assert result['data'] == created_server
+        mock_http_client.post.assert_called_once_with(
+            region='ap1',
+            workspace='testworkspace',
+            endpoint='/api/servers/servers/',
+            token='test-token',
+            data={'name': 'new-server', 'platform': 'debian'},
+        )
+
+    @pytest.mark.asyncio
+    async def test_create_server_with_description(
+        self, mock_http_client, mock_token_manager
+    ):
+        """Creates a server with optional description included in request body."""
+        mock_http_client.post.return_value = {
+            'id': '550e8400-e29b-41d4-a716-446655440001',
+            'name': 'new-server',
+            'platform': 'rhel',
+            'description': 'A production RHEL server',
+        }
+
+        result = await create_server(
+            workspace='testworkspace',
+            name='new-server',
+            platform='rhel',
+            description='A production RHEL server',
+            region='ap1',
+        )
+
+        assert result['status'] == 'success'
+        _, kwargs = mock_http_client.post.call_args
+        assert kwargs['data']['description'] == 'A production RHEL server'
+
+    @pytest.mark.asyncio
+    async def test_create_server_no_token(self, mock_http_client, mock_token_manager):
+        """Returns error when token is missing."""
+        mock_token_manager.get_token.return_value = None
+
+        result = await create_server(
+            workspace='testworkspace', name='new-server', platform='debian'
+        )
+
+        assert result['status'] == 'error'
+        assert 'No token found' in result['message']
+        mock_http_client.post.assert_not_called()
+
+
+class TestUpdateServer:
+    """Tests for update_server tool."""
+
+    @pytest.mark.asyncio
+    async def test_update_server_success(self, mock_http_client, mock_token_manager):
+        """Updates server fields via PATCH and returns updated data."""
+        updated_server = {
+            'id': '550e8400-e29b-41d4-a716-446655440123',
+            'name': 'renamed-server',
+        }
+        mock_http_client.patch.return_value = updated_server
+
+        result = await update_server(
+            server_id='550e8400-e29b-41d4-a716-446655440123',
+            workspace='testworkspace',
+            name='renamed-server',
+            region='ap1',
+        )
+
+        assert result['status'] == 'success'
+        assert result['data'] == updated_server
+        mock_http_client.patch.assert_called_once_with(
+            region='ap1',
+            workspace='testworkspace',
+            endpoint='/api/servers/servers/550e8400-e29b-41d4-a716-446655440123/',
+            token='test-token',
+            data={'name': 'renamed-server'},
+        )
+
+    @pytest.mark.asyncio
+    async def test_update_server_no_token(self, mock_http_client, mock_token_manager):
+        """Returns error when token is missing."""
+        mock_token_manager.get_token.return_value = None
+
+        result = await update_server(
+            server_id='550e8400-e29b-41d4-a716-446655440123',
+            workspace='testworkspace',
+            name='renamed-server',
+        )
+
+        assert result['status'] == 'error'
+        assert 'No token found' in result['message']
+        mock_http_client.patch.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_update_server_partial_fields(
+        self, mock_http_client, mock_token_manager
+    ):
+        """Only provided fields are sent in PATCH body."""
+        mock_http_client.patch.return_value = {
+            'id': '550e8400-e29b-41d4-a716-446655440123',
+            'description': 'Updated description',
+        }
+
+        await update_server(
+            server_id='550e8400-e29b-41d4-a716-446655440123',
+            workspace='testworkspace',
+            description='Updated description',
+            region='ap1',
+        )
+
+        _, kwargs = mock_http_client.patch.call_args
+        assert kwargs['data'] == {'description': 'Updated description'}
+        assert 'name' not in kwargs['data']
+
+
+class TestDeleteServer:
+    """Tests for delete_server tool."""
+
+    @pytest.mark.asyncio
+    async def test_delete_server_success(self, mock_http_client, mock_token_manager):
+        """Deletes server by UUID and returns success."""
+        mock_http_client.delete.return_value = {}
+
+        result = await delete_server(
+            server_id='550e8400-e29b-41d4-a716-446655440123',
+            workspace='testworkspace',
+            region='ap1',
+        )
+
+        assert result['status'] == 'success'
+        mock_http_client.delete.assert_called_once_with(
+            region='ap1',
+            workspace='testworkspace',
+            endpoint='/api/servers/servers/550e8400-e29b-41d4-a716-446655440123/',
+            token='test-token',
+        )
+
+    @pytest.mark.asyncio
+    async def test_delete_server_no_token(self, mock_http_client, mock_token_manager):
+        """Returns error when token is missing."""
+        mock_token_manager.get_token.return_value = None
+
+        result = await delete_server(
+            server_id='550e8400-e29b-41d4-a716-446655440123',
+            workspace='testworkspace',
+        )
+
+        assert result['status'] == 'error'
+        assert 'No token found' in result['message']
+        mock_http_client.delete.assert_not_called()
+
+
+class TestStarServer:
+    """Tests for star_server tool."""
+
+    @pytest.mark.asyncio
+    async def test_star_server_success(self, mock_http_client, mock_token_manager):
+        """Posts to star endpoint with empty body and returns success."""
+        mock_http_client.post.return_value = {'starred': True}
+
+        result = await star_server(
+            server_id='550e8400-e29b-41d4-a716-446655440123',
+            workspace='testworkspace',
+            region='ap1',
+        )
+
+        assert result['status'] == 'success'
+        mock_http_client.post.assert_called_once_with(
+            region='ap1',
+            workspace='testworkspace',
+            endpoint='/api/servers/servers/550e8400-e29b-41d4-a716-446655440123/star/',
+            token='test-token',
+            data={},
+        )
+
+    @pytest.mark.asyncio
+    async def test_star_server_no_token(self, mock_http_client, mock_token_manager):
+        """Returns error when token is missing."""
+        mock_token_manager.get_token.return_value = None
+
+        result = await star_server(
+            server_id='550e8400-e29b-41d4-a716-446655440123',
+            workspace='testworkspace',
+        )
+
+        assert result['status'] == 'error'
+        assert 'No token found' in result['message']
+        mock_http_client.post.assert_not_called()
+
+
+class TestGetServerSync:
+    """Tests for get_server_sync tool."""
+
+    @pytest.mark.asyncio
+    async def test_get_server_sync_success(self, mock_http_client, mock_token_manager):
+        """Returns sync status for a server."""
+        mock_http_client.get.return_value = {'synced': True, 'last_sync': '2024-01-01T00:00:00Z'}
+
+        result = await get_server_sync(
+            server_id='550e8400-e29b-41d4-a716-446655440123',
+            workspace='testworkspace',
+            region='ap1',
+        )
+
+        assert result['status'] == 'success'
+        mock_http_client.get.assert_called_once_with(
+            region='ap1',
+            workspace='testworkspace',
+            endpoint='/api/servers/servers/550e8400-e29b-41d4-a716-446655440123/sync/',
+            token='test-token',
+        )
+
+    @pytest.mark.asyncio
+    async def test_get_server_sync_no_token(self, mock_http_client, mock_token_manager):
+        """Returns error when token is missing."""
+        mock_token_manager.get_token.return_value = None
+
+        result = await get_server_sync(
+            server_id='550e8400-e29b-41d4-a716-446655440123',
+            workspace='testworkspace',
+        )
+
+        assert result['status'] == 'error'
+        assert 'No token found' in result['message']
+        mock_http_client.get.assert_not_called()
+
+
+class TestGetServerAccessPolicy:
+    """Tests for get_server_access_policy tool."""
+
+    @pytest.mark.asyncio
+    async def test_get_server_access_policy_success(
+        self, mock_http_client, mock_token_manager
+    ):
+        """Returns access policy for a server."""
+        mock_http_client.get.return_value = {
+            'users': ['alice', 'bob'],
+            'groups': ['admins'],
+        }
+
+        result = await get_server_access_policy(
+            server_id='550e8400-e29b-41d4-a716-446655440123',
+            workspace='testworkspace',
+            region='ap1',
+        )
+
+        assert result['status'] == 'success'
+        mock_http_client.get.assert_called_once_with(
+            region='ap1',
+            workspace='testworkspace',
+            endpoint='/api/servers/servers/550e8400-e29b-41d4-a716-446655440123/access-policy/',
+            token='test-token',
+        )
+
+    @pytest.mark.asyncio
+    async def test_get_server_access_policy_no_token(
+        self, mock_http_client, mock_token_manager
+    ):
+        """Returns error when token is missing."""
+        mock_token_manager.get_token.return_value = None
+
+        result = await get_server_access_policy(
+            server_id='550e8400-e29b-41d4-a716-446655440123',
+            workspace='testworkspace',
+        )
+
+        assert result['status'] == 'error'
+        assert 'No token found' in result['message']
+        mock_http_client.get.assert_not_called()
+
+
+class TestListRegistrationTokens:
+    """Tests for list_registration_tokens tool."""
+
+    @pytest.mark.asyncio
+    async def test_list_registration_tokens_success(
+        self, mock_http_client, mock_token_manager
+    ):
+        """Returns paginated list of registration tokens."""
+        token_list = {
+            'count': 2,
+            'results': [
+                {'id': 'tok-1', 'name': 'prod-token'},
+                {'id': 'tok-2', 'name': 'staging-token'},
+            ],
+        }
+        mock_http_client.get.return_value = token_list
+
+        result = await list_registration_tokens(
+            workspace='testworkspace', region='ap1'
+        )
+
+        assert result['status'] == 'success'
+        assert result['data'] == token_list
+        mock_http_client.get.assert_called_once_with(
+            region='ap1',
+            workspace='testworkspace',
+            endpoint='/api/servers/registration-tokens/',
+            token='test-token',
+            params={'page': 1, 'page_size': 20},
+        )
+
+    @pytest.mark.asyncio
+    async def test_list_registration_tokens_pagination(
+        self, mock_http_client, mock_token_manager
+    ):
+        """Passes page and page_size params to the API."""
+        mock_http_client.get.return_value = {'count': 0, 'results': []}
+
+        await list_registration_tokens(
+            workspace='testworkspace', region='ap1', page=2, page_size=5
+        )
+
+        _, kwargs = mock_http_client.get.call_args
+        assert kwargs['params'] == {'page': 2, 'page_size': 5}
+
+    @pytest.mark.asyncio
+    async def test_list_registration_tokens_no_token(
+        self, mock_http_client, mock_token_manager
+    ):
+        """Returns error when token is missing."""
+        mock_token_manager.get_token.return_value = None
+
+        result = await list_registration_tokens(workspace='testworkspace')
+
+        assert result['status'] == 'error'
+        assert 'No token found' in result['message']
+        mock_http_client.get.assert_not_called()
+
+
+class TestCreateRegistrationToken:
+    """Tests for create_registration_token tool."""
+
+    @pytest.mark.asyncio
+    async def test_create_registration_token_success(
+        self, mock_http_client, mock_token_manager
+    ):
+        """Creates a registration token with required name."""
+        created_token = {'id': 'tok-123', 'name': 'my-token', 'token': 'abc123xyz'}
+        mock_http_client.post.return_value = created_token
+
+        result = await create_registration_token(
+            workspace='testworkspace', name='my-token', region='ap1'
+        )
+
+        assert result['status'] == 'success'
+        assert result['data'] == created_token
+        mock_http_client.post.assert_called_once_with(
+            region='ap1',
+            workspace='testworkspace',
+            endpoint='/api/servers/registration-tokens/',
+            token='test-token',
+            data={'name': 'my-token'},
+        )
+
+    @pytest.mark.asyncio
+    async def test_create_registration_token_with_description(
+        self, mock_http_client, mock_token_manager
+    ):
+        """Includes description in POST body when provided."""
+        mock_http_client.post.return_value = {
+            'id': 'tok-123',
+            'name': 'my-token',
+            'description': 'For production servers',
+        }
+
+        result = await create_registration_token(
+            workspace='testworkspace',
+            name='my-token',
+            description='For production servers',
+            region='ap1',
+        )
+
+        assert result['status'] == 'success'
+        _, kwargs = mock_http_client.post.call_args
+        assert kwargs['data']['description'] == 'For production servers'
+
+    @pytest.mark.asyncio
+    async def test_create_registration_token_no_token(
+        self, mock_http_client, mock_token_manager
+    ):
+        """Returns error when auth token is missing."""
+        mock_token_manager.get_token.return_value = None
+
+        result = await create_registration_token(
+            workspace='testworkspace', name='my-token'
+        )
+
+        assert result['status'] == 'error'
+        assert 'No token found' in result['message']
+        mock_http_client.post.assert_not_called()
+
+
+class TestDeleteRegistrationToken:
+    """Tests for delete_registration_token tool."""
+
+    @pytest.mark.asyncio
+    async def test_delete_registration_token_success(
+        self, mock_http_client, mock_token_manager
+    ):
+        """Deletes registration token by ID."""
+        mock_http_client.delete.return_value = {}
+
+        result = await delete_registration_token(
+            token_id='tok-123', workspace='testworkspace', region='ap1'
+        )
+
+        assert result['status'] == 'success'
+        mock_http_client.delete.assert_called_once_with(
+            region='ap1',
+            workspace='testworkspace',
+            endpoint='/api/servers/registration-tokens/tok-123/',
+            token='test-token',
+        )
+
+    @pytest.mark.asyncio
+    async def test_delete_registration_token_no_token(
+        self, mock_http_client, mock_token_manager
+    ):
+        """Returns error when auth token is missing."""
+        mock_token_manager.get_token.return_value = None
+
+        result = await delete_registration_token(
+            token_id='tok-123', workspace='testworkspace'
+        )
+
+        assert result['status'] == 'error'
+        assert 'No token found' in result['message']
+        mock_http_client.delete.assert_not_called()
+
+
+class TestGetRegistrationGuide:
+    """Tests for get_registration_guide tool."""
+
+    @pytest.mark.asyncio
+    async def test_get_registration_guide_success(
+        self, mock_http_client, mock_token_manager
+    ):
+        """Returns installation guide for the specified platform and token."""
+        guide = {'platform': 'debian', 'commands': ['curl -s https://install.sh | bash']}
+        mock_http_client.post.return_value = guide
+
+        result = await get_registration_guide(
+            workspace='testworkspace',
+            platform='debian',
+            token_id='tok-123',
+            region='ap1',
+        )
+
+        assert result['status'] == 'success'
+        assert result['data'] == guide
+        mock_http_client.post.assert_called_once_with(
+            region='ap1',
+            workspace='testworkspace',
+            endpoint='/api/servers/registration-methods/token-install/guide/?response_type=json',
+            token='test-token',
+            data={'platform': 'debian', 'token': 'tok-123'},
+        )
+
+    @pytest.mark.asyncio
+    async def test_get_registration_guide_with_server_name(
+        self, mock_http_client, mock_token_manager
+    ):
+        """Includes server_name in POST body when provided."""
+        mock_http_client.post.return_value = {'platform': 'rhel', 'commands': []}
+
+        await get_registration_guide(
+            workspace='testworkspace',
+            platform='rhel',
+            token_id='tok-123',
+            server_name='my-new-server',
+            region='ap1',
+        )
+
+        _, kwargs = mock_http_client.post.call_args
+        assert kwargs['data']['server_name'] == 'my-new-server'
+
+    @pytest.mark.asyncio
+    async def test_get_registration_guide_no_token(
+        self, mock_http_client, mock_token_manager
+    ):
+        """Returns error when auth token is missing."""
+        mock_token_manager.get_token.return_value = None
+
+        result = await get_registration_guide(
+            workspace='testworkspace', platform='debian', token_id='tok-123'
+        )
+
+        assert result['status'] == 'error'
+        assert 'No token found' in result['message']
+        mock_http_client.post.assert_not_called()
 
 
 if __name__ == '__main__':

--- a/tests/test_server_tools.py
+++ b/tests/test_server_tools.py
@@ -621,6 +621,42 @@ class TestCreateServer:
         assert 'No token found' in result['message']
         mock_http_client.post.assert_not_called()
 
+    @pytest.mark.asyncio
+    async def test_create_server_invalid_platform(
+        self, mock_http_client, mock_token_manager
+    ):
+        """Returns validation error when platform is not a valid value."""
+        result = await create_server(
+            workspace='testworkspace',
+            name='new-server',
+            platform='ubuntu',
+            region='ap1',
+        )
+
+        assert result['status'] == 'error'
+        assert result['error_code'] == 'validation'
+        assert result['field'] == 'platform'
+        mock_http_client.post.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_create_server_http_error(self, mock_http_client, mock_token_manager):
+        """Returns error when http_client returns an upstream error envelope."""
+        mock_http_client.post.return_value = {
+            'error': 'Bad Request',
+            'status_code': 400,
+            'message': 'Server name already exists',
+        }
+
+        result = await create_server(
+            workspace='testworkspace',
+            name='existing-server',
+            platform='debian',
+            region='ap1',
+        )
+
+        assert result['status'] == 'error'
+        assert result['message'] == 'Server name already exists'
+
 
 class TestUpdateServer:
     """Tests for update_server tool."""
@@ -678,7 +714,11 @@ class TestUpdateServer:
         )
 
         assert result['status'] == 'error'
-        assert 'No update data provided' in result['message']
+        assert result['error_code'] == 'validation'
+        assert (
+            'At least one of name or description must be provided.'
+            in result['suggestion']
+        )
         mock_http_client.patch.assert_not_called()
 
     @pytest.mark.asyncio
@@ -1021,6 +1061,22 @@ class TestDeleteRegistrationToken:
         assert 'No token found' in result['message']
         mock_http_client.delete.assert_not_called()
 
+    @pytest.mark.asyncio
+    async def test_delete_registration_token_invalid_token_id(
+        self, mock_http_client, mock_token_manager
+    ):
+        """Returns validation error when token_id is not a valid UUID."""
+        result = await delete_registration_token(
+            token_id='not-a-uuid',
+            workspace='testworkspace',
+            region='ap1',
+        )
+
+        assert result['status'] == 'error'
+        assert result['error_code'] == 'validation'
+        assert result['field'] == 'token_id'
+        mock_http_client.delete.assert_not_called()
+
 
 class TestGetRegistrationGuide:
     """Tests for get_registration_guide tool."""
@@ -1039,7 +1095,7 @@ class TestGetRegistrationGuide:
         result = await get_registration_guide(
             workspace='testworkspace',
             platform='debian',
-            token_id='tok-123',
+            token_id='a1b2c3d4-e5f6-7890-abcd-ef1234567890',
             region='ap1',
         )
 
@@ -1050,7 +1106,10 @@ class TestGetRegistrationGuide:
             workspace='testworkspace',
             endpoint='/api/servers/registration-methods/token-install/guide/?response_type=json',
             token='test-token',
-            data={'platform': 'debian', 'token': 'tok-123'},
+            data={
+                'platform': 'debian',
+                'token': 'a1b2c3d4-e5f6-7890-abcd-ef1234567890',
+            },
         )
 
     @pytest.mark.asyncio
@@ -1063,7 +1122,7 @@ class TestGetRegistrationGuide:
         await get_registration_guide(
             workspace='testworkspace',
             platform='rhel',
-            token_id='tok-123',
+            token_id='a1b2c3d4-e5f6-7890-abcd-ef1234567890',
             server_name='my-new-server',
             region='ap1',
         )

--- a/tests/test_server_tools.py
+++ b/tests/test_server_tools.py
@@ -1146,6 +1146,40 @@ class TestGetRegistrationGuide:
         assert 'No token found' in result['message']
         mock_http_client.post.assert_not_called()
 
+    @pytest.mark.asyncio
+    async def test_get_registration_guide_invalid_token_id(
+        self, mock_http_client, mock_token_manager
+    ):
+        """Returns validation error when token_id is not a valid UUID."""
+        result = await get_registration_guide(
+            workspace='testworkspace',
+            platform='debian',
+            token_id='not-a-uuid',
+            region='ap1',
+        )
+
+        assert result['status'] == 'error'
+        assert result['error_code'] == 'validation'
+        assert result['field'] == 'token_id'
+        mock_http_client.post.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_get_registration_guide_invalid_platform(
+        self, mock_http_client, mock_token_manager
+    ):
+        """Returns validation error when platform is unsupported."""
+        result = await get_registration_guide(
+            workspace='testworkspace',
+            platform='solaris',
+            token_id='a1b2c3d4-e5f6-7890-abcd-ef1234567890',
+            region='ap1',
+        )
+
+        assert result['status'] == 'error'
+        assert result['error_code'] == 'validation'
+        assert result['field'] == 'platform'
+        mock_http_client.post.assert_not_called()
+
 
 if __name__ == '__main__':
     pytest.main([__file__, '-v'])

--- a/tools/server_tools.py
+++ b/tools/server_tools.py
@@ -799,51 +799,6 @@ async def star_server(
 
 @mcp_tool_handler(
     description=(
-        'Get the access policy for a server, showing which users and groups have access and what permissions they hold. '
-        'Related: list_server_acls (command ACLs), list_servers.'
-    ),
-    annotations=READ_ONLY,
-    meta={'anthropic/searchHint': 'server access policy permissions who can access'},
-)
-async def get_server_access_policy(
-    server_id: str, workspace: str, region: str = '', **kwargs
-) -> dict[str, Any]:
-    """Get the access policy for a server.
-
-    Args:
-        server_id: Server UUID
-        workspace: Workspace name. Required parameter
-        region: Region (ap1, us1, eu1). Auto-detected if not provided
-
-    Returns:
-        Server access policy
-    """
-    token = kwargs.get('token')
-
-    result = await http_client.get(
-        region=region,
-        workspace=workspace,
-        endpoint=f'/api/servers/servers/{server_id}/access-policy/',
-        token=token,
-    )
-
-    err = unwrap_http_result(
-        result,
-        default_message='Failed to get server access policy',
-        server_id=server_id,
-        region=region,
-        workspace=workspace,
-    )
-    if err:
-        return err
-
-    return success_response(
-        data=result, server_id=server_id, region=region, workspace=workspace
-    )
-
-
-@mcp_tool_handler(
-    description=(
         'List all server registration tokens in a workspace. '
         'Registration tokens are used to install the Alpacon agent on new servers. '
         'Related: create_registration_token, delete_registration_token, get_registration_guide.'

--- a/tools/server_tools.py
+++ b/tools/server_tools.py
@@ -8,6 +8,9 @@ from utils.error_handler import format_validation_error, validate_server_id_form
 from utils.http_client import http_client
 from utils.tool_annotations import ADDITIVE, DESTRUCTIVE, IDEMPOTENT_WRITE, READ_ONLY
 
+VALID_PLATFORMS = frozenset({'debian', 'rhel', 'darwin', 'windows'})
+_PLATFORM_LIST_STR = ', '.join(f'"{p}"' for p in sorted(VALID_PLATFORMS))
+
 
 @mcp_tool_handler(
     description=(
@@ -633,33 +636,10 @@ async def shutdown_system(
     )
 
 
-VALID_PLATFORMS = frozenset({'debian', 'rhel', 'darwin', 'windows'})
-
-
-def _validate_platform(platform: str) -> dict[str, Any] | None:
-    if platform not in VALID_PLATFORMS:
-        return format_validation_error(
-            'platform',
-            platform,
-            f'Must be one of: {", ".join(sorted(VALID_PLATFORMS))}',
-        )
-    return None
-
-
-def _validate_token_id(token_id: str) -> dict[str, Any] | None:
-    if not validate_server_id_format(token_id):
-        return format_validation_error(
-            'token_id',
-            token_id,
-            'Must be a valid UUID. Example: 550e8400-e29b-41d4-a716-446655440000',
-        )
-    return None
-
-
 @mcp_tool_handler(
     description=(
         'Create a new server record in a workspace. '
-        'The platform must be one of: "debian", "rhel", "darwin", "windows". '
+        f'The platform must be one of: {_PLATFORM_LIST_STR}. '
         'After creation, use get_registration_guide to get the agent installation instructions. '
         'Related: list_servers (view after creation), delete_server.'
     ),
@@ -1130,7 +1110,7 @@ async def delete_registration_token(
     description=(
         'Get the agent installation guide for a specific platform and registration token. '
         'Returns shell commands or instructions to install the Alpacon agent on a new server. '
-        'The platform must be one of: "debian", "rhel", "darwin", "windows". '
+        f'The platform must be one of: {_PLATFORM_LIST_STR}. '
         'Related: list_registration_tokens (get token ID), create_registration_token.'
     ),
     annotations=READ_ONLY,
@@ -1188,3 +1168,23 @@ async def get_registration_guide(
         return err
 
     return success_response(data=result, region=region, workspace=workspace)
+
+
+def _validate_platform(platform: str) -> dict[str, Any] | None:
+    if platform not in VALID_PLATFORMS:
+        return format_validation_error(
+            'platform',
+            platform,
+            f'Must be one of: {", ".join(sorted(VALID_PLATFORMS))}',
+        )
+    return None
+
+
+def _validate_token_id(token_id: str) -> dict[str, Any] | None:
+    if not validate_server_id_format(token_id):
+        return format_validation_error(
+            'token_id',
+            token_id,
+            'Must be a valid UUID. Example: 550e8400-e29b-41d4-a716-446655440000',
+        )
+    return None

--- a/tools/server_tools.py
+++ b/tools/server_tools.py
@@ -638,12 +638,13 @@ async def shutdown_system(
 
 @mcp_tool_handler(
     description=(
-        'Update an existing server record by its UUID. '
-        'Supports partial updates: only fields you provide will be changed. '
-        'Related: get_server (view current state), delete_server.'
+        "Rename or relabel a host's Alpacon entry (`name`, `description`) by UUID. "
+        'Use when a server is re-purposed or moved between teams—this updates the '
+        'fleet-inventory metadata only. '
+        'Related: get_server (view current state), unregister_server.'
     ),
     annotations=IDEMPOTENT_WRITE,
-    meta={'anthropic/searchHint': 'server update edit modify rename'},
+    meta={'anthropic/searchHint': 'server update edit modify rename relabel'},
 )
 async def update_server(
     server_id: str,
@@ -705,17 +706,18 @@ async def update_server(
 
 @mcp_tool_handler(
     description=(
-        'Permanently delete a server record from the workspace by its UUID. '
-        'This action cannot be undone. The server will be removed from all listings. '
-        'Related: list_servers (find server UUID first), get_server (confirm before deleting).'
+        'Unregister a host from this workspace by UUID. The host is removed from '
+        'all listings and no new Work Sessions can target it, but the Alpamon agent '
+        'on the host keeps running until uninstalled. Irreversible from this API. '
+        'Related: list_servers (find UUID), get_server (confirm before unregistering).'
     ),
     annotations=DESTRUCTIVE,
-    meta={'anthropic/searchHint': 'server delete remove permanently'},
+    meta={'anthropic/searchHint': 'server unregister deregister delete remove'},
 )
-async def delete_server(
+async def unregister_server(
     server_id: str, workspace: str, region: str = '', **kwargs
 ) -> dict[str, Any]:
-    """Delete a server from the workspace.
+    """Unregister a server from the workspace.
 
     Args:
         server_id: Server UUID
@@ -723,7 +725,7 @@ async def delete_server(
         region: Region (ap1, us1, eu1). Auto-detected if not provided
 
     Returns:
-        Deletion confirmation
+        Unregister confirmation
     """
     token = kwargs.get('token')
 
@@ -736,7 +738,7 @@ async def delete_server(
 
     err = unwrap_http_result(
         result,
-        default_message='Failed to delete server',
+        default_message='Failed to unregister server',
         server_id=server_id,
         region=region,
         workspace=workspace,
@@ -751,12 +753,13 @@ async def delete_server(
 
 @mcp_tool_handler(
     description=(
-        'Set the starred/favorite status of a server. '
-        'Starred servers can be quickly accessed in the workspace dashboard. '
-        'Related: list_servers, get_server.'
+        'Pin or unpin a server for the caller for faster access—a personal-preference '
+        'flag, not a fleet-wide setting. Does not change visibility, RBAC, or ACLs '
+        'for any other principal. Use `status=True` to pin, `False` to unpin. '
+        'Related: list_servers (the unfiltered inventory).'
     ),
     annotations=IDEMPOTENT_WRITE,
-    meta={'anthropic/searchHint': 'server star favorite bookmark'},
+    meta={'anthropic/searchHint': 'server star pin favorite bookmark personalization'},
 )
 async def star_server(
     server_id: str, status: bool, workspace: str, region: str = '', **kwargs
@@ -799,12 +802,14 @@ async def star_server(
 
 @mcp_tool_handler(
     description=(
-        'List all server registration tokens in a workspace. '
-        'Registration tokens are used to install the Alpacon agent on new servers. '
+        'List Alpamon registration tokens issued in this workspace—credentials '
+        'embedded in the install script to authenticate a host on first run. '
+        'Returns token IDs, names, and creation metadata. Use before issuing new '
+        'tokens or rotating compromised ones. '
         'Related: create_registration_token, delete_registration_token, get_registration_guide.'
     ),
     annotations=READ_ONLY,
-    meta={'anthropic/searchHint': 'registration token list agent install'},
+    meta={'anthropic/searchHint': 'registration token list alpamon install'},
 )
 async def list_registration_tokens(
     workspace: str,
@@ -854,13 +859,14 @@ async def list_registration_tokens(
 
 @mcp_tool_handler(
     description=(
-        'Create a new server registration token. '
-        'The token is used to authenticate the Alpacon agent during installation on a new server. '
-        'After creating a token, use get_registration_guide to get the installation instructions. '
+        'Mint a new Alpamon registration token for installing the agent on a new '
+        'host. The returned token is embedded in the install script '
+        '(get_registration_guide). Name the token per cohort/batch '
+        '(e.g., `prod-web-2026-q2`) for clean rotation later. '
         'Related: list_registration_tokens, delete_registration_token, get_registration_guide.'
     ),
     annotations=ADDITIVE,
-    meta={'anthropic/searchHint': 'registration token create new agent install'},
+    meta={'anthropic/searchHint': 'registration token create mint issue alpamon install new host'},
 )
 async def create_registration_token(
     workspace: str,
@@ -908,12 +914,13 @@ async def create_registration_token(
 
 @mcp_tool_handler(
     description=(
-        'Delete a server registration token by its ID. '
-        'This invalidates the token and prevents any future agent installations using it. '
+        'Revoke an Alpamon registration token by ID. Already-enrolled hosts keep '
+        'working—this only blocks future enrollments using the same token. Use to '
+        'rotate after a suspected token leak or when a rollout cohort is complete. '
         'Related: list_registration_tokens (find token ID first), create_registration_token.'
     ),
     annotations=DESTRUCTIVE,
-    meta={'anthropic/searchHint': 'registration token delete remove invalidate'},
+    meta={'anthropic/searchHint': 'registration token delete revoke rotate invalidate'},
 )
 async def delete_registration_token(
     token_id: str, workspace: str, region: str = '', **kwargs
@@ -958,13 +965,15 @@ async def delete_registration_token(
 
 @mcp_tool_handler(
     description=(
-        'Get the agent installation guide for a specific platform and registration token. '
-        'Returns shell commands or instructions to install the Alpacon agent on a new server. '
-        f'The platform must be one of: {_PLATFORM_LIST_STR}. '
+        'Get the platform-specific Alpamon install script for a registration token. '
+        'Returns the exact shell commands an Operator runs on the target host to '
+        "bring it under Alpacon's control plane. "
+        f'The `platform` must be one of: {_PLATFORM_LIST_STR}. '
+        'Optionally pre-name the host via `server_name`. '
         'Related: list_registration_tokens (get token ID), create_registration_token.'
     ),
     annotations=READ_ONLY,
-    meta={'anthropic/searchHint': 'registration guide install agent setup script'},
+    meta={'anthropic/searchHint': 'registration guide install script alpamon setup operator'},
 )
 async def get_registration_guide(
     token_id: str,

--- a/tools/server_tools.py
+++ b/tools/server_tools.py
@@ -372,11 +372,6 @@ async def delete_server_note(
     )
 
 
-# ===============================
-# AGENT ACTION TOOLS
-# ===============================
-
-
 @mcp_tool_handler(
     description=(
         'Restart the Alpacon agent process on a server. The agent will briefly go offline during restart. '
@@ -637,10 +632,6 @@ async def shutdown_system(
         data=result, server_id=server_id, region=region, workspace=workspace
     )
 
-
-# ===============================
-# SERVER CRUD TOOLS
-# ===============================
 
 VALID_PLATFORMS = frozenset({'debian', 'rhel', 'darwin', 'windows'})
 
@@ -974,11 +965,6 @@ async def get_server_access_policy(
     return success_response(
         data=result, server_id=server_id, region=region, workspace=workspace
     )
-
-
-# ===============================
-# REGISTRATION TOKEN TOOLS
-# ===============================
 
 
 @mcp_tool_handler(

--- a/tools/server_tools.py
+++ b/tools/server_tools.py
@@ -636,3 +636,420 @@ async def shutdown_system(
     return success_response(
         data=result, server_id=server_id, region=region, workspace=workspace
     )
+
+
+# ===============================
+# SERVER CRUD TOOLS
+# ===============================
+
+
+@mcp_tool_handler(
+    description=(
+        'Create a new server record in a workspace. '
+        'The platform must be one of: "debian", "rhel", "darwin", "windows". '
+        'After creation, use get_registration_guide to get the agent installation instructions. '
+        'Related: list_servers (view after creation), delete_server.'
+    ),
+    annotations=ADDITIVE,
+    meta={'anthropic/searchHint': 'server create add new register'},
+)
+async def create_server(
+    workspace: str,
+    name: str,
+    platform: str,
+    description: str | None = None,
+    region: str = '',
+    **kwargs,
+) -> dict[str, Any]:
+    """Create a new server in the workspace.
+
+    Args:
+        workspace: Workspace name. Required parameter
+        name: Server name
+        platform: Server platform ("debian" | "rhel" | "darwin" | "windows")
+        description: Optional server description
+        region: Region (ap1, us1, eu1). Auto-detected if not provided
+
+    Returns:
+        Created server data
+    """
+    token = kwargs.get('token')
+
+    data: dict[str, Any] = {'name': name, 'platform': platform}
+    if description is not None:
+        data['description'] = description
+
+    result = await http_client.post(
+        region=region,
+        workspace=workspace,
+        endpoint='/api/servers/servers/',
+        token=token,
+        data=data,
+    )
+
+    return success_response(data=result, region=region, workspace=workspace)
+
+
+@mcp_tool_handler(
+    description=(
+        'Update an existing server record by its UUID. '
+        'Supports partial updates: only fields you provide will be changed. '
+        'Related: get_server (view current state), delete_server.'
+    ),
+    annotations=IDEMPOTENT_WRITE,
+    meta={'anthropic/searchHint': 'server update edit modify rename'},
+)
+async def update_server(
+    server_id: str,
+    workspace: str,
+    name: str | None = None,
+    description: str | None = None,
+    region: str = '',
+    **kwargs,
+) -> dict[str, Any]:
+    """Update an existing server record.
+
+    Args:
+        server_id: Server UUID
+        workspace: Workspace name. Required parameter
+        name: New server name (optional)
+        description: New server description (optional)
+        region: Region (ap1, us1, eu1). Auto-detected if not provided
+
+    Returns:
+        Updated server data
+    """
+    token = kwargs.get('token')
+
+    update_data: dict[str, Any] = {}
+    if name is not None:
+        update_data['name'] = name
+    if description is not None:
+        update_data['description'] = description
+
+    result = await http_client.patch(
+        region=region,
+        workspace=workspace,
+        endpoint=f'/api/servers/servers/{server_id}/',
+        token=token,
+        data=update_data,
+    )
+
+    return success_response(
+        data=result, server_id=server_id, region=region, workspace=workspace
+    )
+
+
+@mcp_tool_handler(
+    description=(
+        'Permanently delete a server record from the workspace by its UUID. '
+        'This action cannot be undone. The server will be removed from all listings. '
+        'Related: list_servers (find server UUID first), get_server (confirm before deleting).'
+    ),
+    annotations=DESTRUCTIVE,
+    meta={'anthropic/searchHint': 'server delete remove permanently'},
+)
+async def delete_server(
+    server_id: str, workspace: str, region: str = '', **kwargs
+) -> dict[str, Any]:
+    """Delete a server from the workspace.
+
+    Args:
+        server_id: Server UUID
+        workspace: Workspace name. Required parameter
+        region: Region (ap1, us1, eu1). Auto-detected if not provided
+
+    Returns:
+        Deletion confirmation
+    """
+    token = kwargs.get('token')
+
+    result = await http_client.delete(
+        region=region,
+        workspace=workspace,
+        endpoint=f'/api/servers/servers/{server_id}/',
+        token=token,
+    )
+
+    return success_response(
+        data=result, server_id=server_id, region=region, workspace=workspace
+    )
+
+
+@mcp_tool_handler(
+    description=(
+        'Toggle the starred/favorite status of a server. '
+        'Starred servers can be quickly accessed in the workspace dashboard. '
+        'Related: list_servers, get_server.'
+    ),
+    annotations=IDEMPOTENT_WRITE,
+    meta={'anthropic/searchHint': 'server star favorite bookmark'},
+)
+async def star_server(
+    server_id: str, workspace: str, region: str = '', **kwargs
+) -> dict[str, Any]:
+    """Toggle star status on a server.
+
+    Args:
+        server_id: Server UUID
+        workspace: Workspace name. Required parameter
+        region: Region (ap1, us1, eu1). Auto-detected if not provided
+
+    Returns:
+        Star toggle response
+    """
+    token = kwargs.get('token')
+
+    result = await http_client.post(
+        region=region,
+        workspace=workspace,
+        endpoint=f'/api/servers/servers/{server_id}/star/',
+        token=token,
+        data={},
+    )
+
+    return success_response(
+        data=result, server_id=server_id, region=region, workspace=workspace
+    )
+
+
+@mcp_tool_handler(
+    description=(
+        'Get the sync status of a server, showing whether the agent data is up to date with the platform. '
+        'Use this to check if a server is in sync after configuration changes. '
+        'Related: update_information (trigger a resync), get_server.'
+    ),
+    annotations=READ_ONLY,
+    meta={'anthropic/searchHint': 'server sync status check drift'},
+)
+async def get_server_sync(
+    server_id: str, workspace: str, region: str = '', **kwargs
+) -> dict[str, Any]:
+    """Get sync status for a server.
+
+    Args:
+        server_id: Server UUID
+        workspace: Workspace name. Required parameter
+        region: Region (ap1, us1, eu1). Auto-detected if not provided
+
+    Returns:
+        Server sync status
+    """
+    token = kwargs.get('token')
+
+    result = await http_client.get(
+        region=region,
+        workspace=workspace,
+        endpoint=f'/api/servers/servers/{server_id}/sync/',
+        token=token,
+    )
+
+    return success_response(
+        data=result, server_id=server_id, region=region, workspace=workspace
+    )
+
+
+@mcp_tool_handler(
+    description=(
+        'Get the access policy for a server, showing which users and groups have access and what permissions they hold. '
+        'Related: list_server_acls (command ACLs), list_servers.'
+    ),
+    annotations=READ_ONLY,
+    meta={'anthropic/searchHint': 'server access policy permissions who can access'},
+)
+async def get_server_access_policy(
+    server_id: str, workspace: str, region: str = '', **kwargs
+) -> dict[str, Any]:
+    """Get the access policy for a server.
+
+    Args:
+        server_id: Server UUID
+        workspace: Workspace name. Required parameter
+        region: Region (ap1, us1, eu1). Auto-detected if not provided
+
+    Returns:
+        Server access policy
+    """
+    token = kwargs.get('token')
+
+    result = await http_client.get(
+        region=region,
+        workspace=workspace,
+        endpoint=f'/api/servers/servers/{server_id}/access-policy/',
+        token=token,
+    )
+
+    return success_response(
+        data=result, server_id=server_id, region=region, workspace=workspace
+    )
+
+
+# ===============================
+# REGISTRATION TOKEN TOOLS
+# ===============================
+
+
+@mcp_tool_handler(
+    description=(
+        'List all server registration tokens in a workspace. '
+        'Registration tokens are used to install the Alpacon agent on new servers. '
+        'Related: create_registration_token, delete_registration_token, get_registration_guide.'
+    ),
+    annotations=READ_ONLY,
+    meta={'anthropic/searchHint': 'registration token list agent install'},
+)
+async def list_registration_tokens(
+    workspace: str,
+    region: str = '',
+    page: int = 1,
+    page_size: int = 20,
+    **kwargs,
+) -> dict[str, Any]:
+    """List server registration tokens.
+
+    Args:
+        workspace: Workspace name. Required parameter
+        region: Region (ap1, us1, eu1). Auto-detected if not provided
+        page: Page number for pagination (default: 1)
+        page_size: Number of results per page (default: 20)
+
+    Returns:
+        List of registration tokens
+    """
+    token = kwargs.get('token')
+
+    result = await http_client.get(
+        region=region,
+        workspace=workspace,
+        endpoint='/api/servers/registration-tokens/',
+        token=token,
+        params={'page': page, 'page_size': page_size},
+    )
+
+    return success_response(data=result, region=region, workspace=workspace)
+
+
+@mcp_tool_handler(
+    description=(
+        'Create a new server registration token. '
+        'The token is used to authenticate the Alpacon agent during installation on a new server. '
+        'After creating a token, use get_registration_guide to get the installation instructions. '
+        'Related: list_registration_tokens, delete_registration_token, get_registration_guide.'
+    ),
+    annotations=ADDITIVE,
+    meta={'anthropic/searchHint': 'registration token create new agent install'},
+)
+async def create_registration_token(
+    workspace: str,
+    name: str,
+    description: str | None = None,
+    region: str = '',
+    **kwargs,
+) -> dict[str, Any]:
+    """Create a server registration token.
+
+    Args:
+        workspace: Workspace name. Required parameter
+        name: Token name
+        description: Optional token description
+        region: Region (ap1, us1, eu1). Auto-detected if not provided
+
+    Returns:
+        Created registration token data
+    """
+    token = kwargs.get('token')
+
+    data: dict[str, Any] = {'name': name}
+    if description is not None:
+        data['description'] = description
+
+    result = await http_client.post(
+        region=region,
+        workspace=workspace,
+        endpoint='/api/servers/registration-tokens/',
+        token=token,
+        data=data,
+    )
+
+    return success_response(data=result, region=region, workspace=workspace)
+
+
+@mcp_tool_handler(
+    description=(
+        'Delete a server registration token by its ID. '
+        'This invalidates the token and prevents any future agent installations using it. '
+        'Related: list_registration_tokens (find token ID first), create_registration_token.'
+    ),
+    annotations=DESTRUCTIVE,
+    meta={'anthropic/searchHint': 'registration token delete remove invalidate'},
+)
+async def delete_registration_token(
+    token_id: str, workspace: str, region: str = '', **kwargs
+) -> dict[str, Any]:
+    """Delete a server registration token.
+
+    Args:
+        token_id: Registration token UUID
+        workspace: Workspace name. Required parameter
+        region: Region (ap1, us1, eu1). Auto-detected if not provided
+
+    Returns:
+        Deletion confirmation
+    """
+    token = kwargs.get('token')
+
+    result = await http_client.delete(
+        region=region,
+        workspace=workspace,
+        endpoint=f'/api/servers/registration-tokens/{token_id}/',
+        token=token,
+    )
+
+    return success_response(data=result, region=region, workspace=workspace)
+
+
+@mcp_tool_handler(
+    description=(
+        'Get the agent installation guide for a specific platform and registration token. '
+        'Returns shell commands or instructions to install the Alpacon agent on a new server. '
+        'The platform must be one of: "debian", "rhel", "darwin", "windows". '
+        'Related: list_registration_tokens (get token ID), create_registration_token.'
+    ),
+    annotations=ADDITIVE,
+    meta={'anthropic/searchHint': 'registration guide install agent setup script'},
+)
+async def get_registration_guide(
+    workspace: str,
+    platform: str,
+    token_id: str,
+    server_name: str | None = None,
+    region: str = '',
+    **kwargs,
+) -> dict[str, Any]:
+    """Get agent installation guide for a platform and registration token.
+
+    Args:
+        workspace: Workspace name. Required parameter
+        platform: Target platform ("debian" | "rhel" | "darwin" | "windows")
+        token_id: Registration token UUID to embed in the install script
+        server_name: Optional server name to pre-configure during installation
+        region: Region (ap1, us1, eu1). Auto-detected if not provided
+
+    Returns:
+        Installation guide with commands/instructions
+    """
+    token = kwargs.get('token')
+
+    data: dict[str, Any] = {'platform': platform, 'token': token_id}
+    if server_name is not None:
+        data['server_name'] = server_name
+
+    result = await http_client.post(
+        region=region,
+        workspace=workspace,
+        endpoint='/api/servers/registration-methods/token-install/guide/?response_type=json',
+        token=token,
+        data=data,
+    )
+
+    return success_response(data=result, region=region, workspace=workspace)

--- a/tools/server_tools.py
+++ b/tools/server_tools.py
@@ -638,66 +638,6 @@ async def shutdown_system(
 
 @mcp_tool_handler(
     description=(
-        'Create a new server record in a workspace. '
-        f'The platform must be one of: {_PLATFORM_LIST_STR}. '
-        'After creation, use get_registration_guide to get the agent installation instructions. '
-        'Related: list_servers (view after creation), delete_server.'
-    ),
-    annotations=ADDITIVE,
-    meta={'anthropic/searchHint': 'server create add new register'},
-)
-async def create_server(
-    workspace: str,
-    name: str,
-    platform: str,
-    description: str | None = None,
-    region: str = '',
-    **kwargs,
-) -> dict[str, Any]:
-    """Create a new server in the workspace.
-
-    Args:
-        workspace: Workspace name. Required parameter
-        name: Server name
-        platform: Server platform ("debian" | "rhel" | "darwin" | "windows")
-        description: Optional server description
-        region: Region (ap1, us1, eu1). Auto-detected if not provided
-
-    Returns:
-        Created server data
-    """
-    token = kwargs.get('token')
-
-    err = _validate_platform(platform)
-    if err:
-        return err
-
-    data: dict[str, Any] = {'name': name, 'platform': platform}
-    if description is not None:
-        data['description'] = description
-
-    result = await http_client.post(
-        region=region,
-        workspace=workspace,
-        endpoint='/api/servers/servers/',
-        token=token,
-        data=data,
-    )
-
-    err = unwrap_http_result(
-        result,
-        default_message='Failed to create server',
-        region=region,
-        workspace=workspace,
-    )
-    if err:
-        return err
-
-    return success_response(data=result, region=region, workspace=workspace)
-
-
-@mcp_tool_handler(
-    description=(
         'Update an existing server record by its UUID. '
         'Supports partial updates: only fields you provide will be changed. '
         'Related: get_server (view current state), delete_server.'
@@ -845,52 +785,6 @@ async def star_server(
     err = unwrap_http_result(
         result,
         default_message='Failed to update server star status',
-        server_id=server_id,
-        region=region,
-        workspace=workspace,
-    )
-    if err:
-        return err
-
-    return success_response(
-        data=result, server_id=server_id, region=region, workspace=workspace
-    )
-
-
-@mcp_tool_handler(
-    description=(
-        'Get the sync status of a server, showing whether the agent data is up to date with the platform. '
-        'Use this to check if a server is in sync after configuration changes. '
-        'Related: update_information (trigger a resync), get_server.'
-    ),
-    annotations=READ_ONLY,
-    meta={'anthropic/searchHint': 'server sync status check drift'},
-)
-async def get_server_sync(
-    server_id: str, workspace: str, region: str = '', **kwargs
-) -> dict[str, Any]:
-    """Get sync status for a server.
-
-    Args:
-        server_id: Server UUID
-        workspace: Workspace name. Required parameter
-        region: Region (ap1, us1, eu1). Auto-detected if not provided
-
-    Returns:
-        Server sync status
-    """
-    token = kwargs.get('token')
-
-    result = await http_client.get(
-        region=region,
-        workspace=workspace,
-        endpoint=f'/api/servers/servers/{server_id}/sync/',
-        token=token,
-    )
-
-    err = unwrap_http_result(
-        result,
-        default_message='Failed to get server sync status',
         server_id=server_id,
         region=region,
         workspace=workspace,

--- a/tools/server_tools.py
+++ b/tools/server_tools.py
@@ -645,6 +645,26 @@ async def shutdown_system(
 VALID_PLATFORMS = frozenset({'debian', 'rhel', 'darwin', 'windows'})
 
 
+def _validate_platform(platform: str) -> dict[str, Any] | None:
+    if platform not in VALID_PLATFORMS:
+        return format_validation_error(
+            'platform',
+            platform,
+            f'Must be one of: {", ".join(sorted(VALID_PLATFORMS))}',
+        )
+    return None
+
+
+def _validate_token_id(token_id: str) -> dict[str, Any] | None:
+    if not validate_server_id_format(token_id):
+        return format_validation_error(
+            'token_id',
+            token_id,
+            'Must be a valid UUID. Example: 550e8400-e29b-41d4-a716-446655440000',
+        )
+    return None
+
+
 @mcp_tool_handler(
     description=(
         'Create a new server record in a workspace. '
@@ -677,12 +697,9 @@ async def create_server(
     """
     token = kwargs.get('token')
 
-    if platform not in VALID_PLATFORMS:
-        return format_validation_error(
-            'platform',
-            platform,
-            f'Must be one of: {", ".join(sorted(VALID_PLATFORMS))}',
-        )
+    err = _validate_platform(platform)
+    if err:
+        return err
 
     data: dict[str, Any] = {'name': name, 'platform': platform}
     if description is not None:
@@ -1097,12 +1114,9 @@ async def delete_registration_token(
     """
     token = kwargs.get('token')
 
-    if not validate_server_id_format(token_id):
-        return format_validation_error(
-            'token_id',
-            token_id,
-            'Must be a valid UUID. Example: 550e8400-e29b-41d4-a716-446655440000',
-        )
+    err = _validate_token_id(token_id)
+    if err:
+        return err
 
     result = await http_client.delete(
         region=region,
@@ -1155,18 +1169,12 @@ async def get_registration_guide(
     """
     token = kwargs.get('token')
 
-    if not validate_server_id_format(token_id):
-        return format_validation_error(
-            'token_id',
-            token_id,
-            'Must be a valid UUID. Example: 550e8400-e29b-41d4-a716-446655440000',
-        )
-    if platform not in VALID_PLATFORMS:
-        return format_validation_error(
-            'platform',
-            platform,
-            f'Must be one of: {", ".join(sorted(VALID_PLATFORMS))}',
-        )
+    err = _validate_token_id(token_id)
+    if err:
+        return err
+    err = _validate_platform(platform)
+    if err:
+        return err
 
     data: dict[str, Any] = {'platform': platform, 'token': token_id}
     if server_name is not None:

--- a/tools/server_tools.py
+++ b/tools/server_tools.py
@@ -1061,10 +1061,9 @@ async def get_registration_guide(
     result = await http_client.post(
         region=region,
         workspace=workspace,
-        endpoint='/api/servers/registration-methods/token-install/guide/',
+        endpoint='/api/servers/registration-methods/token-install/guide/?response_type=json',
         token=token,
         data=data,
-        params={'response_type': 'json'},
     )
 
     return success_response(data=result, region=region, workspace=workspace)

--- a/tools/server_tools.py
+++ b/tools/server_tools.py
@@ -1151,9 +1151,9 @@ async def delete_registration_token(
     meta={'anthropic/searchHint': 'registration guide install agent setup script'},
 )
 async def get_registration_guide(
+    token_id: str,
     workspace: str,
     platform: str,
-    token_id: str,
     server_name: str | None = None,
     region: str = '',
     **kwargs,
@@ -1161,9 +1161,9 @@ async def get_registration_guide(
     """Get agent installation guide for a platform and registration token.
 
     Args:
+        token_id: Registration token UUID to embed in the install script
         workspace: Workspace name. Required parameter
         platform: Target platform ("debian" | "rhel" | "darwin" | "windows")
-        token_id: Registration token UUID to embed in the install script
         server_name: Optional server name to pre-configure during installation
         region: Region (ap1, us1, eu1). Auto-detected if not provided
 

--- a/tools/server_tools.py
+++ b/tools/server_tools.py
@@ -1128,13 +1128,16 @@ async def delete_registration_token(
     err = unwrap_http_result(
         result,
         default_message='Failed to delete registration token',
+        token_id=token_id,
         region=region,
         workspace=workspace,
     )
     if err:
         return err
 
-    return success_response(data=result, region=region, workspace=workspace)
+    return success_response(
+        data=result, token_id=token_id, region=region, workspace=workspace
+    )
 
 
 @mcp_tool_handler(

--- a/tools/server_tools.py
+++ b/tools/server_tools.py
@@ -868,7 +868,9 @@ async def list_registration_tokens(
         'Related: list_registration_tokens, delete_registration_token, get_registration_guide.'
     ),
     annotations=ADDITIVE,
-    meta={'anthropic/searchHint': 'registration token create mint issue alpamon install new host'},
+    meta={
+        'anthropic/searchHint': 'registration token create mint issue alpamon install new host'
+    },
 )
 async def create_registration_token(
     workspace: str,
@@ -975,7 +977,9 @@ async def delete_registration_token(
         'Related: list_registration_tokens (get token ID), create_registration_token.'
     ),
     annotations=READ_ONLY,
-    meta={'anthropic/searchHint': 'registration guide install script alpamon setup operator'},
+    meta={
+        'anthropic/searchHint': 'registration guide install script alpamon setup operator'
+    },
 )
 async def get_registration_guide(
     token_id: str,

--- a/tools/server_tools.py
+++ b/tools/server_tools.py
@@ -811,25 +811,26 @@ async def delete_server(
 
 @mcp_tool_handler(
     description=(
-        'Toggle the starred/favorite status of a server. '
+        'Set the starred/favorite status of a server. '
         'Starred servers can be quickly accessed in the workspace dashboard. '
         'Related: list_servers, get_server.'
     ),
-    annotations=ADDITIVE,
+    annotations=IDEMPOTENT_WRITE,
     meta={'anthropic/searchHint': 'server star favorite bookmark'},
 )
 async def star_server(
-    server_id: str, workspace: str, region: str = '', **kwargs
+    server_id: str, status: bool, workspace: str, region: str = '', **kwargs
 ) -> dict[str, Any]:
-    """Toggle star status on a server.
+    """Set star status on a server.
 
     Args:
         server_id: Server UUID
+        status: True to star, False to unstar
         workspace: Workspace name. Required parameter
         region: Region (ap1, us1, eu1). Auto-detected if not provided
 
     Returns:
-        Star toggle response
+        Star update response
     """
     token = kwargs.get('token')
 
@@ -838,12 +839,12 @@ async def star_server(
         workspace=workspace,
         endpoint=f'/api/servers/servers/{server_id}/star/',
         token=token,
-        data={},
+        data={'status': status},
     )
 
     err = unwrap_http_result(
         result,
-        default_message='Failed to toggle server star status',
+        default_message='Failed to update server star status',
         server_id=server_id,
         region=region,
         workspace=workspace,

--- a/tools/server_tools.py
+++ b/tools/server_tools.py
@@ -727,6 +727,9 @@ async def update_server(
     if description is not None:
         update_data['description'] = description
 
+    if not update_data:
+        return error_response('No update data provided')
+
     result = await http_client.patch(
         region=region,
         workspace=workspace,
@@ -782,7 +785,7 @@ async def delete_server(
         'Starred servers can be quickly accessed in the workspace dashboard. '
         'Related: list_servers, get_server.'
     ),
-    annotations=IDEMPOTENT_WRITE,
+    annotations=ADDITIVE,
     meta={'anthropic/searchHint': 'server star favorite bookmark'},
 )
 async def star_server(
@@ -1015,7 +1018,7 @@ async def delete_registration_token(
         'The platform must be one of: "debian", "rhel", "darwin", "windows". '
         'Related: list_registration_tokens (get token ID), create_registration_token.'
     ),
-    annotations=ADDITIVE,
+    annotations=READ_ONLY,
     meta={'anthropic/searchHint': 'registration guide install agent setup script'},
 )
 async def get_registration_guide(

--- a/tools/server_tools.py
+++ b/tools/server_tools.py
@@ -1183,9 +1183,10 @@ async def get_registration_guide(
     result = await http_client.post(
         region=region,
         workspace=workspace,
-        endpoint='/api/servers/registration-methods/token-install/guide/?response_type=json',
+        endpoint='/api/servers/registration-methods/token-install/guide/',
         token=token,
         data=data,
+        params={'response_type': 'json'},
     )
 
     err = unwrap_http_result(

--- a/tools/server_tools.py
+++ b/tools/server_tools.py
@@ -708,7 +708,9 @@ async def update_server(
     description=(
         'Unregister a host from this workspace by UUID. The host is removed from '
         'all listings and no new Work Sessions can target it, but the Alpamon agent '
-        'on the host keeps running until uninstalled. Irreversible from this API. '
+        'on the host keeps running until uninstalled. Cannot be undone by this '
+        'tool—re-enrolling the host requires running the install script with a '
+        'registration token again. '
         'Related: list_servers (find UUID), get_server (confirm before unregistering).'
     ),
     annotations=DESTRUCTIVE,

--- a/tools/server_tools.py
+++ b/tools/server_tools.py
@@ -4,7 +4,7 @@ from typing import Any
 
 from utils.common import error_response, success_response, unwrap_http_result
 from utils.decorators import mcp_tool_handler
-from utils.error_handler import format_validation_error
+from utils.error_handler import format_validation_error, validate_server_id_format
 from utils.http_client import http_client
 from utils.tool_annotations import ADDITIVE, DESTRUCTIVE, IDEMPOTENT_WRITE, READ_ONLY
 
@@ -904,8 +904,8 @@ async def get_server_access_policy(
 async def list_registration_tokens(
     workspace: str,
     region: str = '',
-    page: int = 1,
-    page_size: int = 20,
+    page: int | None = None,
+    page_size: int | None = None,
     **kwargs,
 ) -> dict[str, Any]:
     """List server registration tokens.
@@ -913,20 +913,26 @@ async def list_registration_tokens(
     Args:
         workspace: Workspace name. Required parameter
         region: Region (ap1, us1, eu1). Auto-detected if not provided
-        page: Page number for pagination (default: 1)
-        page_size: Number of results per page (default: 20)
+        page: Page number for pagination (optional)
+        page_size: Number of results per page (optional)
 
     Returns:
         List of registration tokens
     """
     token = kwargs.get('token')
 
+    params: dict[str, Any] = {}
+    if page is not None:
+        params['page'] = page
+    if page_size is not None:
+        params['page_size'] = page_size
+
     result = await http_client.get(
         region=region,
         workspace=workspace,
         endpoint='/api/servers/registration-tokens/',
         token=token,
-        params={'page': page, 'page_size': page_size},
+        params=params,
     )
 
     return success_response(data=result, region=region, workspace=workspace)
@@ -1001,6 +1007,11 @@ async def delete_registration_token(
     """
     token = kwargs.get('token')
 
+    if not validate_server_id_format(token_id):
+        return error_response(
+            f"Invalid token_id format: '{token_id}'. Must be a valid UUID."
+        )
+
     result = await http_client.delete(
         region=region,
         workspace=workspace,
@@ -1050,9 +1061,10 @@ async def get_registration_guide(
     result = await http_client.post(
         region=region,
         workspace=workspace,
-        endpoint='/api/servers/registration-methods/token-install/guide/?response_type=json',
+        endpoint='/api/servers/registration-methods/token-install/guide/',
         token=token,
         data=data,
+        params={'response_type': 'json'},
     )
 
     return success_response(data=result, region=region, workspace=workspace)

--- a/tools/server_tools.py
+++ b/tools/server_tools.py
@@ -642,6 +642,8 @@ async def shutdown_system(
 # SERVER CRUD TOOLS
 # ===============================
 
+VALID_PLATFORMS = frozenset({'debian', 'rhel', 'darwin', 'windows'})
+
 
 @mcp_tool_handler(
     description=(
@@ -675,6 +677,13 @@ async def create_server(
     """
     token = kwargs.get('token')
 
+    if platform not in VALID_PLATFORMS:
+        return format_validation_error(
+            'platform',
+            platform,
+            f'Must be one of: {", ".join(sorted(VALID_PLATFORMS))}',
+        )
+
     data: dict[str, Any] = {'name': name, 'platform': platform}
     if description is not None:
         data['description'] = description
@@ -686,6 +695,15 @@ async def create_server(
         token=token,
         data=data,
     )
+
+    err = unwrap_http_result(
+        result,
+        default_message='Failed to create server',
+        region=region,
+        workspace=workspace,
+    )
+    if err:
+        return err
 
     return success_response(data=result, region=region, workspace=workspace)
 
@@ -728,7 +746,11 @@ async def update_server(
         update_data['description'] = description
 
     if not update_data:
-        return error_response('No update data provided')
+        return format_validation_error(
+            'name or description',
+            None,
+            'At least one of name or description must be provided.',
+        )
 
     result = await http_client.patch(
         region=region,
@@ -737,6 +759,16 @@ async def update_server(
         token=token,
         data=update_data,
     )
+
+    err = unwrap_http_result(
+        result,
+        default_message='Failed to update server',
+        server_id=server_id,
+        region=region,
+        workspace=workspace,
+    )
+    if err:
+        return err
 
     return success_response(
         data=result, server_id=server_id, region=region, workspace=workspace
@@ -773,6 +805,16 @@ async def delete_server(
         endpoint=f'/api/servers/servers/{server_id}/',
         token=token,
     )
+
+    err = unwrap_http_result(
+        result,
+        default_message='Failed to delete server',
+        server_id=server_id,
+        region=region,
+        workspace=workspace,
+    )
+    if err:
+        return err
 
     return success_response(
         data=result, server_id=server_id, region=region, workspace=workspace
@@ -811,6 +853,16 @@ async def star_server(
         data={},
     )
 
+    err = unwrap_http_result(
+        result,
+        default_message='Failed to toggle server star status',
+        server_id=server_id,
+        region=region,
+        workspace=workspace,
+    )
+    if err:
+        return err
+
     return success_response(
         data=result, server_id=server_id, region=region, workspace=workspace
     )
@@ -847,6 +899,16 @@ async def get_server_sync(
         token=token,
     )
 
+    err = unwrap_http_result(
+        result,
+        default_message='Failed to get server sync status',
+        server_id=server_id,
+        region=region,
+        workspace=workspace,
+    )
+    if err:
+        return err
+
     return success_response(
         data=result, server_id=server_id, region=region, workspace=workspace
     )
@@ -881,6 +943,16 @@ async def get_server_access_policy(
         endpoint=f'/api/servers/servers/{server_id}/access-policy/',
         token=token,
     )
+
+    err = unwrap_http_result(
+        result,
+        default_message='Failed to get server access policy',
+        server_id=server_id,
+        region=region,
+        workspace=workspace,
+    )
+    if err:
+        return err
 
     return success_response(
         data=result, server_id=server_id, region=region, workspace=workspace
@@ -935,6 +1007,15 @@ async def list_registration_tokens(
         params=params,
     )
 
+    err = unwrap_http_result(
+        result,
+        default_message='Failed to list registration tokens',
+        region=region,
+        workspace=workspace,
+    )
+    if err:
+        return err
+
     return success_response(data=result, region=region, workspace=workspace)
 
 
@@ -980,6 +1061,15 @@ async def create_registration_token(
         data=data,
     )
 
+    err = unwrap_http_result(
+        result,
+        default_message='Failed to create registration token',
+        region=region,
+        workspace=workspace,
+    )
+    if err:
+        return err
+
     return success_response(data=result, region=region, workspace=workspace)
 
 
@@ -1008,8 +1098,10 @@ async def delete_registration_token(
     token = kwargs.get('token')
 
     if not validate_server_id_format(token_id):
-        return error_response(
-            f"Invalid token_id format: '{token_id}'. Must be a valid UUID."
+        return format_validation_error(
+            'token_id',
+            token_id,
+            'Must be a valid UUID. Example: 550e8400-e29b-41d4-a716-446655440000',
         )
 
     result = await http_client.delete(
@@ -1018,6 +1110,15 @@ async def delete_registration_token(
         endpoint=f'/api/servers/registration-tokens/{token_id}/',
         token=token,
     )
+
+    err = unwrap_http_result(
+        result,
+        default_message='Failed to delete registration token',
+        region=region,
+        workspace=workspace,
+    )
+    if err:
+        return err
 
     return success_response(data=result, region=region, workspace=workspace)
 
@@ -1054,6 +1155,19 @@ async def get_registration_guide(
     """
     token = kwargs.get('token')
 
+    if not validate_server_id_format(token_id):
+        return format_validation_error(
+            'token_id',
+            token_id,
+            'Must be a valid UUID. Example: 550e8400-e29b-41d4-a716-446655440000',
+        )
+    if platform not in VALID_PLATFORMS:
+        return format_validation_error(
+            'platform',
+            platform,
+            f'Must be one of: {", ".join(sorted(VALID_PLATFORMS))}',
+        )
+
     data: dict[str, Any] = {'platform': platform, 'token': token_id}
     if server_name is not None:
         data['server_name'] = server_name
@@ -1065,5 +1179,14 @@ async def get_registration_guide(
         token=token,
         data=data,
     )
+
+    err = unwrap_http_result(
+        result,
+        default_message='Failed to get registration guide',
+        region=region,
+        workspace=workspace,
+    )
+    if err:
+        return err
 
     return success_response(data=result, region=region, workspace=workspace)

--- a/utils/http_client.py
+++ b/utils/http_client.py
@@ -556,6 +556,7 @@ class AlpaconHTTPClient:
         endpoint: str,
         token: str | None = None,
         data: dict[str, Any] | None = None,
+        params: dict[str, Any] | None = None,
     ) -> dict[str, Any]:
         """Execute POST request.
 
@@ -565,6 +566,7 @@ class AlpaconHTTPClient:
             endpoint: API endpoint path
             token: API token
             data: Request body data
+            params: Query parameters
 
         Returns:
             Response data
@@ -573,7 +575,7 @@ class AlpaconHTTPClient:
         full_url = urljoin(base_url, endpoint)
 
         return await self.request(
-            method='POST', url=full_url, token=token, json_data=data
+            method='POST', url=full_url, token=token, json_data=data, params=params
         )
 
     async def put(

--- a/utils/http_client.py
+++ b/utils/http_client.py
@@ -486,6 +486,7 @@ class AlpaconHTTPClient:
                     endpoint=req['endpoint'],
                     token=req['token'],
                     data=req.get('data'),
+                    params=req.get('params'),
                 )
             else:
                 # For other methods, use the generic request method


### PR DESCRIPTION
## Summary

Adds 7 new server-management MCP tools to `tools/server_tools.py` (live-verified against `dev/alpacax`):

**Server lifecycle**
- `update_server`, `unregister_server`, `star_server`

**Registration tokens**
- `list_registration_tokens`, `create_registration_token`, `delete_registration_token`, `get_registration_guide`

`star_server` annotation is `IDEMPOTENT_WRITE` and its payload uses the `status: bool` field expected by `ServerStarStatusSerializer` on the server side. `update_server` returns an early validation error when called with no fields. `get_registration_guide` and `delete_registration_token` reject non-UUID `token_id` before the API call.

## Breaking change

`delete_server` was renamed to `unregister_server` to match the product UI (the alpacon-web confirmation dialog reads *"Unregister server"*) and the actual semantics — the host is removed from the workspace registry but its Alpamon agent keeps running until uninstalled. Any external MCP client referencing `mcp_alpacon_delete_server` must update to `mcp_alpacon_unregister_server`.

## Description rewrites

Tool descriptions for the 7 new tools were tightened toward the codebase median (~40 words) and aligned with the alpacon-handbook vocabulary canon (`Alpamon`, `Work Session`, `control plane`, `principal`). Each description now:
- Uses semantically accurate verbs (`Unregister`, `Pin`, `Mint`, `Revoke`) instead of generic `delete/set/create` framings
- Disclaims non-obvious caveats inline (e.g., `unregister_server` notes that the agent keeps running; `star_server` notes it does not change RBAC/ACLs)
- Anchors registration-token tools on Alpamon install rather than generic "onboarding"

## Removed during review

After cross-checking with `alpacon-server`:

- `create_server` — `POST /api/servers/servers/` returns HTTP 500 against `dev` with the documented payload. Not shippable until the server-side bug is resolved.
- `get_server_sync` — `/sync/` action is gated by `IsAPIClient()` (`servers/api/views.py:177-190`); it is reachable only from alpamon agent tokens, not from user API tokens issued via MCP.
- `get_server_access_policy` — same `IsAPIClient()` gating; `AccessPolicySerializer` (`servers/api/serializers.py:886`) is designed for alpamon to read its workspace `block_local_sudo` policy, not for end-user consumption.

## Live verification (dev/alpacax)

| Tool | Result |
| --- | --- |
| `list_registration_tokens` | 200 — 11 tokens (`test-ansible-cjs` present) |
| `get_registration_guide(token=test-ansible-cjs, platform=debian)` | 200 — `method_id=token-install`, install URL returned |
| `create_registration_token(name=mcp-smoke-temp)` | 200 — token id `1c6e9ea5-…` issued |
| `delete_registration_token(<new id>)` | 204 |
| `star_server(status=False)` then `(status=True)` | 200 / 200 |
| `update_server(description=…)` | 200 — change reflected on live server |
| `unregister_server(windows-test-f1aaea)` | 204 — server count 17 → 16, name no longer present |

## Test plan

- [x] `uv run --extra dev pytest tests/test_server_tools.py` — 44 passed
- [x] Validation errors (bad platform / non-UUID `server_id` / non-UUID `token_id` / unsupported region / malformed workspace) reject before any HTTP call
- [x] `update_server` empty payload guard returns validation error
- [x] `list_registration_tokens` omits pagination params when not provided
- [x] `get_registration_guide` passes `response_type=json` via `params=`, not via endpoint string

Closes #76