### PR TITLE
chore: remove unused dependencies and tighten version constraints

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -405,8 +405,9 @@ Alternative endpoints available in the server:
 ## Dependencies
 
 **Runtime dependencies** (from `pyproject.toml`):
-- `mcp[cli]>=1.9.4`: Model Context Protocol framework
-- `httpx>=0.25.0`: Async HTTP client
+- `mcp>=1.9.4`: Model Context Protocol framework
+- `httpx>=0.27.1`: Async HTTP client
+- `PyJWT[crypto]>=2.10.1`: JWT token verification
 
 **Development dependencies**:
 - `pytest>=7.0.0`: Testing framework

--- a/docs/README.md
+++ b/docs/README.md
@@ -17,7 +17,7 @@ Welcome to the Alpacon MCP Server documentation. Alpacon provides browser-based,
 1. **Install dependencies**
    ```bash
    uv venv && source .venv/bin/activate
-   uv pip install mcp[cli] httpx
+   uv pip install mcp httpx
    ```
 
 2. **Configure tokens**

--- a/docs/README.md
+++ b/docs/README.md
@@ -17,7 +17,7 @@ Welcome to the Alpacon MCP Server documentation. Alpacon provides browser-based,
 1. **Install dependencies**
    ```bash
    uv venv && source .venv/bin/activate
-   uv pip install mcp httpx
+   uv pip install mcp httpx "PyJWT[crypto]"
    ```
 
 2. **Configure tokens**

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -316,7 +316,7 @@ WORKDIR /app
 COPY . .
 
 RUN pip install uv
-RUN uv venv && uv pip install mcp[cli] httpx
+RUN uv venv && uv pip install mcp httpx
 
 # Use config volume for tokens
 VOLUME ["/app/config"]

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -316,7 +316,7 @@ WORKDIR /app
 COPY . .
 
 RUN pip install uv
-RUN uv venv && uv pip install mcp httpx
+RUN uv venv && uv pip install mcp httpx "PyJWT[crypto]"
 
 # Use config volume for tokens
 VOLUME ["/app/config"]

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -70,7 +70,7 @@ source .venv/bin/activate  # Linux/macOS
 # .venv\Scripts\activate     # Windows
 
 # Install dependencies
-uv pip install mcp[cli] httpx
+uv pip install mcp httpx
 ```
 
 ### Step 3: Get API token from Alpacon

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -70,7 +70,7 @@ source .venv/bin/activate  # Linux/macOS
 # .venv\Scripts\activate     # Windows
 
 # Install dependencies
-uv pip install mcp httpx
+uv pip install mcp httpx "PyJWT[crypto]"
 ```
 
 ### Step 3: Get API token from Alpacon

--- a/docs/installation-guide.md
+++ b/docs/installation-guide.md
@@ -34,9 +34,9 @@ Comprehensive installation and setup guide for the Alpacon MCP Server across dif
 
 The following dependencies are automatically installed:
 
-- **mcp[cli]** ≥1.9.4: Model Context Protocol framework
-- **httpx** ≥0.25.0: Async HTTP client for API calls
-- **websockets** ≥15.0.1: WebSocket support for real-time features
+- **mcp** ≥1.9.4: Model Context Protocol framework
+- **httpx** ≥0.27.1: Async HTTP client for API calls
+- **PyJWT[crypto]** ≥2.10.1: JWT token verification for authentication
 
 ## Installation methods
 

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -72,7 +72,7 @@ source .venv/bin/activate  # Linux/macOS
 # .venv\Scripts\activate     # Windows
 
 # Install dependencies
-uv pip install mcp httpx
+uv pip install mcp httpx "PyJWT[crypto]"
 
 # Configure tokens
 mkdir -p config
@@ -107,7 +107,7 @@ uv venv
 source .venv/bin/activate
 
 # Install dependencies
-uv pip install mcp httpx
+uv pip install mcp httpx "PyJWT[crypto]"
 ```
 
 #### Method 2: Using system Python
@@ -129,7 +129,7 @@ uv venv
 source .venv/bin/activate
 
 # Install dependencies
-uv pip install mcp httpx
+uv pip install mcp httpx "PyJWT[crypto]"
 ```
 
 #### macOS-specific configuration
@@ -170,7 +170,7 @@ uv venv
 source .venv/bin/activate
 
 # Install dependencies
-uv pip install mcp httpx
+uv pip install mcp httpx "PyJWT[crypto]"
 
 # Test installation
 python main.py --test
@@ -230,7 +230,7 @@ cd alpacon-mcp
 
 uv venv
 source .venv/bin/activate
-uv pip install mcp httpx
+uv pip install mcp httpx "PyJWT[crypto]"
 ```
 
 ### Windows
@@ -261,7 +261,7 @@ uv venv
 .venv\Scripts\Activate.ps1
 
 # Install dependencies
-uv pip install mcp httpx
+uv pip install mcp httpx "PyJWT[crypto]"
 
 # Test installation
 python main.py --test
@@ -524,7 +524,7 @@ chmod +x ~/.local/bin/uv
 rm -rf .venv
 uv venv
 source .venv/bin/activate
-uv pip install mcp httpx
+uv pip install mcp httpx "PyJWT[crypto]"
 ```
 
 ### Platform-specific issues

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -467,7 +467,7 @@ echo '{"jsonrpc":"2.0","id":1,"method":"initialize","params":{"clientInfo":{"nam
 git pull origin main
 
 # Update dependencies
-uv pip install --upgrade mcp httpx
+uv pip install --upgrade mcp httpx "PyJWT[crypto]"
 
 # Restart service if running
 sudo systemctl restart alpacon-mcp  # Linux service

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -72,7 +72,7 @@ source .venv/bin/activate  # Linux/macOS
 # .venv\Scripts\activate     # Windows
 
 # Install dependencies
-uv pip install mcp[cli] httpx
+uv pip install mcp httpx
 
 # Configure tokens
 mkdir -p config
@@ -107,7 +107,7 @@ uv venv
 source .venv/bin/activate
 
 # Install dependencies
-uv pip install mcp[cli] httpx
+uv pip install mcp httpx
 ```
 
 #### Method 2: Using system Python
@@ -129,7 +129,7 @@ uv venv
 source .venv/bin/activate
 
 # Install dependencies
-uv pip install mcp[cli] httpx
+uv pip install mcp httpx
 ```
 
 #### macOS-specific configuration
@@ -170,7 +170,7 @@ uv venv
 source .venv/bin/activate
 
 # Install dependencies
-uv pip install mcp[cli] httpx
+uv pip install mcp httpx
 
 # Test installation
 python main.py --test
@@ -230,7 +230,7 @@ cd alpacon-mcp
 
 uv venv
 source .venv/bin/activate
-uv pip install mcp[cli] httpx
+uv pip install mcp httpx
 ```
 
 ### Windows
@@ -261,7 +261,7 @@ uv venv
 .venv\Scripts\Activate.ps1
 
 # Install dependencies
-uv pip install mcp[cli] httpx
+uv pip install mcp httpx
 
 # Test installation
 python main.py --test
@@ -467,7 +467,7 @@ echo '{"jsonrpc":"2.0","id":1,"method":"initialize","params":{"clientInfo":{"nam
 git pull origin main
 
 # Update dependencies
-uv pip install --upgrade mcp[cli] httpx
+uv pip install --upgrade mcp httpx
 
 # Restart service if running
 sudo systemctl restart alpacon-mcp  # Linux service
@@ -524,7 +524,7 @@ chmod +x ~/.local/bin/uv
 rm -rf .venv
 uv venv
 source .venv/bin/activate
-uv pip install mcp[cli] httpx
+uv pip install mcp httpx
 ```
 
 ### Platform-specific issues

--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -69,10 +69,10 @@ ImportError: No module named 'httpx'
 #### Solutions
 ```bash
 # Install missing dependencies
-uv pip install mcp httpx
+uv pip install mcp httpx "PyJWT[crypto]"
 
 # Or using pip
-pip install mcp httpx
+pip install mcp httpx "PyJWT[crypto]"
 
 # Verify virtual environment is activated
 source .venv/bin/activate
@@ -585,7 +585,7 @@ When reporting issues, include:
 Before seeking help, verify:
 
 - [ ] Virtual environment is activated
-- [ ] All dependencies are installed (`mcp`, `httpx`)
+- [ ] All dependencies are installed (`mcp`, `httpx`, `PyJWT[crypto]`)
 - [ ] Token configuration file exists and is properly formatted
 - [ ] Absolute paths are used in MCP client configuration
 - [ ] Server can be started manually with `python main.py`

--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -69,7 +69,7 @@ ImportError: No module named 'httpx'
 #### Solutions
 ```bash
 # Install missing dependencies
-uv pip install mcp[cli] httpx
+uv pip install mcp httpx
 
 # Or using pip
 pip install mcp httpx
@@ -585,7 +585,7 @@ When reporting issues, include:
 Before seeking help, verify:
 
 - [ ] Virtual environment is activated
-- [ ] All dependencies are installed (`mcp[cli]`, `httpx`)
+- [ ] All dependencies are installed (`mcp`, `httpx`)
 - [ ] Token configuration file exists and is properly formatted
 - [ ] Absolute paths are used in MCP client configuration
 - [ ] Server can be started manually with `python main.py`

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -40,7 +40,7 @@ classifiers = [
     "Environment :: Console",
 ]
 dependencies = [
-    "mcp[cli]>=1.9.4",
+    "mcp>=1.9.4",
     "httpx>=0.27.1",
     "PyJWT[crypto]>=2.10.1",
 ]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -42,7 +42,6 @@ classifiers = [
 dependencies = [
     "mcp[cli]>=1.9.4",
     "httpx>=0.25.0",
-    "websockets>=15.0.1",
     "PyJWT[crypto]>=2.8.0",
 ]
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -41,8 +41,8 @@ classifiers = [
 ]
 dependencies = [
     "mcp[cli]>=1.9.4",
-    "httpx>=0.25.0",
-    "PyJWT[crypto]>=2.8.0",
+    "httpx>=0.27.1",
+    "PyJWT[crypto]>=2.10.1",
 ]
 
 [project.urls]

--- a/utils/common.py
+++ b/utils/common.py
@@ -18,7 +18,7 @@ except importlib.metadata.PackageNotFoundError:
     MCP_VERSION = '0.4.2-dev'
 
 # MCP User-Agent for identification
-MCP_USER_AGENT = f'alpacon-mcp/{MCP_VERSION} (MCP-Server; persistent-pool) Python/3.12 websockets/15.0.1'
+MCP_USER_AGENT = f'alpacon-mcp/{MCP_VERSION} (MCP-Server; persistent-pool) Python/3.12'
 
 
 def validate_token(region: str, workspace: str) -> str | None:

--- a/utils/common.py
+++ b/utils/common.py
@@ -1,6 +1,7 @@
 """Common utilities for all MCP tools."""
 
 import importlib.metadata
+import platform
 from typing import Any
 
 from utils.logger import get_logger
@@ -18,7 +19,7 @@ except importlib.metadata.PackageNotFoundError:
     MCP_VERSION = '0.4.2-dev'
 
 # MCP User-Agent for identification
-MCP_USER_AGENT = f'alpacon-mcp/{MCP_VERSION} (MCP-Server; persistent-pool) Python/3.12'
+MCP_USER_AGENT = f'alpacon-mcp/{MCP_VERSION} (MCP-Server; persistent-pool) Python/{platform.python_version()}'
 
 
 def validate_token(region: str, workspace: str) -> str | None:

--- a/uv.lock
+++ b/uv.lock
@@ -8,7 +8,7 @@ version = "0.6.0"
 source = { editable = "." }
 dependencies = [
     { name = "httpx" },
-    { name = "mcp", extra = ["cli"] },
+    { name = "mcp" },
     { name = "pyjwt", extra = ["crypto"] },
 ]
 
@@ -35,7 +35,7 @@ requires-dist = [
     { name = "flake8", marker = "extra == 'dev'", specifier = ">=6.0.0" },
     { name = "httpx", specifier = ">=0.27.1" },
     { name = "isort", marker = "extra == 'dev'", specifier = ">=5.12.0" },
-    { name = "mcp", extras = ["cli"], specifier = ">=1.9.4" },
+    { name = "mcp", specifier = ">=1.9.4" },
     { name = "mypy", marker = "extra == 'dev'", specifier = ">=1.0.0" },
     { name = "pyjwt", extras = ["crypto"], specifier = ">=2.10.1" },
     { name = "pytest", marker = "extra == 'dev'", specifier = ">=7.0.0" },
@@ -453,18 +453,6 @@ wheels = [
 ]
 
 [[package]]
-name = "markdown-it-py"
-version = "3.0.0"
-source = { registry = "https://pypi.org/simple" }
-dependencies = [
-    { name = "mdurl" },
-]
-sdist = { url = "https://files.pythonhosted.org/packages/38/71/3b932df36c1a044d397a1f92d1cf91ee0a503d91e470cbd670aa66b07ed0/markdown-it-py-3.0.0.tar.gz", hash = "sha256:e3f60a94fa066dc52ec76661e37c851cb232d92f9886b15cb560aaada2df8feb", size = 74596, upload-time = "2023-06-03T06:41:14.443Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/42/d7/1ec15b46af6af88f19b8e5ffea08fa375d433c998b8a7639e76935c14f1f/markdown_it_py-3.0.0-py3-none-any.whl", hash = "sha256:355216845c60bd96232cd8d8c40e8f9765cc86f46880e43a8fd22dc1a1a8cab1", size = 87528, upload-time = "2023-06-03T06:41:11.019Z" },
-]
-
-[[package]]
 name = "mccabe"
 version = "0.7.0"
 source = { registry = "https://pypi.org/simple" }
@@ -496,21 +484,6 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/25/1a/9c8a5362e3448d585081d6c7aa95898a64e0ac59d3e26169ae6c3ca5feaf/mcp-1.23.0.tar.gz", hash = "sha256:84e0c29316d0a8cf0affd196fd000487ac512aa3f771b63b2ea864e22961772b", size = 596506, upload-time = "2025-12-02T13:40:02.558Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/7b/b2/28739ce409f98159c0121eab56e69ad71546c4f34ac8b42e58c03f57dccc/mcp-1.23.0-py3-none-any.whl", hash = "sha256:5a645cf111ed329f4619f2629a3f15d9aabd7adc2ea09d600d31467b51ecb64f", size = 231427, upload-time = "2025-12-02T13:40:00.738Z" },
-]
-
-[package.optional-dependencies]
-cli = [
-    { name = "python-dotenv" },
-    { name = "typer" },
-]
-
-[[package]]
-name = "mdurl"
-version = "0.1.2"
-source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/d6/54/cfe61301667036ec958cb99bd3efefba235e65cdeb9c84d24a8293ba1d90/mdurl-0.1.2.tar.gz", hash = "sha256:bb413d29f5eea38f31dd4754dd7377d4465116fb207585f97bf925588687c1ba", size = 8729, upload-time = "2022-08-14T12:40:10.846Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/b3/38/89ba8ad64ae25be8de66a6d463314cf1eb366222074cfda9ee839c56a4b4/mdurl-0.1.2-py3-none-any.whl", hash = "sha256:84008a41e51615a49fc9966191ff91509e3c40b939176e643fd50a5c2196b8f8", size = 9979, upload-time = "2022-08-14T12:40:09.779Z" },
 ]
 
 [[package]]
@@ -832,19 +805,6 @@ wheels = [
 ]
 
 [[package]]
-name = "rich"
-version = "14.0.0"
-source = { registry = "https://pypi.org/simple" }
-dependencies = [
-    { name = "markdown-it-py" },
-    { name = "pygments" },
-]
-sdist = { url = "https://files.pythonhosted.org/packages/a1/53/830aa4c3066a8ab0ae9a9955976fb770fe9c6102117c8ec4ab3ea62d89e8/rich-14.0.0.tar.gz", hash = "sha256:82f1bc23a6a21ebca4ae0c45af9bdbc492ed20231dcb63f297d6d1021a9d5725", size = 224078, upload-time = "2025-03-30T14:15:14.23Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/0d/9b/63f4c7ebc259242c89b3acafdb37b41d1185c07ff0011164674e9076b491/rich-14.0.0-py3-none-any.whl", hash = "sha256:1c9491e1951aac09caffd42f448ee3d04e58923ffe14993f6e83068dc395d7e0", size = 243229, upload-time = "2025-03-30T14:15:12.283Z" },
-]
-
-[[package]]
 name = "rpds-py"
 version = "0.30.0"
 source = { registry = "https://pypi.org/simple" }
@@ -926,15 +886,6 @@ wheels = [
 ]
 
 [[package]]
-name = "shellingham"
-version = "1.5.4"
-source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/58/15/8b3609fd3830ef7b27b655beb4b4e9c62313a4e8da8c676e142cc210d58e/shellingham-1.5.4.tar.gz", hash = "sha256:8dbca0739d487e5bd35ab3ca4b36e11c4078f3a234bfce294b0a0291363404de", size = 10310, upload-time = "2023-10-24T04:13:40.426Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/e0/f9/0595336914c5619e5f28a1fb793285925a8cd4b432c9da0a987836c7f822/shellingham-1.5.4-py2.py3-none-any.whl", hash = "sha256:7ecfff8f2fd72616f7481040475a65b2bf8af90a56c89140852d1120324e8686", size = 9755, upload-time = "2023-10-24T04:13:38.866Z" },
-]
-
-[[package]]
 name = "sniffio"
 version = "1.3.1"
 source = { registry = "https://pypi.org/simple" }
@@ -966,21 +917,6 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/1b/3f/507c21db33b66fb027a332f2cb3abbbe924cc3a79ced12f01ed8645955c9/starlette-0.49.1.tar.gz", hash = "sha256:481a43b71e24ed8c43b11ea02f5353d77840e01480881b8cb5a26b8cae64a8cb", size = 2654703, upload-time = "2025-10-28T17:34:10.928Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/51/da/545b75d420bb23b5d494b0517757b351963e974e79933f01e05c929f20a6/starlette-0.49.1-py3-none-any.whl", hash = "sha256:d92ce9f07e4a3caa3ac13a79523bd18e3bc0042bb8ff2d759a8e7dd0e1859875", size = 74175, upload-time = "2025-10-28T17:34:09.13Z" },
-]
-
-[[package]]
-name = "typer"
-version = "0.16.0"
-source = { registry = "https://pypi.org/simple" }
-dependencies = [
-    { name = "click" },
-    { name = "rich" },
-    { name = "shellingham" },
-    { name = "typing-extensions" },
-]
-sdist = { url = "https://files.pythonhosted.org/packages/c5/8c/7d682431efca5fd290017663ea4588bf6f2c6aad085c7f108c5dbc316e70/typer-0.16.0.tar.gz", hash = "sha256:af377ffaee1dbe37ae9440cb4e8f11686ea5ce4e9bae01b84ae7c63b87f1dd3b", size = 102625, upload-time = "2025-05-26T14:30:31.824Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/76/42/3efaf858001d2c2913de7f354563e3a3a2f0decae3efe98427125a8f441e/typer-0.16.0-py3-none-any.whl", hash = "sha256:1f79bed11d4d02d4310e3c1b7ba594183bcedb0ac73b27a9e5f28f6fb5b98855", size = 46317, upload-time = "2025-05-26T14:30:30.523Z" },
 ]
 
 [[package]]

--- a/uv.lock
+++ b/uv.lock
@@ -33,11 +33,11 @@ dev = [
 requires-dist = [
     { name = "black", marker = "extra == 'dev'", specifier = ">=23.0.0" },
     { name = "flake8", marker = "extra == 'dev'", specifier = ">=6.0.0" },
-    { name = "httpx", specifier = ">=0.25.0" },
+    { name = "httpx", specifier = ">=0.27.1" },
     { name = "isort", marker = "extra == 'dev'", specifier = ">=5.12.0" },
     { name = "mcp", extras = ["cli"], specifier = ">=1.9.4" },
     { name = "mypy", marker = "extra == 'dev'", specifier = ">=1.0.0" },
-    { name = "pyjwt", extras = ["crypto"], specifier = ">=2.8.0" },
+    { name = "pyjwt", extras = ["crypto"], specifier = ">=2.10.1" },
     { name = "pytest", marker = "extra == 'dev'", specifier = ">=7.0.0" },
     { name = "pytest-asyncio", marker = "extra == 'dev'", specifier = ">=0.21.0" },
 ]

--- a/uv.lock
+++ b/uv.lock
@@ -10,7 +10,6 @@ dependencies = [
     { name = "httpx" },
     { name = "mcp", extra = ["cli"] },
     { name = "pyjwt", extra = ["crypto"] },
-    { name = "websockets" },
 ]
 
 [package.optional-dependencies]
@@ -41,7 +40,6 @@ requires-dist = [
     { name = "pyjwt", extras = ["crypto"], specifier = ">=2.8.0" },
     { name = "pytest", marker = "extra == 'dev'", specifier = ">=7.0.0" },
     { name = "pytest-asyncio", marker = "extra == 'dev'", specifier = ">=0.21.0" },
-    { name = "websockets", specifier = ">=15.0.1" },
 ]
 provides-extras = ["dev"]
 
@@ -1017,35 +1015,4 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/de/ad/713be230bcda622eaa35c28f0d328c3675c371238470abdea52417f17a8e/uvicorn-0.34.3.tar.gz", hash = "sha256:35919a9a979d7a59334b6b10e05d77c1d0d574c50e0fc98b8b1a0f165708b55a", size = 76631, upload-time = "2025-06-01T07:48:17.531Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/6d/0d/8adfeaa62945f90d19ddc461c55f4a50c258af7662d34b6a3d5d1f8646f6/uvicorn-0.34.3-py3-none-any.whl", hash = "sha256:16246631db62bdfbf069b0645177d6e8a77ba950cfedbfd093acef9444e4d885", size = 62431, upload-time = "2025-06-01T07:48:15.664Z" },
-]
-
-[[package]]
-name = "websockets"
-version = "15.0.1"
-source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/21/e6/26d09fab466b7ca9c7737474c52be4f76a40301b08362eb2dbc19dcc16c1/websockets-15.0.1.tar.gz", hash = "sha256:82544de02076bafba038ce055ee6412d68da13ab47f0c60cab827346de828dee", size = 177016, upload-time = "2025-03-05T20:03:41.606Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/51/6b/4545a0d843594f5d0771e86463606a3988b5a09ca5123136f8a76580dd63/websockets-15.0.1-cp312-cp312-macosx_10_13_universal2.whl", hash = "sha256:3e90baa811a5d73f3ca0bcbf32064d663ed81318ab225ee4f427ad4e26e5aff3", size = 175437, upload-time = "2025-03-05T20:02:16.706Z" },
-    { url = "https://files.pythonhosted.org/packages/f4/71/809a0f5f6a06522af902e0f2ea2757f71ead94610010cf570ab5c98e99ed/websockets-15.0.1-cp312-cp312-macosx_10_13_x86_64.whl", hash = "sha256:592f1a9fe869c778694f0aa806ba0374e97648ab57936f092fd9d87f8bc03665", size = 173096, upload-time = "2025-03-05T20:02:18.832Z" },
-    { url = "https://files.pythonhosted.org/packages/3d/69/1a681dd6f02180916f116894181eab8b2e25b31e484c5d0eae637ec01f7c/websockets-15.0.1-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:0701bc3cfcb9164d04a14b149fd74be7347a530ad3bbf15ab2c678a2cd3dd9a2", size = 173332, upload-time = "2025-03-05T20:02:20.187Z" },
-    { url = "https://files.pythonhosted.org/packages/a6/02/0073b3952f5bce97eafbb35757f8d0d54812b6174ed8dd952aa08429bcc3/websockets-15.0.1-cp312-cp312-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:e8b56bdcdb4505c8078cb6c7157d9811a85790f2f2b3632c7d1462ab5783d215", size = 183152, upload-time = "2025-03-05T20:02:22.286Z" },
-    { url = "https://files.pythonhosted.org/packages/74/45/c205c8480eafd114b428284840da0b1be9ffd0e4f87338dc95dc6ff961a1/websockets-15.0.1-cp312-cp312-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:0af68c55afbd5f07986df82831c7bff04846928ea8d1fd7f30052638788bc9b5", size = 182096, upload-time = "2025-03-05T20:02:24.368Z" },
-    { url = "https://files.pythonhosted.org/packages/14/8f/aa61f528fba38578ec553c145857a181384c72b98156f858ca5c8e82d9d3/websockets-15.0.1-cp312-cp312-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:64dee438fed052b52e4f98f76c5790513235efaa1ef7f3f2192c392cd7c91b65", size = 182523, upload-time = "2025-03-05T20:02:25.669Z" },
-    { url = "https://files.pythonhosted.org/packages/ec/6d/0267396610add5bc0d0d3e77f546d4cd287200804fe02323797de77dbce9/websockets-15.0.1-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:d5f6b181bb38171a8ad1d6aa58a67a6aa9d4b38d0f8c5f496b9e42561dfc62fe", size = 182790, upload-time = "2025-03-05T20:02:26.99Z" },
-    { url = "https://files.pythonhosted.org/packages/02/05/c68c5adbf679cf610ae2f74a9b871ae84564462955d991178f95a1ddb7dd/websockets-15.0.1-cp312-cp312-musllinux_1_2_i686.whl", hash = "sha256:5d54b09eba2bada6011aea5375542a157637b91029687eb4fdb2dab11059c1b4", size = 182165, upload-time = "2025-03-05T20:02:30.291Z" },
-    { url = "https://files.pythonhosted.org/packages/29/93/bb672df7b2f5faac89761cb5fa34f5cec45a4026c383a4b5761c6cea5c16/websockets-15.0.1-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:3be571a8b5afed347da347bfcf27ba12b069d9d7f42cb8c7028b5e98bbb12597", size = 182160, upload-time = "2025-03-05T20:02:31.634Z" },
-    { url = "https://files.pythonhosted.org/packages/ff/83/de1f7709376dc3ca9b7eeb4b9a07b4526b14876b6d372a4dc62312bebee0/websockets-15.0.1-cp312-cp312-win32.whl", hash = "sha256:c338ffa0520bdb12fbc527265235639fb76e7bc7faafbb93f6ba80d9c06578a9", size = 176395, upload-time = "2025-03-05T20:02:33.017Z" },
-    { url = "https://files.pythonhosted.org/packages/7d/71/abf2ebc3bbfa40f391ce1428c7168fb20582d0ff57019b69ea20fa698043/websockets-15.0.1-cp312-cp312-win_amd64.whl", hash = "sha256:fcd5cf9e305d7b8338754470cf69cf81f420459dbae8a3b40cee57417f4614a7", size = 176841, upload-time = "2025-03-05T20:02:34.498Z" },
-    { url = "https://files.pythonhosted.org/packages/cb/9f/51f0cf64471a9d2b4d0fc6c534f323b664e7095640c34562f5182e5a7195/websockets-15.0.1-cp313-cp313-macosx_10_13_universal2.whl", hash = "sha256:ee443ef070bb3b6ed74514f5efaa37a252af57c90eb33b956d35c8e9c10a1931", size = 175440, upload-time = "2025-03-05T20:02:36.695Z" },
-    { url = "https://files.pythonhosted.org/packages/8a/05/aa116ec9943c718905997412c5989f7ed671bc0188ee2ba89520e8765d7b/websockets-15.0.1-cp313-cp313-macosx_10_13_x86_64.whl", hash = "sha256:5a939de6b7b4e18ca683218320fc67ea886038265fd1ed30173f5ce3f8e85675", size = 173098, upload-time = "2025-03-05T20:02:37.985Z" },
-    { url = "https://files.pythonhosted.org/packages/ff/0b/33cef55ff24f2d92924923c99926dcce78e7bd922d649467f0eda8368923/websockets-15.0.1-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:746ee8dba912cd6fc889a8147168991d50ed70447bf18bcda7039f7d2e3d9151", size = 173329, upload-time = "2025-03-05T20:02:39.298Z" },
-    { url = "https://files.pythonhosted.org/packages/31/1d/063b25dcc01faa8fada1469bdf769de3768b7044eac9d41f734fd7b6ad6d/websockets-15.0.1-cp313-cp313-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:595b6c3969023ecf9041b2936ac3827e4623bfa3ccf007575f04c5a6aa318c22", size = 183111, upload-time = "2025-03-05T20:02:40.595Z" },
-    { url = "https://files.pythonhosted.org/packages/93/53/9a87ee494a51bf63e4ec9241c1ccc4f7c2f45fff85d5bde2ff74fcb68b9e/websockets-15.0.1-cp313-cp313-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:3c714d2fc58b5ca3e285461a4cc0c9a66bd0e24c5da9911e30158286c9b5be7f", size = 182054, upload-time = "2025-03-05T20:02:41.926Z" },
-    { url = "https://files.pythonhosted.org/packages/ff/b2/83a6ddf56cdcbad4e3d841fcc55d6ba7d19aeb89c50f24dd7e859ec0805f/websockets-15.0.1-cp313-cp313-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:0f3c1e2ab208db911594ae5b4f79addeb3501604a165019dd221c0bdcabe4db8", size = 182496, upload-time = "2025-03-05T20:02:43.304Z" },
-    { url = "https://files.pythonhosted.org/packages/98/41/e7038944ed0abf34c45aa4635ba28136f06052e08fc2168520bb8b25149f/websockets-15.0.1-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:229cf1d3ca6c1804400b0a9790dc66528e08a6a1feec0d5040e8b9eb14422375", size = 182829, upload-time = "2025-03-05T20:02:48.812Z" },
-    { url = "https://files.pythonhosted.org/packages/e0/17/de15b6158680c7623c6ef0db361da965ab25d813ae54fcfeae2e5b9ef910/websockets-15.0.1-cp313-cp313-musllinux_1_2_i686.whl", hash = "sha256:756c56e867a90fb00177d530dca4b097dd753cde348448a1012ed6c5131f8b7d", size = 182217, upload-time = "2025-03-05T20:02:50.14Z" },
-    { url = "https://files.pythonhosted.org/packages/33/2b/1f168cb6041853eef0362fb9554c3824367c5560cbdaad89ac40f8c2edfc/websockets-15.0.1-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:558d023b3df0bffe50a04e710bc87742de35060580a293c2a984299ed83bc4e4", size = 182195, upload-time = "2025-03-05T20:02:51.561Z" },
-    { url = "https://files.pythonhosted.org/packages/86/eb/20b6cdf273913d0ad05a6a14aed4b9a85591c18a987a3d47f20fa13dcc47/websockets-15.0.1-cp313-cp313-win32.whl", hash = "sha256:ba9e56e8ceeeedb2e080147ba85ffcd5cd0711b89576b83784d8605a7df455fa", size = 176393, upload-time = "2025-03-05T20:02:53.814Z" },
-    { url = "https://files.pythonhosted.org/packages/1b/6c/c65773d6cab416a64d191d6ee8a8b1c68a09970ea6909d16965d26bfed1e/websockets-15.0.1-cp313-cp313-win_amd64.whl", hash = "sha256:e09473f095a819042ecb2ab9465aee615bd9c2028e4ef7d933600a8401c79561", size = 176837, upload-time = "2025-03-05T20:02:55.237Z" },
-    { url = "https://files.pythonhosted.org/packages/fa/a8/5b41e0da817d64113292ab1f8247140aac61cbf6cfd085d6a0fa77f4984f/websockets-15.0.1-py3-none-any.whl", hash = "sha256:f7a866fbc1e97b5c617ee4116daaa09b722101d4a3c170c787450ba409f9736f", size = 169743, upload-time = "2025-03-05T20:03:39.41Z" },
 ]


### PR DESCRIPTION
## Summary

- Remove `websockets` dependency — never imported anywhere in the codebase; only a stale version string remained in the `MCP_USER_AGENT` header
- Drop `mcp[cli]` extra — `typer`, `shellingham`, `rich`, `markdown-it-py`, `mdurl` are only needed for `mcp dev`/`mcp run` CLI commands which this project does not use; all transports (stdio, SSE, streamable-http) run via `FastMCP.run()` / `anyio` directly
- Tighten `httpx` lower bound from `>=0.25.0` to `>=0.27.1` to match what `mcp` already requires transitively
- Tighten `PyJWT[crypto]` lower bound from `>=2.8.0` to `>=2.10.1` to match what `mcp` already requires transitively

## Packages removed from uv.lock

`websockets`, `typer`, `shellingham`, `rich`, `markdown-it-py`, `mdurl` — 6 packages total

## Test plan

- [x] All utils imports verified (`utils.common`, `utils.auth`, `utils.http_client`, etc.)
- [x] 509/510 tests pass (1 pre-existing failure unrelated to this change — import path collision when running pytest from a directory named `main`)
- [x] `uv lock` resolves cleanly with 52 packages