### PR TITLE
ci: upgrade docker/build-push-action v6 to v7

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -45,7 +45,7 @@ jobs:
             type=raw,value=latest,enable=${{ github.event_name == 'push' }}
 
       - name: Build and push
-        uses: docker/build-push-action@v6
+        uses: docker/build-push-action@v7
         with:
           context: .
           push: true


### PR DESCRIPTION
## Summary
- Bump `docker/build-push-action` from `v6` to `v7` in `.github/workflows/docker.yml`.
- The `@v6` tag is still pinned to the `node20` runtime; `@v7` (latest `v7.1.0`) runs on `node24`.
- This is the only remaining action in this repo still on `node20`. After this change, every Node-based action in the project runs on `node24`, aligning the toolchain with GitHub's Node 20 deprecation timeline.

## Action runtime audit (post-merge state)

| Action | Version | Runtime |
|---|---|---|
| `actions/checkout` | v6 | node24 |
| `actions/setup-python` | v6 | node24 |
| `actions/upload-artifact` | v6 | node24 |
| `actions/download-artifact` | v7 | node24 |
| `astral-sh/setup-uv` | v8.1.0 | node24 |
| `docker/setup-buildx-action` | v4 | node24 |
| `docker/login-action` | v4 | node24 |
| `docker/metadata-action` | v6 | node24 |
| `docker/build-push-action` | **v7** | **node24** |
| `benc-uk/workflow-dispatch` | v1.3.1 | node24 |
| `pypa/gh-action-pypi-publish` | release/v1 | composite (n/a) |

## Test plan

The `Docker` workflow has two triggers (see `docker.yml:4-10`):
- `workflow_run` on `main` after the `Test` workflow completes successfully (dev image path).
- `push` on version tags `v*.*.*` (prod image path).

- [ ] After this PR merges to `main`, the `Test` workflow succeeds → `Docker` workflow runs via `workflow_run` and the `Build and push` step completes successfully on `docker/build-push-action@v7`.
- [ ] Resulting dev image is pushed to Docker Hub with the expected tags from `docker/metadata-action` (`<DOCKER_IMAGE>-dev:<head_sha>`).
- [ ] `deploy-dev` job continues to dispatch `image-tag-update-pr.yaml` against `alpacax/alpacon-gitops` with `env: dev`.
- [ ] Pushing a `v*.*.*` tag triggers the `Docker` workflow via the `push` trigger and produces a prod image tagged `<version>` and `latest`.
- [ ] `deploy-prod` job continues to dispatch `image-tag-update-pr.yaml` against `alpacax/alpacon-gitops` with `env: prod`.
- [ ] No regression in GHA cache behavior (`cache-from: type=gha`, `cache-to: type=gha,mode=max`).