### PR TITLE
ci: replace DEPLOY_ACTIONS_TRIGGER_TOKEN PAT with alpacax-deploy-dispatcher App

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -11,7 +11,6 @@ on:
 
 permissions:
   contents: read
-  actions: write
 
 jobs:
   build-and-push:
@@ -61,13 +60,27 @@ jobs:
     runs-on: ubuntu-latest
     environment: dev
     steps:
+      # Inline App token mint instead of shared-ci wrapper:
+      # alpacon-mcp is public; shared-ci is Internal so public callers
+      # cannot resolve `uses: alpacax/shared-ci/...`. Mirror the wrapper
+      # logic here (App token + workflow-dispatch).
+      - name: Generate App token
+        id: app-token
+        uses: actions/create-github-app-token@v1
+        with:
+          app-id: ${{ secrets.DEPLOY_DISPATCHER_APP_ID }}
+          private-key: ${{ secrets.DEPLOY_DISPATCHER_PRIVATE_KEY }}
+          owner: alpacax
+          repositories: alpacon-gitops
+          permission-actions: write
+
       - name: Trigger dev deployment
         uses: benc-uk/workflow-dispatch@v1.3.1
         with:
           workflow: image-tag-update-pr.yaml
           repo: alpacax/alpacon-gitops
           ref: main
-          token: ${{ secrets.DEPLOY_ACTIONS_TRIGGER_TOKEN }}
+          token: ${{ steps.app-token.outputs.token }}
           inputs: '{"tag": "${{ github.event.workflow_run.head_sha }}", "service": "alpacon-mcp", "env": "dev", "job": "update_image_tag"}'
 
   deploy-prod:
@@ -76,11 +89,21 @@ jobs:
     runs-on: ubuntu-latest
     environment: prod
     steps:
+      - name: Generate App token
+        id: app-token
+        uses: actions/create-github-app-token@v1
+        with:
+          app-id: ${{ secrets.DEPLOY_DISPATCHER_APP_ID }}
+          private-key: ${{ secrets.DEPLOY_DISPATCHER_PRIVATE_KEY }}
+          owner: alpacax
+          repositories: alpacon-gitops
+          permission-actions: write
+
       - name: Trigger prod deployment
         uses: benc-uk/workflow-dispatch@v1.3.1
         with:
           workflow: image-tag-update-pr.yaml
           repo: alpacax/alpacon-gitops
           ref: main
-          token: ${{ secrets.DEPLOY_ACTIONS_TRIGGER_TOKEN }}
+          token: ${{ steps.app-token.outputs.token }}
           inputs: '{"tag": "${{ github.ref_name }}", "service": "alpacon-mcp", "env": "prod", "job": "update_image_tag"}'


### PR DESCRIPTION
## Summary

Replace the `alpacax-gh-bot` `DEPLOY_ACTIONS_TRIGGER_TOKEN` PAT with a short-lived `alpacax-deploy-dispatcher` GitHub App installation token, minted inline before each dispatch.

Part of the cross-repo DEPLOY_ACTIONS_TRIGGER_TOKEN migration. Pilot verified on [alpacon-web#1201](https://github.com/alpacax/alpacon-web/pull/1201).

## Why inline (and not the shared-ci wrapper)

`alpacon-mcp` is public visibility, while `alpacax/shared-ci` is Internal. GitHub re-evaluates caller -> action visibility on every `uses:`, so a public caller cannot resolve an Internal action. The two dispatch jobs therefore inline the wrapper logic (`actions/create-github-app-token@v1` + `benc-uk/workflow-dispatch`). The same constraint already applied to `docker/login-action` (PR #93).

## Changes

- `docker.yml` `deploy-dev` job: add inline App token mint -> use App token for dispatch
- `docker.yml` `deploy-prod` job: same pattern
- Drop the workflow-level `actions: write` GITHUB_TOKEN scope. The App token now carries that scope explicitly, and the workflow convention is to keep `contents: read` at workflow level and add extra scopes at job level only

## Test plan

- [ ] merge to main triggers `Docker` workflow -> `deploy-dev` dispatches `alpacon-gitops/image-tag-update-pr.yaml` as `alpacax-deploy-dispatcher[bot]`
- [ ] next tag push triggers `deploy-prod` -> same identity, env=prod