### PR TITLE
simplify: remove unused websockets dependency

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -42,7 +42,6 @@ classifiers = [
 dependencies = [
     "mcp[cli]>=1.9.4",
     "httpx>=0.25.0",
-    "websockets>=15.0.1",
     "PyJWT[crypto]>=2.8.0",
 ]
 

--- a/tests/test_webftp_tools.py
+++ b/tests/test_webftp_tools.py
@@ -1101,6 +1101,92 @@ class TestWebFtpBulkDownload:
         assert 'processing in progress' in result['message']
 
 
+class TestRemoteModeUnsupported:
+    """Test that file-transfer tools return a clear error in remote mode."""
+
+    SERVER_ID = '550e8400-e29b-41d4-a716-446655440001'
+
+    @pytest.mark.asyncio
+    async def test_upload_file_remote_mode(self, mock_http_client, mock_token_manager):
+        """webftp_upload_file returns remote_mode_unsupported error in remote mode.
+
+        The decorator's auth check is bypassed (auth disabled) so the function
+        body's _is_remote_mode check is what we're exercising here.
+        """
+        with (
+            patch('utils.decorators._is_auth_enabled', return_value=False),
+            patch('tools.webftp_tools._is_remote_mode', return_value=True),
+        ):
+            result = await webftp_upload_file(
+                server_id=self.SERVER_ID,
+                local_file_path='/local/test.txt',
+                remote_file_path='/remote/test.txt',
+                workspace='ws',
+                region='ap1',
+            )
+        assert result['status'] == 'error'
+        assert 'remote mode' in result['message']
+        assert result.get('code') == 'remote_mode_unsupported'
+        mock_http_client.post.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_download_file_remote_mode(self, mock_http_client, mock_token_manager):
+        """webftp_download_file returns remote_mode_unsupported error in remote mode."""
+        with (
+            patch('utils.decorators._is_auth_enabled', return_value=False),
+            patch('tools.webftp_tools._is_remote_mode', return_value=True),
+        ):
+            result = await webftp_download_file(
+                server_id=self.SERVER_ID,
+                remote_file_path='/remote/test.txt',
+                local_file_path='/local/test.txt',
+                workspace='ws',
+                region='ap1',
+            )
+        assert result['status'] == 'error'
+        assert 'remote mode' in result['message']
+        assert result.get('code') == 'remote_mode_unsupported'
+        mock_http_client.post.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_bulk_upload_remote_mode(self, mock_http_client, mock_token_manager):
+        """webftp_bulk_upload returns remote_mode_unsupported error in remote mode."""
+        with (
+            patch('utils.decorators._is_auth_enabled', return_value=False),
+            patch('tools.webftp_tools._is_remote_mode', return_value=True),
+        ):
+            result = await webftp_bulk_upload(
+                server_id=self.SERVER_ID,
+                local_file_paths=['/local/a.txt', '/local/b.txt'],
+                remote_directory='/remote/',
+                workspace='ws',
+                region='ap1',
+            )
+        assert result['status'] == 'error'
+        assert 'remote mode' in result['message']
+        assert result.get('code') == 'remote_mode_unsupported'
+        mock_http_client.post.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_bulk_download_remote_mode(self, mock_http_client, mock_token_manager):
+        """webftp_bulk_download returns remote_mode_unsupported error in remote mode."""
+        with (
+            patch('utils.decorators._is_auth_enabled', return_value=False),
+            patch('tools.webftp_tools._is_remote_mode', return_value=True),
+        ):
+            result = await webftp_bulk_download(
+                server_id=self.SERVER_ID,
+                remote_paths=['/remote/a.txt'],
+                local_file_path='/local/out.zip',
+                workspace='ws',
+                region='ap1',
+            )
+        assert result['status'] == 'error'
+        assert 'remote mode' in result['message']
+        assert result.get('code') == 'remote_mode_unsupported'
+        mock_http_client.post.assert_not_called()
+
+
 class TestAiterFile:
     """Test the _aiter_file streaming-upload helper."""
 

--- a/tests/test_webftp_tools.py
+++ b/tests/test_webftp_tools.py
@@ -1200,24 +1200,6 @@ class TestRemoteModeUnsupported:
         mock_http_client.post.assert_not_called()
 
     @pytest.mark.asyncio
-    async def test_download_file_remote_mode(
-        self, mock_http_client, mock_token_manager
-    ):
-        """webftp_download_file returns remote_mode_unsupported error in remote mode."""
-        with patch('tools.webftp_tools._is_auth_enabled', return_value=True):
-            result = await webftp_download_file(
-                server_id=self.SERVER_ID,
-                remote_file_path='/remote/test.txt',
-                local_file_path='/local/test.txt',
-                workspace='ws',
-                region='ap1',
-            )
-        assert result['status'] == 'error'
-        assert 'remote mode' in result['message']
-        assert result.get('code') == 'remote_mode_unsupported'
-        mock_http_client.post.assert_not_called()
-
-    @pytest.mark.asyncio
     async def test_bulk_upload_remote_mode(self, mock_http_client, mock_token_manager):
         """webftp_bulk_upload returns remote_mode_unsupported error in remote mode."""
         with patch('tools.webftp_tools._is_auth_enabled', return_value=True):
@@ -1250,6 +1232,110 @@ class TestRemoteModeUnsupported:
         assert 'remote mode' in result['message']
         assert result.get('code') == 'remote_mode_unsupported'
         mock_http_client.post.assert_not_called()
+
+
+class TestRemoteModeDownload:
+    """Test webftp_download_file remote mode — returns presigned URL instead of saving locally."""
+
+    SERVER_ID = '550e8400-e29b-41d4-a716-446655440001'
+
+    @pytest.mark.asyncio
+    async def test_download_remote_mode_immediate_url(
+        self, mock_http_client, mock_token_manager
+    ):
+        """When POST response already contains download_url, return it immediately."""
+        mock_http_client.post.return_value = {
+            'id': 'dl-abc',
+            'download_url': 'https://s3.example.com/file?sig=abc',
+        }
+
+        with patch('tools.webftp_tools._is_auth_enabled', return_value=True):
+            result = await webftp_download_file(
+                server_id=self.SERVER_ID,
+                remote_file_path='/remote/file.txt',
+                workspace='ws',
+                region='ap1',
+            )
+
+        assert result['status'] == 'success'
+        assert result['download_url'] == 'https://s3.example.com/file?sig=abc'
+        mock_http_client.post.assert_called_once()
+        mock_http_client.get.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_download_remote_mode_polling(
+        self, mock_http_client, mock_token_manager
+    ):
+        """When download_url is absent, poll status until success=True then return URL."""
+        mock_http_client.post.return_value = {'id': 'dl-abc', 'download_url': None}
+        mock_http_client.get.side_effect = [
+            {'success': None},
+            {'success': True, 'download_url': 'https://s3.example.com/file?sig=abc'},
+        ]
+
+        with (
+            patch('tools.webftp_tools._is_auth_enabled', return_value=True),
+            patch('asyncio.sleep', new_callable=AsyncMock),
+        ):
+            result = await webftp_download_file(
+                server_id=self.SERVER_ID,
+                remote_file_path='/remote/file.txt',
+                workspace='ws',
+                region='ap1',
+            )
+
+        assert result['status'] == 'success'
+        assert result['download_url'] == 'https://s3.example.com/file?sig=abc'
+        assert mock_http_client.get.call_count == 2
+
+    @pytest.mark.asyncio
+    async def test_download_remote_mode_timeout(
+        self, mock_http_client, mock_token_manager
+    ):
+        """Polling that exceeds _REMOTE_DOWNLOAD_TIMEOUT returns download_timeout error."""
+        mock_http_client.post.return_value = {'id': 'dl-abc', 'download_url': None}
+        mock_http_client.get.return_value = {'success': None}
+
+        with (
+            patch('tools.webftp_tools._is_auth_enabled', return_value=True),
+            patch('asyncio.sleep', new_callable=AsyncMock),
+            patch('tools.webftp_tools._REMOTE_DOWNLOAD_TIMEOUT', 2),
+        ):
+            result = await webftp_download_file(
+                server_id=self.SERVER_ID,
+                remote_file_path='/remote/file.txt',
+                workspace='ws',
+                region='ap1',
+            )
+
+        assert result['status'] == 'error'
+        assert result.get('code') == 'download_timeout'
+        assert result.get('file_id') == 'dl-abc'
+
+    @pytest.mark.asyncio
+    async def test_download_remote_mode_server_failure(
+        self, mock_http_client, mock_token_manager
+    ):
+        """When server reports success=False, return error with the server message."""
+        mock_http_client.post.return_value = {'id': 'dl-abc', 'download_url': None}
+        mock_http_client.get.return_value = {
+            'success': False,
+            'message': 'file not found on server',
+        }
+
+        with (
+            patch('tools.webftp_tools._is_auth_enabled', return_value=True),
+            patch('asyncio.sleep', new_callable=AsyncMock),
+        ):
+            result = await webftp_download_file(
+                server_id=self.SERVER_ID,
+                remote_file_path='/remote/file.txt',
+                workspace='ws',
+                region='ap1',
+            )
+
+        assert result['status'] == 'error'
+        assert 'file not found' in result['message']
 
 
 class TestAiterFile:

--- a/tests/test_webftp_tools.py
+++ b/tests/test_webftp_tools.py
@@ -1113,10 +1113,7 @@ class TestRemoteModeUnsupported:
         The decorator's auth check is bypassed (auth disabled) so the function
         body's _is_remote_mode check is what we're exercising here.
         """
-        with (
-            patch('utils.decorators._is_auth_enabled', return_value=False),
-            patch('tools.webftp_tools._is_remote_mode', return_value=True),
-        ):
+        with patch('tools.webftp_tools._is_auth_enabled', return_value=True):
             result = await webftp_upload_file(
                 server_id=self.SERVER_ID,
                 local_file_path='/local/test.txt',
@@ -1132,10 +1129,7 @@ class TestRemoteModeUnsupported:
     @pytest.mark.asyncio
     async def test_download_file_remote_mode(self, mock_http_client, mock_token_manager):
         """webftp_download_file returns remote_mode_unsupported error in remote mode."""
-        with (
-            patch('utils.decorators._is_auth_enabled', return_value=False),
-            patch('tools.webftp_tools._is_remote_mode', return_value=True),
-        ):
+        with patch('tools.webftp_tools._is_auth_enabled', return_value=True):
             result = await webftp_download_file(
                 server_id=self.SERVER_ID,
                 remote_file_path='/remote/test.txt',
@@ -1151,10 +1145,7 @@ class TestRemoteModeUnsupported:
     @pytest.mark.asyncio
     async def test_bulk_upload_remote_mode(self, mock_http_client, mock_token_manager):
         """webftp_bulk_upload returns remote_mode_unsupported error in remote mode."""
-        with (
-            patch('utils.decorators._is_auth_enabled', return_value=False),
-            patch('tools.webftp_tools._is_remote_mode', return_value=True),
-        ):
+        with patch('tools.webftp_tools._is_auth_enabled', return_value=True):
             result = await webftp_bulk_upload(
                 server_id=self.SERVER_ID,
                 local_file_paths=['/local/a.txt', '/local/b.txt'],
@@ -1170,10 +1161,7 @@ class TestRemoteModeUnsupported:
     @pytest.mark.asyncio
     async def test_bulk_download_remote_mode(self, mock_http_client, mock_token_manager):
         """webftp_bulk_download returns remote_mode_unsupported error in remote mode."""
-        with (
-            patch('utils.decorators._is_auth_enabled', return_value=False),
-            patch('tools.webftp_tools._is_remote_mode', return_value=True),
-        ):
+        with patch('tools.webftp_tools._is_auth_enabled', return_value=True):
             result = await webftp_bulk_download(
                 server_id=self.SERVER_ID,
                 remote_paths=['/remote/a.txt'],

--- a/tests/test_webftp_tools.py
+++ b/tests/test_webftp_tools.py
@@ -5,6 +5,7 @@ Tests WebFTP functionality including session management, file uploads,
 file downloads, and file transfer history.
 """
 
+import base64
 from pathlib import Path
 from unittest.mock import AsyncMock, MagicMock, patch
 
@@ -23,6 +24,7 @@ from tools.webftp_tools import (
     webftp_downloads_list,
     webftp_session_create,
     webftp_sessions_list,
+    webftp_upload_content,
     webftp_upload_file,
     webftp_uploads_list,
 )
@@ -1101,6 +1103,77 @@ class TestWebFtpBulkDownload:
         assert 'processing in progress' in result['message']
 
 
+class TestUploadContent:
+    """Test webftp_upload_content — content-based upload for remote and local modes."""
+
+    SERVER_ID = '550e8400-e29b-41d4-a716-446655440001'
+
+    @pytest.mark.asyncio
+    async def test_upload_content_success(
+        self, mock_http_client, mock_token_manager, mock_httpx
+    ):
+        """Happy path: base64 content is decoded, PUT to S3, server is triggered."""
+        file_bytes = b'hello remote world'
+        encoded = base64.b64encode(file_bytes).decode()
+
+        mock_http_client.post.return_value = {
+            'id': 'upload-abc',
+            'upload_url': 'https://s3.example.com/put?sig=abc',
+            'download_url': 'https://s3.example.com/get?sig=abc',
+        }
+        mock_http_client.get.return_value = {}
+
+        put_resp = AsyncMock()
+        put_resp.status_code = 200
+        mock_httpx.put.return_value = put_resp
+
+        result = await webftp_upload_content(
+            server_id=self.SERVER_ID,
+            file_content=encoded,
+            remote_file_path='/remote/hello.txt',
+            workspace='ws',
+            region='ap1',
+        )
+
+        assert result['status'] == 'success'
+        assert result['file_size'] == len(file_bytes)
+        mock_http_client.post.assert_called_once()
+        mock_httpx.put.assert_called_once()
+
+    @pytest.mark.asyncio
+    async def test_upload_content_invalid_base64(
+        self, mock_http_client, mock_token_manager
+    ):
+        """Invalid base64 input returns error with code='invalid_content' before any API call."""
+        result = await webftp_upload_content(
+            server_id=self.SERVER_ID,
+            file_content='not-valid-base64!!!',
+            remote_file_path='/remote/test.txt',
+            workspace='ws',
+            region='ap1',
+        )
+
+        assert result['status'] == 'error'
+        assert result.get('code') == 'invalid_content'
+        mock_http_client.post.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_upload_content_invalid_path(
+        self, mock_http_client, mock_token_manager
+    ):
+        """Path traversal in remote_file_path returns validation error before any API call."""
+        result = await webftp_upload_content(
+            server_id=self.SERVER_ID,
+            file_content=base64.b64encode(b'data').decode(),
+            remote_file_path='../etc/passwd',
+            workspace='ws',
+            region='ap1',
+        )
+
+        assert result['status'] == 'error'
+        mock_http_client.post.assert_not_called()
+
+
 class TestRemoteModeUnsupported:
     """Test that file-transfer tools return a clear error in remote mode."""
 
@@ -1127,7 +1200,9 @@ class TestRemoteModeUnsupported:
         mock_http_client.post.assert_not_called()
 
     @pytest.mark.asyncio
-    async def test_download_file_remote_mode(self, mock_http_client, mock_token_manager):
+    async def test_download_file_remote_mode(
+        self, mock_http_client, mock_token_manager
+    ):
         """webftp_download_file returns remote_mode_unsupported error in remote mode."""
         with patch('tools.webftp_tools._is_auth_enabled', return_value=True):
             result = await webftp_download_file(
@@ -1159,7 +1234,9 @@ class TestRemoteModeUnsupported:
         mock_http_client.post.assert_not_called()
 
     @pytest.mark.asyncio
-    async def test_bulk_download_remote_mode(self, mock_http_client, mock_token_manager):
+    async def test_bulk_download_remote_mode(
+        self, mock_http_client, mock_token_manager
+    ):
         """webftp_bulk_download returns remote_mode_unsupported error in remote mode."""
         with patch('tools.webftp_tools._is_auth_enabled', return_value=True):
             result = await webftp_bulk_download(

--- a/tools/webftp_tools.py
+++ b/tools/webftp_tools.py
@@ -37,6 +37,7 @@ _API_DOWNLOAD_STATUS = _API_DOWNLOADS + '{}/status/'
 _CHUNK_SIZE = 65536
 _UPLOAD_CONCURRENCY = 10
 _BULK_DOWNLOAD_TIMEOUT = 60.0
+_REMOTE_DOWNLOAD_TIMEOUT = 60
 _S3_SUCCESS_CODES = (HTTPStatus.OK, HTTPStatus.CREATED)
 
 # Result statuses
@@ -136,6 +137,83 @@ async def _upload_bytes_to_s3(upload_url: str, data: bytes) -> str | None:
     if resp.status_code not in _S3_SUCCESS_CODES:
         return f'Failed to upload to S3: {resp.status_code} - {resp.text}'
     return None
+
+
+async def _download_remote_mode(
+    *,
+    server_id: str,
+    remote_file_path: str,
+    resource_type: str,
+    workspace: str,
+    region: str,
+    username: str | None,
+    token: str,
+) -> dict[str, Any]:
+    """Handle webftp_download_file in remote mode: poll until ready, return presigned URL."""
+    file_name = os.path.basename(remote_file_path)
+    if resource_type == 'folder':
+        file_name += '.zip'
+
+    download_data: dict[str, Any] = {
+        'server': server_id,
+        'path': remote_file_path,
+        'name': file_name,
+        'resource_type': resource_type,
+    }
+    if username:
+        download_data['username'] = username
+
+    result = await http_client.post(
+        region=region,
+        workspace=workspace,
+        endpoint=_API_DOWNLOADS,
+        token=token,
+        data=download_data,
+    )
+
+    file_id = result.get('id')
+    download_url = result.get('download_url')
+
+    if not download_url:
+        elapsed = 0
+        while elapsed < _REMOTE_DOWNLOAD_TIMEOUT:
+            await asyncio.sleep(1)
+            elapsed += 1
+            status = await http_client.get(
+                region=region,
+                workspace=workspace,
+                endpoint=_API_DOWNLOAD_STATUS.format(file_id),
+                token=token,
+            )
+            if status.get('success') is True:
+                download_url = status.get('download_url')
+                break
+            elif status.get('success') is False:
+                return error_response(
+                    f'Server failed to process download: {status.get("message", "unknown error")}',
+                    file_id=file_id,
+                )
+        else:
+            return error_response(
+                f'Download timed out waiting for server. '
+                f'Use webftp_check_status("{file_id}", "download") to poll manually.',
+                file_id=file_id,
+                code='download_timeout',
+            )
+
+    display_name = os.path.basename(remote_file_path)
+    return success_response(
+        message=f'File ready for download: {display_name}',
+        data=result,
+        server_id=server_id,
+        remote_file_path=remote_file_path,
+        resource_type=resource_type,
+        download_url=download_url,
+        expires_in='24 hours',
+        tip=f"curl -o '{display_name}' '{download_url}'",
+        region=region,
+        workspace=workspace,
+    )
 
 
 @mcp_tool_handler(
@@ -447,15 +525,26 @@ async def webftp_upload_content(
 
 
 @mcp_tool_handler(
-    description='Download a file or folder from a remote server and save it to a local path. For folders, the content is automatically packaged as a ZIP archive. When to use: retrieving a single file or folder from a server. Related: webftp_bulk_download (multiple files as ZIP), webftp_upload_file (upload to server), webftp_downloads_list (check download history). Note: Set resource_type="folder" for directories.',
+    description=(
+        'Download a file or folder from a remote server. '
+        'In local mode: saves to local_file_path. '
+        'In remote mode (streamable-http): polls until the file is ready on S3, '
+        'then returns a presigned download URL valid for 24 hours — '
+        'open it in a browser or run the curl command in the response. '
+        'For folders, content is packaged as a ZIP archive. '
+        'Related: webftp_bulk_download (multiple files as ZIP), '
+        'webftp_upload_file (upload to server), '
+        'webftp_downloads_list (check download history). '
+        'Note: Set resource_type="folder" for directories.'
+    ),
     annotations=ADDITIVE,
     meta={'anthropic/searchHint': 'file download transfer get retrieve server'},
 )
 async def webftp_download_file(
     server_id: str,
     remote_file_path: str,
-    local_file_path: str,
     workspace: str,
+    local_file_path: str | None = None,
     resource_type: str = 'file',
     username: str | None = None,
     region: str = '',
@@ -482,11 +571,23 @@ async def webftp_download_file(
     token = kwargs.get('token')
 
     if _is_auth_enabled():
-        return error_response(_REMOTE_MODE_ERROR, code='remote_mode_unsupported')
+        if not validate_file_path(remote_file_path):
+            return format_validation_error('remote_file_path', remote_file_path)
+        return await _download_remote_mode(
+            server_id=server_id,
+            remote_file_path=remote_file_path,
+            resource_type=resource_type,
+            workspace=workspace,
+            region=region,
+            username=username,
+            token=token or '',
+        )
 
     # Validate file paths
     if not validate_file_path(remote_file_path):
         return format_validation_error('remote_file_path', remote_file_path)
+    if local_file_path is None:
+        return error_response('local_file_path is required in local mode')
     if not validate_file_path(local_file_path):
         return format_validation_error('local_file_path', local_file_path)
 
@@ -517,10 +618,10 @@ async def webftp_download_file(
 
     # Step 3: Download file content from S3 using presigned URL
     if 'download_url' in result and result['download_url']:
+        # local_file_path is guaranteed non-None by the guard above
+        local_path: str = local_file_path  # type: ignore[assignment]
         try:
-            file_size = await _stream_s3_to_file(
-                result['download_url'], local_file_path
-            )
+            file_size = await _stream_s3_to_file(result['download_url'], local_path)
         except _S3DownloadError as e:
             return error_response(
                 f'Failed to download from S3: {e}',

--- a/tools/webftp_tools.py
+++ b/tools/webftp_tools.py
@@ -127,6 +127,15 @@ async def _aiter_file(path: str, chunk_size: int = _CHUNK_SIZE):
         await asyncio.to_thread(src_file.close)
 
 
+async def _upload_bytes_to_s3(upload_url: str, data: bytes) -> str | None:
+    """PUT bytes to a presigned S3 URL. Returns an error message on failure, None on success."""
+    async with httpx.AsyncClient() as client:
+        resp = await client.put(upload_url, content=data)
+    if resp.status_code not in _S3_SUCCESS_CODES:
+        return f'Failed to upload to S3: {resp.status_code} - {resp.text}'
+    return None
+
+
 @mcp_tool_handler(
     description='Create a new WebFTP file transfer session on a server. Returns session ID and connection details. When to use: advanced session management. For simple file transfers, use webftp_upload_file or webftp_download_file directly. Related: webftp_sessions_list (view sessions), webftp_upload_file, webftp_download_file.',
     annotations=ADDITIVE,
@@ -295,17 +304,9 @@ async def webftp_upload_file(
 
     # Step 4: Upload file content to S3 using presigned URL
     if 'upload_url' in result and result['upload_url']:
-        async with httpx.AsyncClient() as client:
-            upload_response = await client.put(
-                result['upload_url'],
-                content=file_content,
-            )
-
-            if upload_response.status_code not in _S3_SUCCESS_CODES:
-                return error_response(
-                    f'Failed to upload to S3: {upload_response.status_code} - {upload_response.text}',
-                    upload_url=result['upload_url'],
-                )
+        err = await _upload_bytes_to_s3(result['upload_url'], file_content)
+        if err:
+            return error_response(err, upload_url=result['upload_url'])
 
         # Step 5: Trigger server to process the uploaded file
         upload_trigger = await http_client.get(

--- a/tools/webftp_tools.py
+++ b/tools/webftp_tools.py
@@ -12,8 +12,16 @@ from server import mcp
 from utils.common import error_response, success_response
 from utils.decorators import mcp_tool_handler
 from utils.error_handler import format_validation_error, validate_file_path
+from utils.health import _is_remote_mode
 from utils.http_client import http_client
 from utils.tool_annotations import ADDITIVE, READ_ONLY
+
+# Error message returned when file transfer tools are called in remote mode.
+_REMOTE_MODE_ERROR = (
+    'WebFTP file transfer is not supported in remote mode. '
+    'The MCP server cannot access your local filesystem from a remote container. '
+    'Use local mode (stdio) for file transfers.'
+)
 
 # API endpoints
 _API_SESSIONS = '/api/webftp/sessions/'
@@ -249,6 +257,9 @@ async def webftp_upload_file(
     """
     token = kwargs.get('token')
 
+    if _is_remote_mode():
+        return error_response(_REMOTE_MODE_ERROR, code='remote_mode_unsupported')
+
     # Validate file paths
     if not validate_file_path(local_file_path):
         return format_validation_error('local_file_path', local_file_path)
@@ -366,6 +377,9 @@ async def webftp_download_file(
         Download response with file saved locally
     """
     token = kwargs.get('token')
+
+    if _is_remote_mode():
+        return error_response(_REMOTE_MODE_ERROR, code='remote_mode_unsupported')
 
     # Validate file paths
     if not validate_file_path(remote_file_path):
@@ -551,6 +565,9 @@ async def webftp_bulk_upload(
     """
     token = kwargs.get('token')
 
+    if _is_remote_mode():
+        return error_response(_REMOTE_MODE_ERROR, code='remote_mode_unsupported')
+
     # Validate non-empty file list
     if not local_file_paths:
         return error_response('local_file_paths must not be empty')
@@ -706,6 +723,9 @@ async def webftp_bulk_download(
         Bulk download response with file saved locally
     """
     token = kwargs.get('token')
+
+    if _is_remote_mode():
+        return error_response(_REMOTE_MODE_ERROR, code='remote_mode_unsupported')
 
     # Validate non-empty paths list
     if not remote_paths:

--- a/tools/webftp_tools.py
+++ b/tools/webftp_tools.py
@@ -6,7 +6,7 @@ import binascii
 import os
 from http import HTTPStatus
 from pathlib import Path
-from typing import Any
+from typing import Any, cast
 
 import httpx
 
@@ -175,10 +175,8 @@ async def _download_remote_mode(
     download_url = result.get('download_url')
 
     if not download_url:
-        elapsed = 0
-        while elapsed < _REMOTE_DOWNLOAD_TIMEOUT:
+        for _ in range(_REMOTE_DOWNLOAD_TIMEOUT):
             await asyncio.sleep(1)
-            elapsed += 1
             status = await http_client.get(
                 region=region,
                 workspace=workspace,
@@ -383,7 +381,7 @@ async def webftp_upload_file(
     )
 
     # Step 4: Upload file content to S3 using presigned URL
-    if 'upload_url' in result and result['upload_url']:
+    if result.get('upload_url'):
         err = await _upload_bytes_to_s3(result['upload_url'], file_content)
         if err:
             return error_response(err, upload_url=result['upload_url'])
@@ -404,7 +402,7 @@ async def webftp_upload_file(
             local_file_path=local_file_path,
             remote_file_path=remote_file_path,
             file_size=len(file_content),
-            upload_url=result.get('upload_url'),
+            upload_url=result['upload_url'],
             download_url=result.get('download_url'),
             region=region,
             workspace=workspace,
@@ -489,7 +487,7 @@ async def webftp_upload_content(
         data=upload_data,
     )
 
-    if 'upload_url' in result and result['upload_url']:
+    if result.get('upload_url'):
         err = await _upload_bytes_to_s3(result['upload_url'], raw_bytes)
         if err:
             return error_response(err, upload_url=result['upload_url'])
@@ -508,7 +506,7 @@ async def webftp_upload_content(
             server_id=server_id,
             remote_file_path=remote_file_path,
             file_size=len(raw_bytes),
-            upload_url=result.get('upload_url'),
+            upload_url=result['upload_url'],
             region=region,
             workspace=workspace,
         )
@@ -570,9 +568,10 @@ async def webftp_download_file(
     """
     token = kwargs.get('token')
 
+    if not validate_file_path(remote_file_path):
+        return format_validation_error('remote_file_path', remote_file_path)
+
     if _is_auth_enabled():
-        if not validate_file_path(remote_file_path):
-            return format_validation_error('remote_file_path', remote_file_path)
         return await _download_remote_mode(
             server_id=server_id,
             remote_file_path=remote_file_path,
@@ -583,9 +582,6 @@ async def webftp_download_file(
             token=token or '',
         )
 
-    # Validate file paths
-    if not validate_file_path(remote_file_path):
-        return format_validation_error('remote_file_path', remote_file_path)
     if local_file_path is None:
         return error_response('local_file_path is required in local mode')
     if not validate_file_path(local_file_path):
@@ -617,11 +613,11 @@ async def webftp_download_file(
     )
 
     # Step 3: Download file content from S3 using presigned URL
-    if 'download_url' in result and result['download_url']:
-        # local_file_path is guaranteed non-None by the guard above
-        local_path: str = local_file_path  # type: ignore[assignment]
+    if result.get('download_url'):
         try:
-            file_size = await _stream_s3_to_file(result['download_url'], local_path)
+            file_size = await _stream_s3_to_file(
+                result['download_url'], cast(str, local_file_path)
+            )
         except _S3DownloadError as e:
             return error_response(
                 f'Failed to download from S3: {e}',

--- a/tools/webftp_tools.py
+++ b/tools/webftp_tools.py
@@ -15,7 +15,6 @@ from utils.error_handler import format_validation_error, validate_file_path
 from utils.http_client import http_client
 from utils.tool_annotations import ADDITIVE, READ_ONLY
 
-# Error message returned when file transfer tools are called in remote mode.
 _REMOTE_MODE_ERROR = (
     'WebFTP file transfer is not supported in remote mode. '
     'The MCP server cannot access your local filesystem from a remote container. '

--- a/tools/webftp_tools.py
+++ b/tools/webftp_tools.py
@@ -10,9 +10,8 @@ import httpx
 
 from server import mcp
 from utils.common import error_response, success_response
-from utils.decorators import mcp_tool_handler
+from utils.decorators import _is_auth_enabled, mcp_tool_handler
 from utils.error_handler import format_validation_error, validate_file_path
-from utils.health import _is_remote_mode
 from utils.http_client import http_client
 from utils.tool_annotations import ADDITIVE, READ_ONLY
 
@@ -257,7 +256,7 @@ async def webftp_upload_file(
     """
     token = kwargs.get('token')
 
-    if _is_remote_mode():
+    if _is_auth_enabled():
         return error_response(_REMOTE_MODE_ERROR, code='remote_mode_unsupported')
 
     # Validate file paths
@@ -378,7 +377,7 @@ async def webftp_download_file(
     """
     token = kwargs.get('token')
 
-    if _is_remote_mode():
+    if _is_auth_enabled():
         return error_response(_REMOTE_MODE_ERROR, code='remote_mode_unsupported')
 
     # Validate file paths
@@ -565,7 +564,7 @@ async def webftp_bulk_upload(
     """
     token = kwargs.get('token')
 
-    if _is_remote_mode():
+    if _is_auth_enabled():
         return error_response(_REMOTE_MODE_ERROR, code='remote_mode_unsupported')
 
     # Validate non-empty file list
@@ -724,7 +723,7 @@ async def webftp_bulk_download(
     """
     token = kwargs.get('token')
 
-    if _is_remote_mode():
+    if _is_auth_enabled():
         return error_response(_REMOTE_MODE_ERROR, code='remote_mode_unsupported')
 
     # Validate non-empty paths list

--- a/tools/webftp_tools.py
+++ b/tools/webftp_tools.py
@@ -1,6 +1,8 @@
 """WebFTP (Web FTP) management tools for Alpacon MCP server."""
 
 import asyncio
+import base64
+import binascii
 import os
 from http import HTTPStatus
 from pathlib import Path
@@ -337,6 +339,108 @@ async def webftp_upload_file(
             server_id=server_id,
             local_file_path=local_file_path,
             remote_file_path=remote_file_path,
+            region=region,
+            workspace=workspace,
+        )
+
+
+@mcp_tool_handler(
+    description=(
+        'Upload file content to a remote server using base64-encoded bytes. '
+        'Use this when you have the file content directly rather than a local file path. '
+        'Suitable for: remote mode (streamable-http), Claude Desktop file attachments, '
+        'or when Claude Code reads a file with its Read tool. '
+        'file_content must be base64-encoded bytes. '
+        'Related: webftp_upload_file (local path), webftp_download_file.'
+    ),
+    annotations=ADDITIVE,
+    meta={'anthropic/searchHint': 'file upload content base64 remote mode attach'},
+)
+async def webftp_upload_content(
+    server_id: str,
+    file_content: str,
+    remote_file_path: str,
+    workspace: str,
+    file_name: str | None = None,
+    username: str | None = None,
+    region: str = '',
+    allow_overwrite: bool = True,
+    **kwargs,
+) -> dict[str, Any]:
+    """Upload base64-encoded file content to a server via WebFTP.
+
+    Args:
+        server_id: Server ID to upload file to
+        file_content: Base64-encoded file bytes
+        remote_file_path: Absolute path on the server (e.g., "/home/user/file.txt")
+        workspace: Workspace name. Required parameter
+        file_name: File name to use on the server. Inferred from remote_file_path if omitted
+        username: Optional username (uses authenticated user if not provided)
+        region: Region (ap1, us1, eu1). Auto-detected if not provided
+        allow_overwrite: Allow overwriting existing files (default: True)
+
+    Returns:
+        File upload response
+    """
+    token = kwargs.get('token')
+
+    try:
+        raw_bytes = base64.b64decode(file_content)
+    except binascii.Error as exc:
+        return error_response(f'Invalid base64 content: {exc}', code='invalid_content')
+
+    if not validate_file_path(remote_file_path):
+        return format_validation_error('remote_file_path', remote_file_path)
+
+    name = file_name or os.path.basename(remote_file_path)
+
+    upload_data: dict[str, Any] = {
+        'server': server_id,
+        'name': name,
+        'path': remote_file_path,
+        'allow_overwrite': allow_overwrite,
+    }
+    if username:
+        upload_data['username'] = username
+
+    result = await http_client.post(
+        region=region,
+        workspace=workspace,
+        endpoint=_API_UPLOADS,
+        token=token,
+        data=upload_data,
+    )
+
+    if 'upload_url' in result and result['upload_url']:
+        err = await _upload_bytes_to_s3(result['upload_url'], raw_bytes)
+        if err:
+            return error_response(err, upload_url=result['upload_url'])
+
+        upload_trigger = await http_client.get(
+            region=region,
+            workspace=workspace,
+            endpoint=f'{_API_UPLOADS}{result["id"]}/upload/',
+            token=token,
+        )
+
+        return success_response(
+            message='File content uploaded successfully and processed by server',
+            data=result,
+            upload_trigger=upload_trigger,
+            server_id=server_id,
+            remote_file_path=remote_file_path,
+            file_size=len(raw_bytes),
+            upload_url=result.get('upload_url'),
+            region=region,
+            workspace=workspace,
+        )
+    else:
+        return success_response(
+            message='File content uploaded successfully (direct upload)',
+            data=result,
+            server_id=server_id,
+            remote_file_path=remote_file_path,
+            file_size=len(raw_bytes),
             region=region,
             workspace=workspace,
         )

--- a/utils/common.py
+++ b/utils/common.py
@@ -18,7 +18,7 @@ except importlib.metadata.PackageNotFoundError:
     MCP_VERSION = '0.4.2-dev'
 
 # MCP User-Agent for identification
-MCP_USER_AGENT = f'alpacon-mcp/{MCP_VERSION} (MCP-Server; persistent-pool) Python/3.12 websockets/15.0.1'
+MCP_USER_AGENT = f'alpacon-mcp/{MCP_VERSION} (MCP-Server; persistent-pool) Python/3.12'
 
 
 def validate_token(region: str, workspace: str) -> str | None:

--- a/uv.lock
+++ b/uv.lock
@@ -10,7 +10,6 @@ dependencies = [
     { name = "httpx" },
     { name = "mcp", extra = ["cli"] },
     { name = "pyjwt", extra = ["crypto"] },
-    { name = "websockets" },
 ]
 
 [package.optional-dependencies]
@@ -41,7 +40,6 @@ requires-dist = [
     { name = "pyjwt", extras = ["crypto"], specifier = ">=2.8.0" },
     { name = "pytest", marker = "extra == 'dev'", specifier = ">=7.0.0" },
     { name = "pytest-asyncio", marker = "extra == 'dev'", specifier = ">=0.21.0" },
-    { name = "websockets", specifier = ">=15.0.1" },
 ]
 provides-extras = ["dev"]
 
@@ -1017,35 +1015,4 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/de/ad/713be230bcda622eaa35c28f0d328c3675c371238470abdea52417f17a8e/uvicorn-0.34.3.tar.gz", hash = "sha256:35919a9a979d7a59334b6b10e05d77c1d0d574c50e0fc98b8b1a0f165708b55a", size = 76631, upload-time = "2025-06-01T07:48:17.531Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/6d/0d/8adfeaa62945f90d19ddc461c55f4a50c258af7662d34b6a3d5d1f8646f6/uvicorn-0.34.3-py3-none-any.whl", hash = "sha256:16246631db62bdfbf069b0645177d6e8a77ba950cfedbfd093acef9444e4d885", size = 62431, upload-time = "2025-06-01T07:48:15.664Z" },
-]
-
-[[package]]
-name = "websockets"
-version = "15.0.1"
-source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/21/e6/26d09fab466b7ca9c7737474c52be4f76a40301b08362eb2dbc19dcc16c1/websockets-15.0.1.tar.gz", hash = "sha256:82544de02076bafba038ce055ee6412d68da13ab47f0c60cab827346de828dee", size = 177016, upload-time = "2025-03-05T20:03:41.606Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/51/6b/4545a0d843594f5d0771e86463606a3988b5a09ca5123136f8a76580dd63/websockets-15.0.1-cp312-cp312-macosx_10_13_universal2.whl", hash = "sha256:3e90baa811a5d73f3ca0bcbf32064d663ed81318ab225ee4f427ad4e26e5aff3", size = 175437, upload-time = "2025-03-05T20:02:16.706Z" },
-    { url = "https://files.pythonhosted.org/packages/f4/71/809a0f5f6a06522af902e0f2ea2757f71ead94610010cf570ab5c98e99ed/websockets-15.0.1-cp312-cp312-macosx_10_13_x86_64.whl", hash = "sha256:592f1a9fe869c778694f0aa806ba0374e97648ab57936f092fd9d87f8bc03665", size = 173096, upload-time = "2025-03-05T20:02:18.832Z" },
-    { url = "https://files.pythonhosted.org/packages/3d/69/1a681dd6f02180916f116894181eab8b2e25b31e484c5d0eae637ec01f7c/websockets-15.0.1-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:0701bc3cfcb9164d04a14b149fd74be7347a530ad3bbf15ab2c678a2cd3dd9a2", size = 173332, upload-time = "2025-03-05T20:02:20.187Z" },
-    { url = "https://files.pythonhosted.org/packages/a6/02/0073b3952f5bce97eafbb35757f8d0d54812b6174ed8dd952aa08429bcc3/websockets-15.0.1-cp312-cp312-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:e8b56bdcdb4505c8078cb6c7157d9811a85790f2f2b3632c7d1462ab5783d215", size = 183152, upload-time = "2025-03-05T20:02:22.286Z" },
-    { url = "https://files.pythonhosted.org/packages/74/45/c205c8480eafd114b428284840da0b1be9ffd0e4f87338dc95dc6ff961a1/websockets-15.0.1-cp312-cp312-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:0af68c55afbd5f07986df82831c7bff04846928ea8d1fd7f30052638788bc9b5", size = 182096, upload-time = "2025-03-05T20:02:24.368Z" },
-    { url = "https://files.pythonhosted.org/packages/14/8f/aa61f528fba38578ec553c145857a181384c72b98156f858ca5c8e82d9d3/websockets-15.0.1-cp312-cp312-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:64dee438fed052b52e4f98f76c5790513235efaa1ef7f3f2192c392cd7c91b65", size = 182523, upload-time = "2025-03-05T20:02:25.669Z" },
-    { url = "https://files.pythonhosted.org/packages/ec/6d/0267396610add5bc0d0d3e77f546d4cd287200804fe02323797de77dbce9/websockets-15.0.1-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:d5f6b181bb38171a8ad1d6aa58a67a6aa9d4b38d0f8c5f496b9e42561dfc62fe", size = 182790, upload-time = "2025-03-05T20:02:26.99Z" },
-    { url = "https://files.pythonhosted.org/packages/02/05/c68c5adbf679cf610ae2f74a9b871ae84564462955d991178f95a1ddb7dd/websockets-15.0.1-cp312-cp312-musllinux_1_2_i686.whl", hash = "sha256:5d54b09eba2bada6011aea5375542a157637b91029687eb4fdb2dab11059c1b4", size = 182165, upload-time = "2025-03-05T20:02:30.291Z" },
-    { url = "https://files.pythonhosted.org/packages/29/93/bb672df7b2f5faac89761cb5fa34f5cec45a4026c383a4b5761c6cea5c16/websockets-15.0.1-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:3be571a8b5afed347da347bfcf27ba12b069d9d7f42cb8c7028b5e98bbb12597", size = 182160, upload-time = "2025-03-05T20:02:31.634Z" },
-    { url = "https://files.pythonhosted.org/packages/ff/83/de1f7709376dc3ca9b7eeb4b9a07b4526b14876b6d372a4dc62312bebee0/websockets-15.0.1-cp312-cp312-win32.whl", hash = "sha256:c338ffa0520bdb12fbc527265235639fb76e7bc7faafbb93f6ba80d9c06578a9", size = 176395, upload-time = "2025-03-05T20:02:33.017Z" },
-    { url = "https://files.pythonhosted.org/packages/7d/71/abf2ebc3bbfa40f391ce1428c7168fb20582d0ff57019b69ea20fa698043/websockets-15.0.1-cp312-cp312-win_amd64.whl", hash = "sha256:fcd5cf9e305d7b8338754470cf69cf81f420459dbae8a3b40cee57417f4614a7", size = 176841, upload-time = "2025-03-05T20:02:34.498Z" },
-    { url = "https://files.pythonhosted.org/packages/cb/9f/51f0cf64471a9d2b4d0fc6c534f323b664e7095640c34562f5182e5a7195/websockets-15.0.1-cp313-cp313-macosx_10_13_universal2.whl", hash = "sha256:ee443ef070bb3b6ed74514f5efaa37a252af57c90eb33b956d35c8e9c10a1931", size = 175440, upload-time = "2025-03-05T20:02:36.695Z" },
-    { url = "https://files.pythonhosted.org/packages/8a/05/aa116ec9943c718905997412c5989f7ed671bc0188ee2ba89520e8765d7b/websockets-15.0.1-cp313-cp313-macosx_10_13_x86_64.whl", hash = "sha256:5a939de6b7b4e18ca683218320fc67ea886038265fd1ed30173f5ce3f8e85675", size = 173098, upload-time = "2025-03-05T20:02:37.985Z" },
-    { url = "https://files.pythonhosted.org/packages/ff/0b/33cef55ff24f2d92924923c99926dcce78e7bd922d649467f0eda8368923/websockets-15.0.1-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:746ee8dba912cd6fc889a8147168991d50ed70447bf18bcda7039f7d2e3d9151", size = 173329, upload-time = "2025-03-05T20:02:39.298Z" },
-    { url = "https://files.pythonhosted.org/packages/31/1d/063b25dcc01faa8fada1469bdf769de3768b7044eac9d41f734fd7b6ad6d/websockets-15.0.1-cp313-cp313-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:595b6c3969023ecf9041b2936ac3827e4623bfa3ccf007575f04c5a6aa318c22", size = 183111, upload-time = "2025-03-05T20:02:40.595Z" },
-    { url = "https://files.pythonhosted.org/packages/93/53/9a87ee494a51bf63e4ec9241c1ccc4f7c2f45fff85d5bde2ff74fcb68b9e/websockets-15.0.1-cp313-cp313-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:3c714d2fc58b5ca3e285461a4cc0c9a66bd0e24c5da9911e30158286c9b5be7f", size = 182054, upload-time = "2025-03-05T20:02:41.926Z" },
-    { url = "https://files.pythonhosted.org/packages/ff/b2/83a6ddf56cdcbad4e3d841fcc55d6ba7d19aeb89c50f24dd7e859ec0805f/websockets-15.0.1-cp313-cp313-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:0f3c1e2ab208db911594ae5b4f79addeb3501604a165019dd221c0bdcabe4db8", size = 182496, upload-time = "2025-03-05T20:02:43.304Z" },
-    { url = "https://files.pythonhosted.org/packages/98/41/e7038944ed0abf34c45aa4635ba28136f06052e08fc2168520bb8b25149f/websockets-15.0.1-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:229cf1d3ca6c1804400b0a9790dc66528e08a6a1feec0d5040e8b9eb14422375", size = 182829, upload-time = "2025-03-05T20:02:48.812Z" },
-    { url = "https://files.pythonhosted.org/packages/e0/17/de15b6158680c7623c6ef0db361da965ab25d813ae54fcfeae2e5b9ef910/websockets-15.0.1-cp313-cp313-musllinux_1_2_i686.whl", hash = "sha256:756c56e867a90fb00177d530dca4b097dd753cde348448a1012ed6c5131f8b7d", size = 182217, upload-time = "2025-03-05T20:02:50.14Z" },
-    { url = "https://files.pythonhosted.org/packages/33/2b/1f168cb6041853eef0362fb9554c3824367c5560cbdaad89ac40f8c2edfc/websockets-15.0.1-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:558d023b3df0bffe50a04e710bc87742de35060580a293c2a984299ed83bc4e4", size = 182195, upload-time = "2025-03-05T20:02:51.561Z" },
-    { url = "https://files.pythonhosted.org/packages/86/eb/20b6cdf273913d0ad05a6a14aed4b9a85591c18a987a3d47f20fa13dcc47/websockets-15.0.1-cp313-cp313-win32.whl", hash = "sha256:ba9e56e8ceeeedb2e080147ba85ffcd5cd0711b89576b83784d8605a7df455fa", size = 176393, upload-time = "2025-03-05T20:02:53.814Z" },
-    { url = "https://files.pythonhosted.org/packages/1b/6c/c65773d6cab416a64d191d6ee8a8b1c68a09970ea6909d16965d26bfed1e/websockets-15.0.1-cp313-cp313-win_amd64.whl", hash = "sha256:e09473f095a819042ecb2ab9465aee615bd9c2028e4ef7d933600a8401c79561", size = 176837, upload-time = "2025-03-05T20:02:55.237Z" },
-    { url = "https://files.pythonhosted.org/packages/fa/a8/5b41e0da817d64113292ab1f8247140aac61cbf6cfd085d6a0fa77f4984f/websockets-15.0.1-py3-none-any.whl", hash = "sha256:f7a866fbc1e97b5c617ee4116daaa09b722101d4a3c170c787450ba409f9736f", size = 169743, upload-time = "2025-03-05T20:03:39.41Z" },
 ]


### PR DESCRIPTION
## Summary

- `websockets` was listed as a runtime dependency but never imported anywhere in the codebase
- Its only appearance was a hardcoded version string inside the `MCP_USER_AGENT` constant in `utils/common.py`, which has been cleaned up
- `uv sync` confirms the package is uninstalled with no breakage (`Uninstalled 1 package: websockets==15.0.1`)

## Changes

- `pyproject.toml`: remove `websockets>=15.0.1` from `dependencies`
- `utils/common.py`: remove stale `websockets/15.0.1` token from `MCP_USER_AGENT` string
- `uv.lock`: updated automatically (57 packages, down from 58)

## Verification

```
$ uv sync
Resolved 57 packages in 19ms
Uninstalled 1 package in 6ms
 - websockets==15.0.1

$ uv lock --check
Resolved 57 packages in 4ms
```

## Test plan

- [x] `uv sync` exits cleanly and removes `websockets`
- [x] `uv lock --check` confirms lock file is consistent
- [x] No source file imports `websockets` (confirmed via `grep -r "import websockets"`)