### PR TITLE
ci: upgrade Docker GitHub Actions to Node.js 24-compatible versions

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -26,7 +26,7 @@ jobs:
           ref: ${{ github.event.workflow_run.head_sha || github.ref }}
 
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v3
+        uses: docker/setup-buildx-action@v4
 
       - name: Log in to Docker Hub
         uses: alpacax/shared-ci/common/dockerhub-login@v1
@@ -35,7 +35,7 @@ jobs:
 
       - name: Extract metadata (tags, labels)
         id: meta
-        uses: docker/metadata-action@v5
+        uses: docker/metadata-action@v6
         with:
           images: ${{ github.event_name == 'workflow_run' && format('{0}-dev', vars.DOCKER_IMAGE) || vars.DOCKER_IMAGE }}
           tags: |
@@ -44,7 +44,7 @@ jobs:
             type=raw,value=latest,enable=${{ github.event_name == 'push' }}
 
       - name: Build and push
-        uses: docker/build-push-action@v5
+        uses: docker/build-push-action@v6
         with:
           context: .
           push: true


### PR DESCRIPTION
## Summary

Upgrades Docker GitHub Actions in the `build-and-push` workflow to versions that support Node.js 24. Node.js 20 actions will be force-upgraded by GitHub runners starting June 2026 and removed in September 2026. No migration changes were required for the existing workflow inputs.

## Changes

- `docker/setup-buildx-action`: v3 → v4
- `docker/metadata-action`: v5 → v6
- `docker/build-push-action`: v5 → v6

## Notes

- `build-push-action@v6` enables build summaries in the Actions job summary UI by default (additive, no breakage)
- All existing inputs (`context`, `push`, `platforms`, `tags`, `labels`, `cache-from`, `cache-to`) remain valid in the new versions
- GitHub-hosted runners satisfy the Node.js 24 runner requirement (v2.327.1+) automatically

## Checklist

### Universal
- [x] Self-reviewed the code
- [x] No hardcoded secrets or credentials