### PR TITLE
ci: upgrade all GitHub Actions to Node.js 24-compatible versions

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -21,7 +21,7 @@ jobs:
       (github.event_name == 'workflow_run' && github.event.workflow_run.conclusion == 'success')
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
         with:
           ref: ${{ github.event.workflow_run.head_sha || github.ref }}
 
@@ -61,7 +61,7 @@ jobs:
     environment: dev
     steps:
       - name: Trigger dev deployment
-        uses: benc-uk/workflow-dispatch@v1
+        uses: benc-uk/workflow-dispatch@v1.3.1
         with:
           workflow: image-tag-update-pr.yaml
           repo: alpacax/alpacon-gitops
@@ -76,7 +76,7 @@ jobs:
     environment: prod
     steps:
       - name: Trigger prod deployment
-        uses: benc-uk/workflow-dispatch@v1
+        uses: benc-uk/workflow-dispatch@v1.3.1
         with:
           workflow: image-tag-update-pr.yaml
           repo: alpacax/alpacon-gitops

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -9,10 +9,10 @@ jobs:
   build:
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@v6
 
     - name: Set up Python
-      uses: actions/setup-python@v4
+      uses: actions/setup-python@v6
       with:
         python-version: "3.12"
 
@@ -28,7 +28,7 @@ jobs:
       run: twine check dist/*
 
     - name: Upload build artifacts
-      uses: actions/upload-artifact@v4
+      uses: actions/upload-artifact@v6
       with:
         name: dist
         path: dist/
@@ -41,7 +41,7 @@ jobs:
       id-token: write  # REQUIRED for trusted publishing
     steps:
     - name: Download build artifacts
-      uses: actions/download-artifact@v4
+      uses: actions/download-artifact@v7
       with:
         name: dist
         path: dist/

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -22,16 +22,16 @@ jobs:
       UV_PYTHON: python${{ matrix.python-version }}
 
     steps:
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@v6
 
     - name: Set up Python ${{ matrix.python-version }}
-      uses: actions/setup-python@v5
+      uses: actions/setup-python@v6
       with:
         python-version: ${{ matrix.python-version }}
         allow-prereleases: true
 
     - name: Install uv
-      uses: astral-sh/setup-uv@v3
+      uses: astral-sh/setup-uv@v8.1.0
 
     - name: Create virtual environment
       run: uv venv


### PR DESCRIPTION
## Summary

Complete the Node.js 20 → 24 migration for all GitHub Actions across the repository. The previous PR upgraded Docker-specific actions; this PR covers the remaining actions that were missed.

## Changes

**docker.yml** (missed in previous PR)
- `actions/checkout` v4 → v6
- `benc-uk/workflow-dispatch` v1 → v1.3.1

**publish.yml** (missed in previous PR)
- `actions/checkout` v4 → v6
- `actions/setup-python` v4 → v6
- `actions/upload-artifact` v4 → v6
- `actions/download-artifact` v4 → v7

**test.yml** (missed in previous PR)
- `actions/checkout` v4 → v6
- `actions/setup-python` v5 → v6
- `astral-sh/setup-uv` v3 → v8.1.0

Note: `pypa/gh-action-pypi-publish@release/v1` uses a composite action and has no Node.js runtime dependency — no change needed.

## Background

GitHub Actions will drop Node.js 20 support on June 2, 2026 and enforce Node.js 24 as the minimum runtime. All upgraded versions have been verified to use `node24` runtime via their `action.yml`.

## Test plan

- [ ] Test workflow runs successfully on push/PR
- [ ] Publish workflow triggers correctly on release events
- [ ] Docker workflow triggers after Test workflow completes