### PR TITLE
feat(work-sessions): add Work Session MCP tools and link commands/transfers to sessions

### DIFF
--- a/server.py
+++ b/server.py
@@ -283,6 +283,7 @@ def run(
     import tools.system_info_tools  # noqa: F401
     import tools.webftp_tools  # noqa: F401
     import tools.webhook_tools  # noqa: F401
+    import tools.work_session_tools  # noqa: F401
     import tools.workspace_tools  # noqa: F401
 
     # In remote mode, wrap the Starlette app with upstream auth error

--- a/tests/test_command_tools.py
+++ b/tests/test_command_tools.py
@@ -381,8 +381,6 @@ class TestSubmitCommandWithSession:
 
 
 class TestExecuteCommandWithSession:
-    """Test execute_command session_id and ALPACON_MCP_REQUIRE_SESSION."""
-
     @pytest.mark.asyncio
     async def test_execute_command_passes_session_id(
         self, mock_http_client, mock_token_manager
@@ -406,49 +404,6 @@ class TestExecuteCommandWithSession:
 
         call_data = mock_http_client.post.call_args[1]['data']
         assert call_data['work_session'] == 'ws-uuid-abcd'
-
-    @pytest.mark.asyncio
-    async def test_execute_command_require_session_enforced(
-        self, mock_http_client, mock_token_manager, monkeypatch
-    ):
-        from tools.command_tools import execute_command
-
-        monkeypatch.setenv('ALPACON_MCP_REQUIRE_SESSION', 'true')
-
-        result = await execute_command(
-            server_id='550e8400-e29b-41d4-a716-446655440001',
-            command='ls',
-            workspace='testworkspace',
-            region='ap1',
-        )
-
-        assert result['status'] == 'error'
-        assert 'session_id' in result['message']
-        mock_http_client.post.assert_not_called()
-
-    @pytest.mark.asyncio
-    async def test_execute_command_require_session_passes_when_provided(
-        self, mock_http_client, mock_token_manager, monkeypatch
-    ):
-        from tools.command_tools import execute_command
-
-        monkeypatch.setenv('ALPACON_MCP_REQUIRE_SESSION', 'true')
-        mock_http_client.post.return_value = {'id': 'cmd-999'}
-        mock_http_client.get.return_value = {
-            'id': 'cmd-999',
-            'finished_at': '2026-05-19T10:00:00Z',
-            'status': 'completed',
-        }
-
-        result = await execute_command(
-            server_id='550e8400-e29b-41d4-a716-446655440001',
-            command='ls',
-            workspace='testworkspace',
-            session_id='ws-uuid-abcd',
-            region='ap1',
-        )
-
-        assert result['status'] == 'success'
 
 
 class TestExecuteCommandMultiServerWithSession:

--- a/tests/test_command_tools.py
+++ b/tests/test_command_tools.py
@@ -402,7 +402,7 @@ class TestExecuteCommandWithSession:
             server_id='550e8400-e29b-41d4-a716-446655440001',
             command='ls',
             workspace='testworkspace',
-            session_id='ws-uuid-abcd',
+            work_session_id='ws-uuid-abcd',
             region='ap1',
         )
 
@@ -422,7 +422,7 @@ class TestExecuteCommandMultiServerWithSession:
             server_ids=['550e8400-e29b-41d4-a716-446655440001'],
             command='ls',
             workspace='testworkspace',
-            session_id='ws-uuid-abcd',
+            work_session_id='ws-uuid-abcd',
             region='ap1',
         )
 

--- a/tests/test_command_tools.py
+++ b/tests/test_command_tools.py
@@ -156,6 +156,21 @@ class TestListCommands:
         assert result['status'] == 'error'
         assert 'No token found' in result['message']
 
+    @pytest.mark.asyncio
+    async def test_list_commands_http_error(self, mock_http_client, mock_token_manager):
+        from tools.command_tools import list_commands
+
+        mock_http_client.get.return_value = {
+            'error': 'Forbidden',
+            'message': 'Permission denied',
+            'status_code': 403,
+        }
+
+        result = await list_commands(workspace='testworkspace', region='ap1')
+
+        assert result['status'] == 'error'
+        assert 'Permission denied' in result['message']
+
 
 class TestExecuteCommand:
     """Test execute_command function (renamed from execute_command_sync)."""

--- a/tests/test_command_tools.py
+++ b/tests/test_command_tools.py
@@ -339,3 +339,134 @@ class TestExecuteCommand:
 
         assert result['status'] == 'error'
         assert 'No token found' in result['message']
+
+
+class TestSubmitCommandWithSession:
+    """Test _submit_command forwards work_session to API payload."""
+
+    @pytest.mark.asyncio
+    async def test_submit_includes_work_session_when_provided(self, mock_http_client):
+        from tools.command_tools import _submit_command
+
+        mock_http_client.post.return_value = {'id': 'cmd-ws-001'}
+
+        await _submit_command(
+            server_id='550e8400-e29b-41d4-a716-446655440001',
+            command='ls',
+            workspace='testworkspace',
+            work_session_id='ws-uuid-abcd',
+            region='ap1',
+            token='test-token',
+        )
+
+        call_data = mock_http_client.post.call_args[1]['data']
+        assert call_data['work_session'] == 'ws-uuid-abcd'
+
+    @pytest.mark.asyncio
+    async def test_submit_omits_work_session_when_none(self, mock_http_client):
+        from tools.command_tools import _submit_command
+
+        mock_http_client.post.return_value = {'id': 'cmd-ws-002'}
+
+        await _submit_command(
+            server_id='550e8400-e29b-41d4-a716-446655440001',
+            command='ls',
+            workspace='testworkspace',
+            region='ap1',
+            token='test-token',
+        )
+
+        call_data = mock_http_client.post.call_args[1]['data']
+        assert 'work_session' not in call_data
+
+
+class TestExecuteCommandWithSession:
+    """Test execute_command session_id and ALPACON_MCP_REQUIRE_SESSION."""
+
+    @pytest.mark.asyncio
+    async def test_execute_command_passes_session_id(
+        self, mock_http_client, mock_token_manager
+    ):
+        from tools.command_tools import execute_command
+
+        mock_http_client.post.return_value = {'id': 'cmd-123'}
+        mock_http_client.get.return_value = {
+            'id': 'cmd-123',
+            'finished_at': '2026-05-19T10:00:00Z',
+            'status': 'completed',
+        }
+
+        await execute_command(
+            server_id='550e8400-e29b-41d4-a716-446655440001',
+            command='ls',
+            workspace='testworkspace',
+            session_id='ws-uuid-abcd',
+            region='ap1',
+        )
+
+        call_data = mock_http_client.post.call_args[1]['data']
+        assert call_data['work_session'] == 'ws-uuid-abcd'
+
+    @pytest.mark.asyncio
+    async def test_execute_command_require_session_enforced(
+        self, mock_http_client, mock_token_manager, monkeypatch
+    ):
+        from tools.command_tools import execute_command
+
+        monkeypatch.setenv('ALPACON_MCP_REQUIRE_SESSION', 'true')
+
+        result = await execute_command(
+            server_id='550e8400-e29b-41d4-a716-446655440001',
+            command='ls',
+            workspace='testworkspace',
+            region='ap1',
+        )
+
+        assert result['status'] == 'error'
+        assert 'session_id' in result['message']
+        mock_http_client.post.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_execute_command_require_session_passes_when_provided(
+        self, mock_http_client, mock_token_manager, monkeypatch
+    ):
+        from tools.command_tools import execute_command
+
+        monkeypatch.setenv('ALPACON_MCP_REQUIRE_SESSION', 'true')
+        mock_http_client.post.return_value = {'id': 'cmd-999'}
+        mock_http_client.get.return_value = {
+            'id': 'cmd-999',
+            'finished_at': '2026-05-19T10:00:00Z',
+            'status': 'completed',
+        }
+
+        result = await execute_command(
+            server_id='550e8400-e29b-41d4-a716-446655440001',
+            command='ls',
+            workspace='testworkspace',
+            session_id='ws-uuid-abcd',
+            region='ap1',
+        )
+
+        assert result['status'] == 'success'
+
+
+class TestExecuteCommandMultiServerWithSession:
+    @pytest.mark.asyncio
+    async def test_multi_server_passes_session_id(
+        self, mock_http_client, mock_token_manager
+    ):
+        from tools.command_tools import execute_command_multi_server
+
+        mock_http_client.post.return_value = {'id': 'cmd-multi-1'}
+
+        await execute_command_multi_server(
+            server_ids=['550e8400-e29b-41d4-a716-446655440001'],
+            command='ls',
+            workspace='testworkspace',
+            session_id='ws-uuid-abcd',
+            region='ap1',
+        )
+
+        call_data = mock_http_client.post.call_args[1]['data']
+        assert call_data['work_session'] == 'ws-uuid-abcd'

--- a/tests/test_command_tools.py
+++ b/tests/test_command_tools.py
@@ -4,6 +4,13 @@ from unittest.mock import AsyncMock, patch
 
 import pytest
 
+from tools.command_tools import (
+    _submit_command,
+    execute_command,
+    execute_command_multi_server,
+    list_commands,
+)
+
 
 @pytest.fixture
 def mock_http_client():
@@ -27,7 +34,6 @@ class TestSubmitCommand:
 
     @pytest.mark.asyncio
     async def test_submit_basic(self, mock_http_client):
-        from tools.command_tools import _submit_command
 
         mock_http_client.post.return_value = {'id': 'cmd-123', 'status': 'running'}
 
@@ -55,7 +61,6 @@ class TestSubmitCommand:
 
     @pytest.mark.asyncio
     async def test_submit_with_optional_params(self, mock_http_client):
-        from tools.command_tools import _submit_command
 
         mock_http_client.post.return_value = {'id': 'cmd-456'}
 
@@ -81,7 +86,6 @@ class TestSubmitCommand:
 
     @pytest.mark.asyncio
     async def test_submit_omits_none_params(self, mock_http_client):
-        from tools.command_tools import _submit_command
 
         mock_http_client.post.return_value = {'id': 'cmd-789'}
 
@@ -104,7 +108,6 @@ class TestListCommands:
 
     @pytest.mark.asyncio
     async def test_list_commands_success(self, mock_http_client, mock_token_manager):
-        from tools.command_tools import list_commands
 
         mock_http_client.get.return_value = {
             'count': 2,
@@ -130,7 +133,6 @@ class TestListCommands:
     async def test_list_commands_with_server_filter(
         self, mock_http_client, mock_token_manager
     ):
-        from tools.command_tools import list_commands
 
         mock_http_client.get.return_value = {'count': 1, 'results': []}
 
@@ -147,7 +149,6 @@ class TestListCommands:
 
     @pytest.mark.asyncio
     async def test_list_commands_no_token(self, mock_http_client, mock_token_manager):
-        from tools.command_tools import list_commands
 
         mock_token_manager.get_token.return_value = None
 
@@ -158,7 +159,6 @@ class TestListCommands:
 
     @pytest.mark.asyncio
     async def test_list_commands_http_error(self, mock_http_client, mock_token_manager):
-        from tools.command_tools import list_commands
 
         mock_http_client.get.return_value = {
             'error': 'Forbidden',
@@ -177,7 +177,6 @@ class TestExecuteCommand:
 
     @pytest.mark.asyncio
     async def test_success(self, mock_http_client, mock_token_manager):
-        from tools.command_tools import execute_command
 
         with (
             patch('tools.command_tools._submit_command') as mock_submit,
@@ -204,7 +203,6 @@ class TestExecuteCommand:
 
     @pytest.mark.asyncio
     async def test_array_response(self, mock_http_client, mock_token_manager):
-        from tools.command_tools import execute_command
 
         with (
             patch('tools.command_tools._submit_command') as mock_submit,
@@ -227,7 +225,6 @@ class TestExecuteCommand:
 
     @pytest.mark.asyncio
     async def test_timeout(self, mock_http_client, mock_token_manager):
-        from tools.command_tools import execute_command
 
         with (
             patch('tools.command_tools._submit_command') as mock_submit,
@@ -253,7 +250,6 @@ class TestExecuteCommand:
 
     @pytest.mark.asyncio
     async def test_acl_error(self, mock_http_client, mock_token_manager):
-        from tools.command_tools import execute_command
 
         with patch('tools.command_tools._submit_command') as mock_submit:
             mock_submit.return_value = {
@@ -272,7 +268,6 @@ class TestExecuteCommand:
 
     @pytest.mark.asyncio
     async def test_empty_data_array(self, mock_http_client, mock_token_manager):
-        from tools.command_tools import execute_command
 
         with patch('tools.command_tools._submit_command') as mock_submit:
             mock_submit.return_value = []
@@ -288,7 +283,6 @@ class TestExecuteCommand:
 
     @pytest.mark.asyncio
     async def test_stuck_status(self, mock_http_client, mock_token_manager):
-        from tools.command_tools import execute_command
 
         with (
             patch('tools.command_tools._submit_command') as mock_submit,
@@ -313,7 +307,6 @@ class TestExecuteCommand:
 
     @pytest.mark.asyncio
     async def test_forwards_all_params(self, mock_http_client, mock_token_manager):
-        from tools.command_tools import execute_command
 
         with (
             patch('tools.command_tools._submit_command') as mock_submit,
@@ -342,7 +335,6 @@ class TestExecuteCommand:
 
     @pytest.mark.asyncio
     async def test_no_token(self, mock_http_client, mock_token_manager):
-        from tools.command_tools import execute_command
 
         mock_token_manager.get_token.return_value = None
 
@@ -361,7 +353,6 @@ class TestSubmitCommandWithSession:
 
     @pytest.mark.asyncio
     async def test_submit_includes_work_session_when_provided(self, mock_http_client):
-        from tools.command_tools import _submit_command
 
         mock_http_client.post.return_value = {'id': 'cmd-ws-001'}
 
@@ -379,7 +370,6 @@ class TestSubmitCommandWithSession:
 
     @pytest.mark.asyncio
     async def test_submit_omits_work_session_when_none(self, mock_http_client):
-        from tools.command_tools import _submit_command
 
         mock_http_client.post.return_value = {'id': 'cmd-ws-002'}
 
@@ -400,7 +390,6 @@ class TestExecuteCommandWithSession:
     async def test_execute_command_passes_session_id(
         self, mock_http_client, mock_token_manager
     ):
-        from tools.command_tools import execute_command
 
         mock_http_client.post.return_value = {'id': 'cmd-123'}
         mock_http_client.get.return_value = {
@@ -426,7 +415,6 @@ class TestExecuteCommandMultiServerWithSession:
     async def test_multi_server_passes_session_id(
         self, mock_http_client, mock_token_manager
     ):
-        from tools.command_tools import execute_command_multi_server
 
         mock_http_client.post.return_value = {'id': 'cmd-multi-1'}
 

--- a/tests/test_webftp_tools.py
+++ b/tests/test_webftp_tools.py
@@ -1513,7 +1513,7 @@ class TestWebFtpUploadContentWithSession:
             file_content=content_b64,
             remote_file_path='/home/user/hello.txt',
             workspace='testworkspace',
-            session_id='ws-uuid-abcd',
+            work_session_id='ws-uuid-abcd',
             region='ap1',
         )
 

--- a/tests/test_webftp_tools.py
+++ b/tests/test_webftp_tools.py
@@ -1472,7 +1472,7 @@ class TestWebFtpSessionCreateWithSession:
         await webftp_session_create(
             server_id='550e8400-e29b-41d4-a716-446655440001',
             workspace='testworkspace',
-            session_id='ws-uuid-abcd',
+            work_session_id='ws-uuid-abcd',
             region='ap1',
         )
 

--- a/tests/test_webftp_tools.py
+++ b/tests/test_webftp_tools.py
@@ -1465,7 +1465,6 @@ class TestWebFtpSessionCreateWithSession:
     async def test_session_create_includes_work_session(
         self, mock_http_client, mock_token_manager
     ):
-        from tools.webftp_tools import webftp_session_create
 
         mock_http_client.post.return_value = {'id': 'ftp-sess-001', 'status': 'active'}
 
@@ -1483,7 +1482,6 @@ class TestWebFtpSessionCreateWithSession:
     async def test_session_create_omits_work_session_when_none(
         self, mock_http_client, mock_token_manager
     ):
-        from tools.webftp_tools import webftp_session_create
 
         mock_http_client.post.return_value = {'id': 'ftp-sess-002', 'status': 'active'}
 
@@ -1502,7 +1500,6 @@ class TestWebFtpUploadContentWithSession:
     async def test_upload_content_includes_work_session(
         self, mock_http_client, mock_token_manager
     ):
-        from tools.webftp_tools import webftp_upload_content
 
         mock_http_client.post.return_value = {
             'id': 'upload-001',
@@ -1527,7 +1524,6 @@ class TestWebFtpUploadContentWithSession:
     async def test_upload_content_omits_work_session_when_none(
         self, mock_http_client, mock_token_manager
     ):
-        from tools.webftp_tools import webftp_upload_content
 
         mock_http_client.post.return_value = {'id': 'upload-002', 'upload_url': None}
 

--- a/tests/test_webftp_tools.py
+++ b/tests/test_webftp_tools.py
@@ -1509,8 +1509,6 @@ class TestWebFtpUploadContentWithSession:
             'upload_url': None,
         }
 
-        import base64
-
         content_b64 = base64.b64encode(b'hello world').decode()
 
         await webftp_upload_content(
@@ -1532,8 +1530,6 @@ class TestWebFtpUploadContentWithSession:
         from tools.webftp_tools import webftp_upload_content
 
         mock_http_client.post.return_value = {'id': 'upload-002', 'upload_url': None}
-
-        import base64
 
         content_b64 = base64.b64encode(b'hello').decode()
 

--- a/tests/test_webftp_tools.py
+++ b/tests/test_webftp_tools.py
@@ -1390,5 +1390,94 @@ class TestEnsureParentDir:
             mock_path_cls.assert_not_called()
 
 
+class TestWebFtpSessionCreateWithSession:
+    @pytest.mark.asyncio
+    async def test_session_create_includes_work_session(
+        self, mock_http_client, mock_token_manager
+    ):
+        from tools.webftp_tools import webftp_session_create
+
+        mock_http_client.post.return_value = {'id': 'ftp-sess-001', 'status': 'active'}
+
+        await webftp_session_create(
+            server_id='550e8400-e29b-41d4-a716-446655440001',
+            workspace='testworkspace',
+            session_id='ws-uuid-abcd',
+            region='ap1',
+        )
+
+        call_data = mock_http_client.post.call_args[1]['data']
+        assert call_data['work_session'] == 'ws-uuid-abcd'
+
+    @pytest.mark.asyncio
+    async def test_session_create_omits_work_session_when_none(
+        self, mock_http_client, mock_token_manager
+    ):
+        from tools.webftp_tools import webftp_session_create
+
+        mock_http_client.post.return_value = {'id': 'ftp-sess-002', 'status': 'active'}
+
+        await webftp_session_create(
+            server_id='550e8400-e29b-41d4-a716-446655440001',
+            workspace='testworkspace',
+            region='ap1',
+        )
+
+        call_data = mock_http_client.post.call_args[1]['data']
+        assert 'work_session' not in call_data
+
+
+class TestWebFtpUploadContentWithSession:
+    @pytest.mark.asyncio
+    async def test_upload_content_includes_work_session(
+        self, mock_http_client, mock_token_manager
+    ):
+        from tools.webftp_tools import webftp_upload_content
+
+        mock_http_client.post.return_value = {
+            'id': 'upload-001',
+            'upload_url': None,
+        }
+
+        import base64
+
+        content_b64 = base64.b64encode(b'hello world').decode()
+
+        await webftp_upload_content(
+            server_id='550e8400-e29b-41d4-a716-446655440001',
+            file_content=content_b64,
+            remote_file_path='/home/user/hello.txt',
+            workspace='testworkspace',
+            session_id='ws-uuid-abcd',
+            region='ap1',
+        )
+
+        call_data = mock_http_client.post.call_args[1]['data']
+        assert call_data['work_session'] == 'ws-uuid-abcd'
+
+    @pytest.mark.asyncio
+    async def test_upload_content_omits_work_session_when_none(
+        self, mock_http_client, mock_token_manager
+    ):
+        from tools.webftp_tools import webftp_upload_content
+
+        mock_http_client.post.return_value = {'id': 'upload-002', 'upload_url': None}
+
+        import base64
+
+        content_b64 = base64.b64encode(b'hello').decode()
+
+        await webftp_upload_content(
+            server_id='550e8400-e29b-41d4-a716-446655440001',
+            file_content=content_b64,
+            remote_file_path='/home/user/hello.txt',
+            workspace='testworkspace',
+            region='ap1',
+        )
+
+        call_data = mock_http_client.post.call_args[1]['data']
+        assert 'work_session' not in call_data
+
+
 if __name__ == '__main__':
     pytest.main([__file__, '-v'])

--- a/tests/test_webftp_tools.py
+++ b/tests/test_webftp_tools.py
@@ -20,6 +20,7 @@ from tools.webftp_tools import (
     _save_stream,
     webftp_bulk_download,
     webftp_bulk_upload,
+    webftp_check_status,
     webftp_download_file,
     webftp_downloads_list,
     webftp_session_create,
@@ -227,6 +228,19 @@ class TestWebFtpSessionsList:
         assert result['status'] == _STATUS_ERROR
         assert 'No token found' in result['message']
         mock_http_client.get.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_sessions_list_http_error(self, mock_http_client, mock_token_manager):
+        mock_http_client.get.return_value = {
+            'error': 'Forbidden',
+            'message': 'Permission denied',
+            'status_code': 403,
+        }
+
+        result = await webftp_sessions_list(workspace='testworkspace', region='ap1')
+
+        assert result['status'] == _STATUS_ERROR
+        assert 'Permission denied' in result['message']
 
 
 class TestWebFtpUploadFile:
@@ -716,6 +730,62 @@ class TestWebFtpDownloadsList:
 
         assert result['status'] == _STATUS_ERROR
         assert 'HTTP 500' in result['message']
+
+
+class TestWebFtpCheckStatus:
+    @pytest.mark.asyncio
+    async def test_check_status_upload_success(
+        self, mock_http_client, mock_token_manager
+    ):
+        mock_http_client.get.return_value = {
+            'id': 'file-123',
+            'status': 'completed',
+            'file_path': '/home/user/file.txt',
+        }
+
+        result = await webftp_check_status(
+            file_id='file-123',
+            transfer_type='upload',
+            workspace='testworkspace',
+            region='ap1',
+        )
+
+        assert result['status'] == 'success'
+        assert result['file_id'] == 'file-123'
+        assert result['transfer_type'] == 'upload'
+
+    @pytest.mark.asyncio
+    async def test_check_status_invalid_transfer_type(
+        self, mock_http_client, mock_token_manager
+    ):
+        result = await webftp_check_status(
+            file_id='file-123',
+            transfer_type='invalid',
+            workspace='testworkspace',
+            region='ap1',
+        )
+
+        assert result['status'] == _STATUS_ERROR
+        assert 'Invalid transfer_type' in result['message']
+        mock_http_client.get.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_check_status_http_error(self, mock_http_client, mock_token_manager):
+        mock_http_client.get.return_value = {
+            'error': 'Not found',
+            'message': 'File not found',
+            'status_code': 404,
+        }
+
+        result = await webftp_check_status(
+            file_id='file-nonexistent',
+            transfer_type='download',
+            workspace='testworkspace',
+            region='ap1',
+        )
+
+        assert result['status'] == _STATUS_ERROR
+        assert 'File not found' in result['message']
 
 
 class TestWebFtpBulkUpload:

--- a/tests/test_work_session_tools.py
+++ b/tests/test_work_session_tools.py
@@ -36,6 +36,7 @@ class TestWorkSessionCreate:
             scopes=['command'],
             servers=['550e8400-e29b-41d4-a716-446655440001'],
             expires_at='2026-05-19T13:00:00+00:00',
+            description='Fix nginx config',
             region='ap1',
         )
 
@@ -51,6 +52,7 @@ class TestWorkSessionCreate:
                 'scopes': ['command'],
                 'servers': ['550e8400-e29b-41d4-a716-446655440001'],
                 'expires_at': '2026-05-19T13:00:00+00:00',
+                'description': 'Fix nginx config',
             },
         )
 
@@ -79,9 +81,7 @@ class TestWorkSessionCreate:
         assert 'auth_method' not in call_data
 
     @pytest.mark.asyncio
-    async def test_create_omits_empty_title_and_description(
-        self, mock_http_client, mock_token_manager
-    ):
+    async def test_create_omits_empty_title(self, mock_http_client, mock_token_manager):
         from tools.work_session_tools import work_session_create
 
         mock_http_client.post.return_value = {'id': 'ws-uuid-0000', 'status': 'pending'}
@@ -91,12 +91,13 @@ class TestWorkSessionCreate:
             scopes=['command'],
             servers=['550e8400-e29b-41d4-a716-446655440001'],
             expires_at='2026-05-19T13:00:00+00:00',
+            description='Routine maintenance',
             region='ap1',
         )
 
         call_data = mock_http_client.post.call_args[1]['data']
         assert 'title' not in call_data
-        assert 'description' not in call_data
+        assert call_data['description'] == 'Routine maintenance'
 
 
 class TestWorkSessionClose:
@@ -189,3 +190,19 @@ class TestWorkSessionList:
 
         call_params = mock_http_client.get.call_args[1]['params']
         assert call_params['status'] == 'active'
+
+    @pytest.mark.asyncio
+    async def test_list_with_auth_method_filter(
+        self, mock_http_client, mock_token_manager
+    ):
+        from tools.work_session_tools import work_session_list
+
+        mock_http_client.get.return_value = {'count': 1, 'results': []}
+
+        await work_session_list(
+            workspace='testworkspace', auth_method='mcp_oauth', region='ap1'
+        )
+
+        call_params = mock_http_client.get.call_args[1]['params']
+        assert call_params['auth_method'] == 'mcp_oauth'
+        assert 'status' not in call_params

--- a/tests/test_work_session_tools.py
+++ b/tests/test_work_session_tools.py
@@ -152,6 +152,25 @@ class TestWorkSessionGet:
             token='test-token',
         )
 
+    @pytest.mark.asyncio
+    async def test_get_propagates_api_error(self, mock_http_client, mock_token_manager):
+        from tools.work_session_tools import work_session_get
+
+        mock_http_client.get.return_value = {
+            'error': 'Not found',
+            'message': 'Work Session not found',
+            'status_code': 404,
+        }
+
+        result = await work_session_get(
+            session_id='ws-nonexistent',
+            workspace='testworkspace',
+            region='ap1',
+        )
+
+        assert result['status'] == 'error'
+        assert 'Work Session not found' in result['message']
+
 
 class TestWorkSessionList:
     @pytest.mark.asyncio
@@ -206,3 +225,20 @@ class TestWorkSessionList:
         call_params = mock_http_client.get.call_args[1]['params']
         assert call_params['auth_method'] == 'mcp_oauth'
         assert 'status' not in call_params
+
+    @pytest.mark.asyncio
+    async def test_list_propagates_api_error(
+        self, mock_http_client, mock_token_manager
+    ):
+        from tools.work_session_tools import work_session_list
+
+        mock_http_client.get.return_value = {
+            'error': 'Forbidden',
+            'message': 'Permission denied',
+            'status_code': 403,
+        }
+
+        result = await work_session_list(workspace='testworkspace', region='ap1')
+
+        assert result['status'] == 'error'
+        assert 'Permission denied' in result['message']

--- a/tests/test_work_session_tools.py
+++ b/tests/test_work_session_tools.py
@@ -1,0 +1,191 @@
+"""Unit tests for work_session_tools module."""
+
+from unittest.mock import AsyncMock, patch
+
+import pytest
+
+
+@pytest.fixture
+def mock_http_client():
+    with patch('tools.work_session_tools.http_client') as mock_client:
+        mock_client.get = AsyncMock()
+        mock_client.post = AsyncMock()
+        yield mock_client
+
+
+@pytest.fixture
+def mock_token_manager():
+    with patch('utils.common.token_manager') as mock_manager:
+        mock_manager.get_token.return_value = 'test-token'
+        yield mock_manager
+
+
+class TestWorkSessionCreate:
+    @pytest.mark.asyncio
+    async def test_create_success(self, mock_http_client, mock_token_manager):
+        from tools.work_session_tools import work_session_create
+
+        mock_http_client.post.return_value = {
+            'id': 'ws-uuid-1234',
+            'status': 'pending',
+            'auth_method': 'mcp_oauth',
+        }
+
+        result = await work_session_create(
+            workspace='testworkspace',
+            scopes=['command'],
+            servers=['550e8400-e29b-41d4-a716-446655440001'],
+            expires_at='2026-05-19T13:00:00+00:00',
+            region='ap1',
+        )
+
+        assert result['status'] == 'success'
+        assert result['data']['id'] == 'ws-uuid-1234'
+        mock_http_client.post.assert_called_once_with(
+            region='ap1',
+            workspace='testworkspace',
+            endpoint='/api/work-sessions/sessions/',
+            token='test-token',
+            data={
+                'requester_type': 'agent',
+                'scopes': ['command'],
+                'servers': ['550e8400-e29b-41d4-a716-446655440001'],
+                'expires_at': '2026-05-19T13:00:00+00:00',
+            },
+        )
+
+    @pytest.mark.asyncio
+    async def test_create_with_title_and_description(
+        self, mock_http_client, mock_token_manager
+    ):
+        from tools.work_session_tools import work_session_create
+
+        mock_http_client.post.return_value = {'id': 'ws-uuid-5678', 'status': 'pending'}
+
+        await work_session_create(
+            workspace='testworkspace',
+            scopes=['command', 'webftp'],
+            servers=['550e8400-e29b-41d4-a716-446655440001'],
+            expires_at='2026-05-19T13:00:00+00:00',
+            title='Deploy session',
+            description='Deploying config files',
+            region='ap1',
+        )
+
+        call_data = mock_http_client.post.call_args[1]['data']
+        assert call_data['title'] == 'Deploy session'
+        assert call_data['description'] == 'Deploying config files'
+        assert call_data['requester_type'] == 'agent'
+        assert 'auth_method' not in call_data
+
+    @pytest.mark.asyncio
+    async def test_create_omits_empty_title_and_description(
+        self, mock_http_client, mock_token_manager
+    ):
+        from tools.work_session_tools import work_session_create
+
+        mock_http_client.post.return_value = {'id': 'ws-uuid-0000', 'status': 'pending'}
+
+        await work_session_create(
+            workspace='testworkspace',
+            scopes=['command'],
+            servers=['550e8400-e29b-41d4-a716-446655440001'],
+            expires_at='2026-05-19T13:00:00+00:00',
+            region='ap1',
+        )
+
+        call_data = mock_http_client.post.call_args[1]['data']
+        assert 'title' not in call_data
+        assert 'description' not in call_data
+
+
+class TestWorkSessionClose:
+    @pytest.mark.asyncio
+    async def test_close_success(self, mock_http_client, mock_token_manager):
+        from tools.work_session_tools import work_session_close
+
+        mock_http_client.post.return_value = {
+            'id': 'ws-uuid-1234',
+            'status': 'completed',
+        }
+
+        result = await work_session_close(
+            session_id='ws-uuid-1234',
+            workspace='testworkspace',
+            region='ap1',
+        )
+
+        assert result['status'] == 'success'
+        mock_http_client.post.assert_called_once_with(
+            region='ap1',
+            workspace='testworkspace',
+            endpoint='/api/work-sessions/sessions/ws-uuid-1234/complete/',
+            token='test-token',
+            data={},
+        )
+
+
+class TestWorkSessionGet:
+    @pytest.mark.asyncio
+    async def test_get_success(self, mock_http_client, mock_token_manager):
+        from tools.work_session_tools import work_session_get
+
+        mock_http_client.get.return_value = {
+            'id': 'ws-uuid-1234',
+            'status': 'active',
+            'auth_method': 'mcp_oauth',
+        }
+
+        result = await work_session_get(
+            session_id='ws-uuid-1234',
+            workspace='testworkspace',
+            region='ap1',
+        )
+
+        assert result['status'] == 'success'
+        assert result['data']['id'] == 'ws-uuid-1234'
+        mock_http_client.get.assert_called_once_with(
+            region='ap1',
+            workspace='testworkspace',
+            endpoint='/api/work-sessions/sessions/ws-uuid-1234/',
+            token='test-token',
+        )
+
+
+class TestWorkSessionList:
+    @pytest.mark.asyncio
+    async def test_list_success(self, mock_http_client, mock_token_manager):
+        from tools.work_session_tools import work_session_list
+
+        mock_http_client.get.return_value = {
+            'count': 2,
+            'results': [
+                {'id': 'ws-1', 'status': 'active'},
+                {'id': 'ws-2', 'status': 'completed'},
+            ],
+        }
+
+        result = await work_session_list(workspace='testworkspace', region='ap1')
+
+        assert result['status'] == 'success'
+        assert result['data']['count'] == 2
+        mock_http_client.get.assert_called_once_with(
+            region='ap1',
+            workspace='testworkspace',
+            endpoint='/api/work-sessions/sessions/',
+            token='test-token',
+            params={'page_size': 20},
+        )
+
+    @pytest.mark.asyncio
+    async def test_list_with_status_filter(self, mock_http_client, mock_token_manager):
+        from tools.work_session_tools import work_session_list
+
+        mock_http_client.get.return_value = {'count': 1, 'results': []}
+
+        await work_session_list(
+            workspace='testworkspace', status='active', region='ap1'
+        )
+
+        call_params = mock_http_client.get.call_args[1]['params']
+        assert call_params['status'] == 'active'

--- a/tools/command_tools.py
+++ b/tools/command_tools.py
@@ -87,7 +87,6 @@ async def list_commands(
     """List recent commands executed on servers."""
     token = kwargs.get('token')
 
-    # Prepare query parameters
     params = {'page_size': limit, 'ordering': '-added_at'}
 
     if server_id:
@@ -149,7 +148,6 @@ async def execute_command(
             region=region,
         )
 
-    # Submit the command
     exec_data = await _submit_command(
         server_id=server_id,
         command=command,
@@ -166,7 +164,6 @@ async def execute_command(
         token=token,
     )
 
-    # Check if exec_data contains an error (like ACL permission denied)
     if isinstance(exec_data, dict) and 'error' in exec_data:
         return error_response(
             f'Command execution failed: {exec_data.get("error", "Unknown error")}',
@@ -175,7 +172,6 @@ async def execute_command(
             details=exec_data,
         )
 
-    # Extract command ID from response (API may return dict or list)
     if isinstance(exec_data, list):
         if len(exec_data) > 0:
             command_id = exec_data[0].get('id')
@@ -227,7 +223,6 @@ async def execute_command(
         if isinstance(result, dict):
             status = result.get('status', '')
 
-            # Command completed
             if result.get('finished_at') is not None:
                 return success_response(
                     data=result,
@@ -239,7 +234,6 @@ async def execute_command(
                     workspace=workspace,
                 )
 
-            # Command failed with terminal status
             if status in ('stuck', 'error'):
                 return error_response(
                     f'Command failed with status: {status}',
@@ -258,10 +252,8 @@ async def execute_command(
                     hard_deadline,
                 )
 
-        # Wait before next check
         await asyncio.sleep(1)
 
-    # Timeout reached
     return error_response(
         f'Command execution timed out after {timeout} seconds',
         error_type='timeout',

--- a/tools/command_tools.py
+++ b/tools/command_tools.py
@@ -173,7 +173,7 @@ async def execute_command(
         )
 
     if isinstance(exec_data, list):
-        if len(exec_data) > 0:
+        if exec_data:
             command_id = exec_data[0].get('id')
         else:
             return error_response(

--- a/tools/command_tools.py
+++ b/tools/command_tools.py
@@ -251,7 +251,7 @@ async def execute_command(
 
 
 @mcp_tool_handler(
-    description='Run the same shell command on multiple servers simultaneously or sequentially. Returns per-server results with success/failure status. Requires ACL permission. When to use: batch operations like deploying configs, checking status, or running diagnostics across a fleet. Related: execute_command (single server). Note: Set parallel=false for sequential execution. This submits commands without waiting for results — use list_commands to check status.',
+    description='Run the same shell command on multiple servers simultaneously or sequentially. Returns per-server results with success/failure status. Requires ACL permission. Pass session_id to link commands to a Work Session for audit—the server enforces this for MCP OAuth and browser-based auth. When to use: batch operations like deploying configs, checking status, or running diagnostics across a fleet. Related: execute_command (single server), work_session_create (create a Work Session). Note: Set parallel=false for sequential execution. This submits commands without waiting for results — use list_commands to check status.',
     annotations=ADDITIVE,
     meta={'anthropic/searchHint': 'command multi server batch deploy fleet parallel'},
 )

--- a/tools/command_tools.py
+++ b/tools/command_tools.py
@@ -1,6 +1,7 @@
 """Command execution tools for Alpacon MCP server."""
 
 import asyncio
+import os
 from typing import Any
 
 from utils.common import error_response, success_response
@@ -20,6 +21,7 @@ async def _submit_command(
     run_after: list[str] | None = None,
     scheduled_at: str | None = None,
     data: str | None = None,
+    work_session_id: str | None = None,
     region: str = '',
     *,
     token: str | None = None,
@@ -42,6 +44,8 @@ async def _submit_command(
         command_data['scheduled_at'] = scheduled_at
     if data:
         command_data['data'] = data
+    if work_session_id:
+        command_data['work_session'] = work_session_id
 
     return await http_client.post(
         region=region,
@@ -126,11 +130,24 @@ async def execute_command(
     scheduled_at: str | None = None,
     data: str | None = None,
     timeout: int = 300,
+    session_id: str | None = None,
     region: str = '',
     **kwargs,
 ) -> dict[str, Any]:
     """Execute a command on a server and wait for the result (requires ACL permission)."""
     token = kwargs.get('token')
+
+    if (
+        os.getenv('ALPACON_MCP_REQUIRE_SESSION', '').lower() == 'true'
+        and not session_id
+    ):
+        return error_response(
+            'session_id is required when ALPACON_MCP_REQUIRE_SESSION=true. '
+            'Create a WorkSession first with work_session_create.',
+            code='session_required',
+            workspace=workspace,
+            region=region,
+        )
 
     # Submit the command
     exec_data = await _submit_command(
@@ -144,6 +161,7 @@ async def execute_command(
         run_after=run_after,
         scheduled_at=scheduled_at,
         data=data,
+        work_session_id=session_id,
         region=region,
         token=token,
     )
@@ -270,6 +288,7 @@ async def execute_command_multi_server(
     env: dict[str, str] | None = None,
     region: str = '',
     parallel: bool = True,
+    session_id: str | None = None,
     **kwargs,
 ) -> dict[str, Any]:
     """Execute a command on multiple servers using Command API (requires ACL permission)."""
@@ -287,6 +306,7 @@ async def execute_command_multi_server(
             username=username,
             groupname=groupname,
             env=env,
+            work_session_id=session_id,
             region=region,
             token=token,
         )

--- a/tools/command_tools.py
+++ b/tools/command_tools.py
@@ -26,7 +26,6 @@ async def _submit_command(
     *,
     token: str | None = None,
 ) -> dict[str, Any] | list[Any]:
-    """Submit a command to the Command API. Internal helper, not an MCP tool."""
     command_data: dict[str, Any] = {
         'server': server_id,
         'shell': shell,
@@ -63,7 +62,6 @@ async def _get_command_result(
     *,
     token: str | None = None,
 ) -> dict[str, Any]:
-    """Poll a command result by ID. Internal helper, not an MCP tool."""
     return await http_client.get(
         region=region,
         workspace=workspace,

--- a/tools/command_tools.py
+++ b/tools/command_tools.py
@@ -3,7 +3,7 @@
 import asyncio
 from typing import Any
 
-from utils.common import error_response, success_response
+from utils.common import error_response, success_response, unwrap_http_result
 from utils.decorators import mcp_tool_handler
 from utils.http_client import http_client
 from utils.tool_annotations import ADDITIVE, READ_ONLY
@@ -96,6 +96,14 @@ async def list_commands(
         token=token,
         params=params,
     )
+
+    if err := unwrap_http_result(
+        result,
+        default_message='Failed to list commands',
+        region=region,
+        workspace=workspace,
+    ):
+        return err
 
     return success_response(
         data=result,

--- a/tools/command_tools.py
+++ b/tools/command_tools.py
@@ -1,7 +1,6 @@
 """Command execution tools for Alpacon MCP server."""
 
 import asyncio
-import os
 from typing import Any
 
 from utils.common import error_response, success_response
@@ -108,7 +107,7 @@ async def list_commands(
 
 
 @mcp_tool_handler(
-    description='Run a shell command on a server and wait for the result (up to 5 minutes by default). Returns stdout, stderr, and exit code in a single call. Requires ACL permission. The timeout resets when the command is actively running. Supports dependency chains (run_after), scheduled execution (scheduled_at), and stdin data. Pass session_id to link this command to a Work Session for audit—required when ALPACON_MCP_REQUIRE_SESSION=true. When to use: the recommended way to run a command on a server. Related: execute_command_multi_server (run on multiple servers), list_commands (browse history), work_session_create (create a Work Session). Note: Default timeout is 300 seconds (5 minutes).',
+    description='Run a shell command on a server and wait for the result (up to 5 minutes by default). Returns stdout, stderr, and exit code in a single call. Requires ACL permission. The timeout resets when the command is actively running. Supports dependency chains (run_after), scheduled execution (scheduled_at), and stdin data. Pass session_id to link this command to a Work Session for audit—the server enforces this for MCP OAuth and browser-based auth. When to use: the recommended way to run a command on a server. Related: execute_command_multi_server (run on multiple servers), list_commands (browse history), work_session_create (create a Work Session). Note: Default timeout is 300 seconds (5 minutes).',
     annotations=ADDITIVE,
     meta={
         'anthropic/alwaysLoad': True,
@@ -133,18 +132,6 @@ async def execute_command(
 ) -> dict[str, Any]:
     """Execute a command on a server and wait for the result (requires ACL permission)."""
     token = kwargs.get('token')
-
-    if (
-        os.getenv('ALPACON_MCP_REQUIRE_SESSION', '').lower() == 'true'
-        and not session_id
-    ):
-        return error_response(
-            'session_id is required when ALPACON_MCP_REQUIRE_SESSION=true. '
-            'Create a WorkSession first with work_session_create.',
-            code='session_required',
-            workspace=workspace,
-            region=region,
-        )
 
     exec_data = await _submit_command(
         server_id=server_id,

--- a/tools/command_tools.py
+++ b/tools/command_tools.py
@@ -115,7 +115,7 @@ async def list_commands(
 
 
 @mcp_tool_handler(
-    description='Run a shell command on a server and wait for the result (up to 5 minutes by default). Returns stdout, stderr, and exit code in a single call. Requires ACL permission. The timeout resets when the command is actively running. Supports dependency chains (run_after), scheduled execution (scheduled_at), and stdin data. Pass session_id to link this command to a Work Session for audit—the server enforces this for MCP OAuth and browser-based auth. When to use: the recommended way to run a command on a server. Related: execute_command_multi_server (run on multiple servers), list_commands (browse history), work_session_create (create a Work Session). Note: Default timeout is 300 seconds (5 minutes).',
+    description='Run a shell command on a server and wait for the result (up to 5 minutes by default). Returns stdout, stderr, and exit code in a single call. Requires ACL permission. The timeout resets when the command is actively running. Supports dependency chains (run_after), scheduled execution (scheduled_at), and stdin data. Pass work_session_id to link this command to a Work Session for audit—the server enforces this for MCP OAuth and browser-based auth. When to use: the recommended way to run a command on a server. Related: execute_command_multi_server (run on multiple servers), list_commands (browse history), work_session_create (create a Work Session). Note: Default timeout is 300 seconds (5 minutes).',
     annotations=ADDITIVE,
     meta={
         'anthropic/alwaysLoad': True,
@@ -134,7 +134,7 @@ async def execute_command(
     scheduled_at: str | None = None,
     data: str | None = None,
     timeout: int = 300,
-    session_id: str | None = None,
+    work_session_id: str | None = None,
     region: str = '',
     **kwargs,
 ) -> dict[str, Any]:
@@ -152,7 +152,7 @@ async def execute_command(
         run_after=run_after,
         scheduled_at=scheduled_at,
         data=data,
-        work_session_id=session_id,
+        work_session_id=work_session_id,
         region=region,
         token=token,
     )
@@ -259,7 +259,7 @@ async def execute_command(
 
 
 @mcp_tool_handler(
-    description='Run the same shell command on multiple servers simultaneously or sequentially. Returns per-server results with success/failure status. Requires ACL permission. Pass session_id to link commands to a Work Session for audit—the server enforces this for MCP OAuth and browser-based auth. When to use: batch operations like deploying configs, checking status, or running diagnostics across a fleet. Related: execute_command (single server), work_session_create (create a Work Session). Note: Set parallel=false for sequential execution. This submits commands without waiting for results — use list_commands to check status.',
+    description='Run the same shell command on multiple servers simultaneously or sequentially. Returns per-server results with success/failure status. Requires ACL permission. Pass work_session_id to link commands to a Work Session for audit—the server enforces this for MCP OAuth and browser-based auth. When to use: batch operations like deploying configs, checking status, or running diagnostics across a fleet. Related: execute_command (single server), work_session_create (create a Work Session). Note: Set parallel=false for sequential execution. This submits commands without waiting for results — use list_commands to check status.',
     annotations=ADDITIVE,
     meta={'anthropic/searchHint': 'command multi server batch deploy fleet parallel'},
 )
@@ -273,7 +273,7 @@ async def execute_command_multi_server(
     env: dict[str, str] | None = None,
     region: str = '',
     parallel: bool = True,
-    session_id: str | None = None,
+    work_session_id: str | None = None,
     **kwargs,
 ) -> dict[str, Any]:
     """Execute a command on multiple servers using Command API (requires ACL permission)."""
@@ -291,7 +291,7 @@ async def execute_command_multi_server(
             username=username,
             groupname=groupname,
             env=env,
-            work_session_id=session_id,
+            work_session_id=work_session_id,
             region=region,
             token=token,
         )

--- a/tools/command_tools.py
+++ b/tools/command_tools.py
@@ -311,8 +311,7 @@ async def execute_command_multi_server(
         results = await asyncio.gather(
             *[_submit_one(sid) for sid in server_ids], return_exceptions=True
         )
-        for i, result in enumerate(results):
-            sid = server_ids[i]
+        for sid, result in zip(server_ids, results, strict=True):
             if isinstance(result, BaseException):
                 if not isinstance(result, Exception):
                     raise result

--- a/tools/command_tools.py
+++ b/tools/command_tools.py
@@ -108,7 +108,7 @@ async def list_commands(
 
 
 @mcp_tool_handler(
-    description='Run a shell command on a server and wait for the result (up to 5 minutes by default). Returns stdout, stderr, and exit code in a single call. Requires ACL permission. The timeout resets when the command is actively running. Supports dependency chains (run_after), scheduled execution (scheduled_at), and stdin data. When to use: the recommended way to run a command on a server. Related: execute_command_multi_server (run on multiple servers), list_commands (browse history). Note: Default timeout is 300 seconds (5 minutes).',
+    description='Run a shell command on a server and wait for the result (up to 5 minutes by default). Returns stdout, stderr, and exit code in a single call. Requires ACL permission. The timeout resets when the command is actively running. Supports dependency chains (run_after), scheduled execution (scheduled_at), and stdin data. Pass session_id to link this command to a Work Session for audit—required when ALPACON_MCP_REQUIRE_SESSION=true. When to use: the recommended way to run a command on a server. Related: execute_command_multi_server (run on multiple servers), list_commands (browse history), work_session_create (create a Work Session). Note: Default timeout is 300 seconds (5 minutes).',
     annotations=ADDITIVE,
     meta={
         'anthropic/alwaysLoad': True,

--- a/tools/webftp_tools.py
+++ b/tools/webftp_tools.py
@@ -184,10 +184,10 @@ async def _download_remote_mode(
     ):
         return err
 
-    file_id = result.get('id')
     download_url = result.get('download_url')
 
     if not download_url:
+        file_id = result.get('id')
         for _ in range(_REMOTE_DOWNLOAD_TIMEOUT):
             await asyncio.sleep(1)
             status = await http_client.get(
@@ -196,6 +196,12 @@ async def _download_remote_mode(
                 endpoint=_API_DOWNLOAD_STATUS.format(file_id),
                 token=token,
             )
+            if err := unwrap_http_result(
+                status,
+                default_message='Failed to poll download status',
+                file_id=file_id,
+            ):
+                return err
             if status.get('success') is True:
                 download_url = status.get('download_url')
                 break
@@ -228,7 +234,7 @@ async def _download_remote_mode(
 
 
 @mcp_tool_handler(
-    description='Create a new WebFTP file transfer session on a server. Returns session ID and connection details. Pass session_id (a Work Session ID from work_session_create) to link this WebFTP session to a Work Session for audit—note that session_id here refers to the Work Session, not the WebFTP session being created. When to use: advanced session management. For simple file transfers, use webftp_upload_file or webftp_download_file directly. Related: webftp_sessions_list (view sessions), webftp_upload_file, webftp_download_file, work_session_create (create a Work Session).',
+    description='Create a new WebFTP file transfer session on a server. Returns session ID and connection details. Pass work_session_id to link this WebFTP session to a Work Session for audit. When to use: advanced session management. For simple file transfers, use webftp_upload_file or webftp_download_file directly. Related: webftp_sessions_list (view sessions), webftp_upload_file, webftp_download_file, work_session_create (create a Work Session).',
     annotations=ADDITIVE,
     meta={'anthropic/searchHint': 'webftp session create file transfer'},
 )
@@ -236,7 +242,7 @@ async def webftp_session_create(
     server_id: str,
     workspace: str,
     username: str | None = None,
-    session_id: str | None = None,
+    work_session_id: str | None = None,
     region: str = '',
     **kwargs,
 ) -> dict[str, Any]:
@@ -246,8 +252,8 @@ async def webftp_session_create(
     session_data = {'server': server_id}
     if username:
         session_data['username'] = username
-    if session_id:
-        session_data['work_session'] = session_id
+    if work_session_id:
+        session_data['work_session'] = work_session_id
 
     result = await http_client.post(
         region=region,
@@ -313,7 +319,7 @@ async def webftp_sessions_list(
 
 
 @mcp_tool_handler(
-    description='Upload a local file to a remote server. Reads the file from a local absolute path, transfers it via S3 presigned URL, and places it at the specified remote path on the server. Pass session_id to link this upload to a Work Session for audit—maps to the work_session field in the API payload; the server enforces this for MCP OAuth and browser-based auth. When to use: transferring a single file to a server. Related: webftp_bulk_upload (multiple files), webftp_download_file (download from server), webftp_uploads_list (check upload history), work_session_create (create a Work Session). Note: Both local and remote paths must be absolute.',
+    description='Upload a local file to a remote server. Reads the file from a local absolute path, transfers it via S3 presigned URL, and places it at the specified remote path on the server. Pass session_id to link this upload to a Work Session for audit; the server enforces this for MCP OAuth and browser-based auth. When to use: transferring a single file to a server. Related: webftp_bulk_upload (multiple files), webftp_download_file (download from server), webftp_uploads_list (check upload history), work_session_create (create a Work Session). Note: Both local and remote paths must be absolute.',
     annotations=ADDITIVE,
     meta={'anthropic/searchHint': 'file upload transfer scp sftp send server'},
 )
@@ -519,7 +525,7 @@ async def webftp_upload_content(
         'then returns a presigned download URL valid for 24 hours — '
         'open it in a browser or run the curl command in the response. '
         'For folders, content is packaged as a ZIP archive. '
-        'Pass session_id to link this download to a Work Session for audit—maps to the work_session field in the API payload; '
+        'Pass session_id to link this download to a Work Session for audit; '
         'the server enforces this for MCP OAuth and browser-based auth. '
         'Related: webftp_bulk_download (multiple files as ZIP), '
         'webftp_upload_file (upload to server), '
@@ -711,7 +717,7 @@ async def webftp_downloads_list(
 
 
 @mcp_tool_handler(
-    description='Upload multiple local files to a remote server in a single operation. All files are placed in the same destination directory. Uses S3 presigned URLs with concurrent uploads. Pass session_id to link this upload to a Work Session for audit—maps to the work_session field in the API payload; the server enforces this for MCP OAuth and browser-based auth. When to use: uploading several files at once (more efficient than repeated webftp_upload_file calls). Related: webftp_upload_file (single file), webftp_bulk_download (download multiple), work_session_create (create a Work Session). Note: All files go to the same remote directory.',
+    description='Upload multiple local files to a remote server in a single operation. All files are placed in the same destination directory. Uses S3 presigned URLs with concurrent uploads. Pass session_id to link this upload to a Work Session for audit; the server enforces this for MCP OAuth and browser-based auth. When to use: uploading several files at once (more efficient than repeated webftp_upload_file calls). Related: webftp_upload_file (single file), webftp_bulk_download (download multiple), work_session_create (create a Work Session). Note: All files go to the same remote directory.',
     annotations=ADDITIVE,
     meta={'anthropic/searchHint': 'bulk upload multiple files batch transfer'},
 )
@@ -865,7 +871,7 @@ async def webftp_bulk_upload(
 
 
 @mcp_tool_handler(
-    description='Download multiple files or folders from a remote server as a single ZIP archive. All paths must share the same parent directory. Pass session_id to link this download to a Work Session for audit—maps to the work_session field in the API payload; the server enforces this for MCP OAuth and browser-based auth. When to use: downloading several files at once. Related: webftp_download_file (single file), webftp_bulk_upload (upload multiple), webftp_check_status (poll if still processing), work_session_create (create a Work Session). Note: If ZIP is not ready, poll with webftp_check_status then retry.',
+    description='Download multiple files or folders from a remote server as a single ZIP archive. All paths must share the same parent directory. Pass session_id to link this download to a Work Session for audit; the server enforces this for MCP OAuth and browser-based auth. When to use: downloading several files at once. Related: webftp_download_file (single file), webftp_bulk_upload (upload multiple), webftp_check_status (poll if still processing), work_session_create (create a Work Session). Note: If ZIP is not ready, poll with webftp_check_status then retry.',
     annotations=ADDITIVE,
     meta={'anthropic/searchHint': 'bulk download multiple files zip archive batch'},
 )

--- a/tools/webftp_tools.py
+++ b/tools/webftp_tools.py
@@ -148,7 +148,7 @@ async def _download_remote_mode(
     workspace: str,
     region: str,
     username: str | None,
-    session_id: str | None,
+    work_session_id: str | None,
     token: str,
 ) -> dict[str, Any]:
     """Handle webftp_download_file in remote mode: poll until ready, return presigned URL."""
@@ -164,8 +164,8 @@ async def _download_remote_mode(
     }
     if username:
         download_data['username'] = username
-    if session_id:
-        download_data['work_session'] = session_id
+    if work_session_id:
+        download_data['work_session'] = work_session_id
 
     result = await http_client.post(
         region=region,
@@ -319,7 +319,7 @@ async def webftp_sessions_list(
 
 
 @mcp_tool_handler(
-    description='Upload a local file to a remote server. Reads the file from a local absolute path, transfers it via S3 presigned URL, and places it at the specified remote path on the server. Pass session_id to link this upload to a Work Session for audit; the server enforces this for MCP OAuth and browser-based auth. When to use: transferring a single file to a server. Related: webftp_bulk_upload (multiple files), webftp_download_file (download from server), webftp_uploads_list (check upload history), work_session_create (create a Work Session). Note: Both local and remote paths must be absolute.',
+    description='Upload a local file to a remote server. Reads the file from a local absolute path, transfers it via S3 presigned URL, and places it at the specified remote path on the server. Pass work_session_id to link this upload to a Work Session for audit; the server enforces this for MCP OAuth and browser-based auth. When to use: transferring a single file to a server. Related: webftp_bulk_upload (multiple files), webftp_download_file (download from server), webftp_uploads_list (check upload history), work_session_create (create a Work Session). Note: Both local and remote paths must be absolute.',
     annotations=ADDITIVE,
     meta={'anthropic/searchHint': 'file upload transfer scp sftp send server'},
 )
@@ -329,7 +329,7 @@ async def webftp_upload_file(
     remote_file_path: str,
     workspace: str,
     username: str | None = None,
-    session_id: str | None = None,
+    work_session_id: str | None = None,
     region: str = '',
     allow_overwrite: bool = True,
     **kwargs,
@@ -360,8 +360,8 @@ async def webftp_upload_file(
     }
     if username:
         upload_data['username'] = username
-    if session_id:
-        upload_data['work_session'] = session_id
+    if work_session_id:
+        upload_data['work_session'] = work_session_id
 
     result = await http_client.post(
         region=region,
@@ -444,7 +444,7 @@ async def webftp_upload_content(
     workspace: str,
     file_name: str | None = None,
     username: str | None = None,
-    session_id: str | None = None,
+    work_session_id: str | None = None,
     region: str = '',
     allow_overwrite: bool = True,
     **kwargs,
@@ -470,8 +470,8 @@ async def webftp_upload_content(
     }
     if username:
         upload_data['username'] = username
-    if session_id:
-        upload_data['work_session'] = session_id
+    if work_session_id:
+        upload_data['work_session'] = work_session_id
 
     result = await http_client.post(
         region=region,
@@ -541,7 +541,7 @@ async def webftp_upload_content(
         'then returns a presigned download URL valid for 24 hours — '
         'open it in a browser or run the curl command in the response. '
         'For folders, content is packaged as a ZIP archive. '
-        'Pass session_id to link this download to a Work Session for audit; '
+        'Pass work_session_id to link this download to a Work Session for audit; '
         'the server enforces this for MCP OAuth and browser-based auth. '
         'Related: webftp_bulk_download (multiple files as ZIP), '
         'webftp_upload_file (upload to server), '
@@ -559,7 +559,7 @@ async def webftp_download_file(
     local_file_path: str | None = None,
     resource_type: str = 'file',
     username: str | None = None,
-    session_id: str | None = None,
+    work_session_id: str | None = None,
     region: str = '',
     **kwargs,
 ) -> dict[str, Any]:
@@ -579,7 +579,7 @@ async def webftp_download_file(
             workspace=workspace,
             region=region,
             username=username,
-            session_id=session_id,
+            work_session_id=work_session_id,
             token=token,
         )
 
@@ -601,8 +601,8 @@ async def webftp_download_file(
 
     if username:
         download_data['username'] = username
-    if session_id:
-        download_data['work_session'] = session_id
+    if work_session_id:
+        download_data['work_session'] = work_session_id
 
     result = await http_client.post(
         region=region,
@@ -733,7 +733,7 @@ async def webftp_downloads_list(
 
 
 @mcp_tool_handler(
-    description='Upload multiple local files to a remote server in a single operation. All files are placed in the same destination directory. Uses S3 presigned URLs with concurrent uploads. Pass session_id to link this upload to a Work Session for audit; the server enforces this for MCP OAuth and browser-based auth. When to use: uploading several files at once (more efficient than repeated webftp_upload_file calls). Related: webftp_upload_file (single file), webftp_bulk_download (download multiple), work_session_create (create a Work Session). Note: All files go to the same remote directory.',
+    description='Upload multiple local files to a remote server in a single operation. All files are placed in the same destination directory. Uses S3 presigned URLs with concurrent uploads. Pass work_session_id to link this upload to a Work Session for audit; the server enforces this for MCP OAuth and browser-based auth. When to use: uploading several files at once (more efficient than repeated webftp_upload_file calls). Related: webftp_upload_file (single file), webftp_bulk_download (download multiple), work_session_create (create a Work Session). Note: All files go to the same remote directory.',
     annotations=ADDITIVE,
     meta={'anthropic/searchHint': 'bulk upload multiple files batch transfer'},
 )
@@ -743,7 +743,7 @@ async def webftp_bulk_upload(
     remote_directory: str,
     workspace: str,
     username: str | None = None,
-    session_id: str | None = None,
+    work_session_id: str | None = None,
     region: str = '',
     allow_overwrite: bool = True,
     **kwargs,
@@ -776,8 +776,8 @@ async def webftp_bulk_upload(
     }
     if username:
         bulk_data['username'] = username
-    if session_id:
-        bulk_data['work_session'] = session_id
+    if work_session_id:
+        bulk_data['work_session'] = work_session_id
 
     result = await http_client.post(
         region=region,
@@ -895,7 +895,7 @@ async def webftp_bulk_upload(
 
 
 @mcp_tool_handler(
-    description='Download multiple files or folders from a remote server as a single ZIP archive. All paths must share the same parent directory. Pass session_id to link this download to a Work Session for audit; the server enforces this for MCP OAuth and browser-based auth. When to use: downloading several files at once. Related: webftp_download_file (single file), webftp_bulk_upload (upload multiple), webftp_check_status (poll if still processing), work_session_create (create a Work Session). Note: If ZIP is not ready, poll with webftp_check_status then retry.',
+    description='Download multiple files or folders from a remote server as a single ZIP archive. All paths must share the same parent directory. Pass work_session_id to link this download to a Work Session for audit; the server enforces this for MCP OAuth and browser-based auth. When to use: downloading several files at once. Related: webftp_download_file (single file), webftp_bulk_upload (upload multiple), webftp_check_status (poll if still processing), work_session_create (create a Work Session). Note: If ZIP is not ready, poll with webftp_check_status then retry.',
     annotations=ADDITIVE,
     meta={'anthropic/searchHint': 'bulk download multiple files zip archive batch'},
 )
@@ -905,7 +905,7 @@ async def webftp_bulk_download(
     local_file_path: str,
     workspace: str,
     username: str | None = None,
-    session_id: str | None = None,
+    work_session_id: str | None = None,
     region: str = '',
     **kwargs,
 ) -> dict[str, Any]:
@@ -939,8 +939,8 @@ async def webftp_bulk_download(
     }
     if username:
         download_data['username'] = username
-    if session_id:
-        download_data['work_session'] = session_id
+    if work_session_id:
+        download_data['work_session'] = work_session_id
 
     result = await http_client.post(
         region=region,

--- a/tools/webftp_tools.py
+++ b/tools/webftp_tools.py
@@ -148,6 +148,7 @@ async def _download_remote_mode(
     workspace: str,
     region: str,
     username: str | None,
+    session_id: str | None,
     token: str,
 ) -> dict[str, Any]:
     """Handle webftp_download_file in remote mode: poll until ready, return presigned URL."""
@@ -163,6 +164,8 @@ async def _download_remote_mode(
     }
     if username:
         download_data['username'] = username
+    if session_id:
+        download_data['work_session'] = session_id
 
     result = await http_client.post(
         region=region,
@@ -224,6 +227,7 @@ async def webftp_session_create(
     server_id: str,
     workspace: str,
     username: str | None = None,
+    session_id: str | None = None,
     region: str = '',
     **kwargs,
 ) -> dict[str, Any]:
@@ -246,6 +250,8 @@ async def webftp_session_create(
     # Only include username if provided
     if username:
         session_data['username'] = username
+    if session_id:
+        session_data['work_session'] = session_id
 
     # Make async call to create FTP session
     result = await http_client.post(
@@ -315,6 +321,7 @@ async def webftp_upload_file(
     remote_file_path: str,
     workspace: str,
     username: str | None = None,
+    session_id: str | None = None,
     region: str = '',
     allow_overwrite: bool = True,
     **kwargs,
@@ -371,6 +378,8 @@ async def webftp_upload_file(
     # Only include username if provided
     if username:
         upload_data['username'] = username
+    if session_id:
+        upload_data['work_session'] = session_id
 
     # Step 3: Create UploadedFile object (this generates presigned URLs when USE_S3=True)
     result = await http_client.post(
@@ -440,6 +449,7 @@ async def webftp_upload_content(
     workspace: str,
     file_name: str | None = None,
     username: str | None = None,
+    session_id: str | None = None,
     region: str = '',
     allow_overwrite: bool = True,
     **kwargs,
@@ -479,6 +489,8 @@ async def webftp_upload_content(
     }
     if username:
         upload_data['username'] = username
+    if session_id:
+        upload_data['work_session'] = session_id
 
     result = await http_client.post(
         region=region,
@@ -546,6 +558,7 @@ async def webftp_download_file(
     local_file_path: str | None = None,
     resource_type: str = 'file',
     username: str | None = None,
+    session_id: str | None = None,
     region: str = '',
     **kwargs,
 ) -> dict[str, Any]:
@@ -582,6 +595,7 @@ async def webftp_download_file(
             workspace=workspace,
             region=region,
             username=username,
+            session_id=session_id,
             token=token,
         )
 
@@ -605,6 +619,8 @@ async def webftp_download_file(
     # Only include username if provided
     if username:
         download_data['username'] = username
+    if session_id:
+        download_data['work_session'] = session_id
 
     # Step 2: Create DownloadedFile object (this generates presigned URLs when USE_S3=True)
     result = await http_client.post(
@@ -748,6 +764,7 @@ async def webftp_bulk_upload(
     remote_directory: str,
     workspace: str,
     username: str | None = None,
+    session_id: str | None = None,
     region: str = '',
     allow_overwrite: bool = True,
     **kwargs,
@@ -796,6 +813,8 @@ async def webftp_bulk_upload(
     }
     if username:
         bulk_data['username'] = username
+    if session_id:
+        bulk_data['work_session'] = session_id
 
     result = await http_client.post(
         region=region,
@@ -909,6 +928,7 @@ async def webftp_bulk_download(
     local_file_path: str,
     workspace: str,
     username: str | None = None,
+    session_id: str | None = None,
     region: str = '',
     **kwargs,
 ) -> dict[str, Any]:
@@ -958,6 +978,8 @@ async def webftp_bulk_download(
     }
     if username:
         download_data['username'] = username
+    if session_id:
+        download_data['work_session'] = session_id
 
     result = await http_client.post(
         region=region,

--- a/tools/webftp_tools.py
+++ b/tools/webftp_tools.py
@@ -231,29 +231,15 @@ async def webftp_session_create(
     region: str = '',
     **kwargs,
 ) -> dict[str, Any]:
-    """Create a new WebFTP session.
-
-    Args:
-        server_id: Server ID to create FTP session on
-        workspace: Workspace name. Required parameter
-        username: Optional username for the FTP session (uses authenticated user if not provided)
-        region: Region (ap1, us1, eu1). Auto-detected if not provided
-
-    Returns:
-        FTP session creation response
-    """
+    """Create a new WebFTP session."""
     token = kwargs.get('token')
 
-    # Prepare FTP session data
     session_data = {'server': server_id}
-
-    # Only include username if provided
     if username:
         session_data['username'] = username
     if session_id:
         session_data['work_session'] = session_id
 
-    # Make async call to create FTP session
     result = await http_client.post(
         region=region,
         workspace=workspace,
@@ -279,24 +265,13 @@ async def webftp_session_create(
 async def webftp_sessions_list(
     workspace: str, server_id: str | None = None, region: str = '', **kwargs
 ) -> dict[str, Any]:
-    """Get list of WebFTP sessions.
-
-    Args:
-        workspace: Workspace name. Required parameter
-        server_id: Optional server ID to filter sessions
-        region: Region (ap1, us1, eu1). Auto-detected if not provided
-
-    Returns:
-        FTP sessions list response
-    """
+    """Get list of WebFTP sessions."""
     token = kwargs.get('token')
 
-    # Prepare query parameters
     params = {}
     if server_id:
         params['server'] = server_id
 
-    # Make async call to get FTP sessions
     result = await http_client.get(
         region=region,
         workspace=workspace,
@@ -326,40 +301,17 @@ async def webftp_upload_file(
     allow_overwrite: bool = True,
     **kwargs,
 ) -> dict[str, Any]:
-    """Upload a file using WebFTP uploads API with S3 presigned URLs.
-
-    This creates an UploadedFile object which generates presigned S3 URLs for upload.
-    The process:
-    1. Read file from local path
-    2. Create UploadedFile object with metadata
-    3. Get presigned upload URL from response
-    4. Upload file content to S3 using the presigned URL
-    5. File is automatically processed on the server
-
-    Args:
-        server_id: Server ID to upload file to
-        local_file_path: Local file path to read from (e.g., "/Users/user/file.txt")
-        remote_file_path: Remote path where the file should be uploaded on the server (e.g., "/home/user/file.txt")
-        workspace: Workspace name. Required parameter
-        username: Optional username for the upload (uses authenticated user if not provided)
-        region: Region (ap1, us1, eu1). Auto-detected if not provided
-        allow_overwrite: Allow overwriting existing files (default: True)
-
-    Returns:
-        File upload response with presigned URLs
-    """
+    """Upload a local file to a server via S3 presigned URL."""
     token = kwargs.get('token')
 
     if _is_auth_enabled():
         return error_response(_REMOTE_MODE_ERROR, code='remote_mode_unsupported')
 
-    # Validate file paths
     if not validate_file_path(local_file_path):
         return format_validation_error('local_file_path', local_file_path)
     if not validate_file_path(remote_file_path):
         return format_validation_error('remote_file_path', remote_file_path)
 
-    # Step 1: Read local file
     try:
         file_content = await asyncio.to_thread(Path(local_file_path).read_bytes)
     except FileNotFoundError:
@@ -367,21 +319,17 @@ async def webftp_upload_file(
     except Exception as e:
         return error_response(f'Failed to read local file: {str(e)}')
 
-    # Step 2: Prepare upload data for UploadedFileCreateSerializer
     upload_data = {
         'server': server_id,
         'name': os.path.basename(remote_file_path),
         'path': remote_file_path,
         'allow_overwrite': allow_overwrite,
     }
-
-    # Only include username if provided
     if username:
         upload_data['username'] = username
     if session_id:
         upload_data['work_session'] = session_id
 
-    # Step 3: Create UploadedFile object (this generates presigned URLs when USE_S3=True)
     result = await http_client.post(
         region=region,
         workspace=workspace,
@@ -390,13 +338,11 @@ async def webftp_upload_file(
         data=upload_data,
     )
 
-    # Step 4: Upload file content to S3 using presigned URL
     if result.get('upload_url'):
         err = await _upload_bytes_to_s3(result['upload_url'], file_content)
         if err:
             return error_response(err, upload_url=result['upload_url'])
 
-        # Step 5: Trigger server to process the uploaded file
         upload_trigger = await http_client.get(
             region=region,
             workspace=workspace,
@@ -418,7 +364,6 @@ async def webftp_upload_file(
             workspace=workspace,
         )
     else:
-        # Fallback to direct upload (when USE_S3=False)
         return success_response(
             message='File uploaded successfully (direct upload)',
             data=result,
@@ -454,21 +399,7 @@ async def webftp_upload_content(
     allow_overwrite: bool = True,
     **kwargs,
 ) -> dict[str, Any]:
-    """Upload base64-encoded file content to a server via WebFTP.
-
-    Args:
-        server_id: Server ID to upload file to
-        file_content: Base64-encoded file bytes
-        remote_file_path: Absolute path on the server (e.g., "/home/user/file.txt")
-        workspace: Workspace name. Required parameter
-        file_name: File name to use on the server. Inferred from remote_file_path if omitted
-        username: Optional username (uses authenticated user if not provided)
-        region: Region (ap1, us1, eu1). Auto-detected if not provided
-        allow_overwrite: Allow overwriting existing files (default: True)
-
-    Returns:
-        File upload response
-    """
+    """Upload base64-encoded file content to a server via WebFTP."""
     token = kwargs.get('token')
 
     try:
@@ -562,24 +493,7 @@ async def webftp_download_file(
     region: str = '',
     **kwargs,
 ) -> dict[str, Any]:
-    """Download a file or folder using WebFTP downloads API.
-
-    This creates a DownloadedFile object which generates presigned S3 URLs for download,
-    then downloads the file content and saves it to local path.
-    For folders, it creates a zip file automatically.
-
-    Args:
-        server_id: Server ID to download from
-        remote_file_path: Path of the file or folder to download from server
-        local_file_path: Local path where the file should be saved
-        workspace: Workspace name. Required parameter
-        resource_type: Type of resource - "file" or "folder" (default: "file")
-        username: Optional username for the download (uses authenticated user if not provided)
-        region: Region (ap1, us1, eu1). Auto-detected if not provided
-
-    Returns:
-        Download response with file saved locally
-    """
+    """Download a file or folder from a server via S3 presigned URL."""
     token = kwargs.get('token')
     if not isinstance(token, str) or not token:
         raise RuntimeError('token must be injected by mcp_tool_handler')
@@ -604,7 +518,6 @@ async def webftp_download_file(
     if not validate_file_path(local_file_path):
         return format_validation_error('local_file_path', local_file_path)
 
-    # Step 1: Prepare download data for DownloadedFileCreateSerializer
     file_name = os.path.basename(remote_file_path)
     if resource_type == 'folder':
         file_name += '.zip'
@@ -616,13 +529,11 @@ async def webftp_download_file(
         'resource_type': resource_type,
     }
 
-    # Only include username if provided
     if username:
         download_data['username'] = username
     if session_id:
         download_data['work_session'] = session_id
 
-    # Step 2: Create DownloadedFile object (this generates presigned URLs when USE_S3=True)
     result = await http_client.post(
         region=region,
         workspace=workspace,
@@ -631,7 +542,6 @@ async def webftp_download_file(
         data=download_data,
     )
 
-    # Step 3: Download file content from S3 using presigned URL
     if result.get('download_url'):
         try:
             file_size = await _stream_s3_to_file(
@@ -658,7 +568,6 @@ async def webftp_download_file(
             workspace=workspace,
         )
     else:
-        # Fallback for direct download (when USE_S3=False)
         return success_response(
             message=f'Download request created for {resource_type}: {remote_file_path}',
             data=result,
@@ -678,24 +587,13 @@ async def webftp_download_file(
 async def webftp_uploads_list(
     workspace: str, server_id: str | None = None, region: str = '', **kwargs
 ) -> dict[str, Any]:
-    """List uploaded files (upload history).
-
-    Args:
-        workspace: Workspace name. Required parameter
-        server_id: Optional server ID to filter uploads
-        region: Region (ap1, us1, eu1). Auto-detected if not provided
-
-    Returns:
-        Uploads list response
-    """
+    """List uploaded files (upload history)."""
     token = kwargs.get('token')
 
-    # Prepare query parameters
     params = {}
     if server_id:
         params['server'] = server_id
 
-    # Make async call to get uploads list
     result = await http_client.get(
         region=region,
         workspace=workspace,
@@ -717,24 +615,13 @@ async def webftp_uploads_list(
 async def webftp_downloads_list(
     workspace: str, server_id: str | None = None, region: str = '', **kwargs
 ) -> dict[str, Any]:
-    """List download requests (download history).
-
-    Args:
-        workspace: Workspace name. Required parameter
-        server_id: Optional server ID to filter downloads
-        region: Region (ap1, us1, eu1). Auto-detected if not provided
-
-    Returns:
-        Downloads list response
-    """
+    """List download requests (download history)."""
     token = kwargs.get('token')
 
-    # Prepare query parameters
     params = {}
     if server_id:
         params['server'] = server_id
 
-    # Make async call to get downloads list
     result = await http_client.get(
         region=region,
         workspace=workspace,
@@ -746,11 +633,6 @@ async def webftp_downloads_list(
     return success_response(
         data=result, server_id=server_id, region=region, workspace=workspace
     )
-
-
-# ===============================
-# BULK WEBFTP TOOLS
-# ===============================
 
 
 @mcp_tool_handler(
@@ -769,30 +651,15 @@ async def webftp_bulk_upload(
     allow_overwrite: bool = True,
     **kwargs,
 ) -> dict[str, Any]:
-    """Upload multiple files to a server using bulk WebFTP API.
-
-    Args:
-        server_id: Server ID to upload files to
-        local_file_paths: List of local file paths to upload (must not be empty)
-        remote_directory: Remote directory to place all files (e.g., "/home/user/uploads/")
-        workspace: Workspace name. Required parameter
-        username: Optional username for the upload (uses authenticated user if not provided)
-        region: Region (ap1, us1, eu1). Auto-detected if not provided
-        allow_overwrite: Allow overwriting existing files (default: True)
-
-    Returns:
-        Bulk upload response with per-file status
-    """
+    """Upload multiple files to a server using bulk WebFTP API."""
     token = kwargs.get('token')
 
     if _is_auth_enabled():
         return error_response(_REMOTE_MODE_ERROR, code='remote_mode_unsupported')
 
-    # Validate non-empty file list
     if not local_file_paths:
         return error_response('local_file_paths must not be empty')
 
-    # Validate all file paths and ensure they are regular, readable files
     for path in local_file_paths:
         if not validate_file_path(path):
             return format_validation_error('local_file_paths', path)
@@ -803,7 +670,6 @@ async def webftp_bulk_upload(
     if not validate_file_path(remote_directory):
         return format_validation_error('remote_directory', remote_directory)
 
-    # Create bulk upload records via API
     file_names = [os.path.basename(p) for p in local_file_paths]
     bulk_data: dict[str, Any] = {
         'server': server_id,
@@ -824,13 +690,11 @@ async def webftp_bulk_upload(
         data=bulk_data,
     )
 
-    # Upload files to S3 concurrently using presigned URLs
     file_ids = []
     upload_items = (
         result if isinstance(result, list) else result.get('results', [result])
     )
 
-    # Collect file IDs
     for item in upload_items:
         file_id = item.get('id')
         if file_id:
@@ -890,7 +754,6 @@ async def webftp_bulk_upload(
         else:
             upload_results.append(gathered)
 
-    # Trigger bulk upload processing
     if file_ids:
         await http_client.post(
             region=region,
@@ -932,36 +795,21 @@ async def webftp_bulk_download(
     region: str = '',
     **kwargs,
 ) -> dict[str, Any]:
-    """Download multiple files/folders as a ZIP archive.
-
-    Args:
-        server_id: Server ID to download from
-        remote_paths: List of remote file/folder paths to download (must share same parent directory)
-        local_file_path: Local path to save the ZIP file (e.g., "/Users/user/downloads/files.zip")
-        workspace: Workspace name. Required parameter
-        username: Optional username for the download (uses authenticated user if not provided)
-        region: Region (ap1, us1, eu1). Auto-detected if not provided
-
-    Returns:
-        Bulk download response with file saved locally
-    """
+    """Download multiple files/folders as a ZIP archive."""
     token = kwargs.get('token')
 
     if _is_auth_enabled():
         return error_response(_REMOTE_MODE_ERROR, code='remote_mode_unsupported')
 
-    # Validate non-empty paths list
     if not remote_paths:
         return error_response('remote_paths must not be empty')
 
-    # Validate paths
     for path in remote_paths:
         if not validate_file_path(path):
             return format_validation_error('remote_paths', path)
     if not validate_file_path(local_file_path):
         return format_validation_error('local_file_path', local_file_path)
 
-    # Ensure all remote paths share the same parent directory
     if len(remote_paths) > 1:
         base_dir = os.path.dirname(remote_paths[0])
         for path in remote_paths[1:]:
@@ -971,7 +819,6 @@ async def webftp_bulk_download(
                     remote_paths=remote_paths,
                 )
 
-    # Create bulk download record
     download_data: dict[str, Any] = {
         'server': server_id,
         'path': remote_paths,
@@ -989,7 +836,6 @@ async def webftp_bulk_download(
         data=download_data,
     )
 
-    # Download ZIP from S3 using streaming to avoid high memory usage
     download_url = result.get('download_url') if isinstance(result, dict) else None
     if download_url:
         try:
@@ -1038,17 +884,7 @@ async def webftp_check_status(
     region: str = '',
     **kwargs,
 ) -> dict[str, Any]:
-    """Check status of a WebFTP file transfer.
-
-    Args:
-        file_id: File ID from upload or download operation
-        transfer_type: Type of transfer - "upload" or "download"
-        workspace: Workspace name. Required parameter
-        region: Region (ap1, us1, eu1). Auto-detected if not provided
-
-    Returns:
-        Transfer status (success, in_progress, or failed)
-    """
+    """Check status of a WebFTP file transfer."""
     token = kwargs.get('token')
 
     endpoint_map = {
@@ -1085,15 +921,7 @@ async def webftp_check_status(
     mime_type='application/json',
 )
 async def webftp_sessions_resource(region: str, workspace: str) -> dict[str, Any]:
-    """Get WebFTP sessions as a resource.
-
-    Args:
-        region: Region (ap1, us1, eu1, etc.)
-        workspace: Workspace name
-
-    Returns:
-        WebFTP sessions information
-    """
+    """Get WebFTP sessions as a resource."""
     sessions_data = await webftp_sessions_list(region=region, workspace=workspace)
     return {'content': sessions_data}
 
@@ -1108,16 +936,7 @@ async def webftp_sessions_resource(region: str, workspace: str) -> dict[str, Any
 async def webftp_downloads_resource(
     session_id: str, region: str, workspace: str
 ) -> dict[str, Any]:
-    """Get WebFTP downloads as a resource.
-
-    Args:
-        session_id: WebFTP session ID
-        region: Region (ap1, us1, eu1, etc.)
-        workspace: Workspace name
-
-    Returns:
-        WebFTP downloads information
-    """
+    """Get WebFTP downloads as a resource."""
     downloads_data = await webftp_downloads_list(
         session_id=session_id, region=region, workspace=workspace
     )

--- a/tools/webftp_tools.py
+++ b/tools/webftp_tools.py
@@ -913,7 +913,6 @@ async def webftp_check_status(
     )
 
 
-# WebFTP sessions resource
 @mcp.resource(
     uri='webftp://sessions/{region}/{workspace}',
     name='WebFTP Sessions List',
@@ -926,7 +925,6 @@ async def webftp_sessions_resource(region: str, workspace: str) -> dict[str, Any
     return {'content': sessions_data}
 
 
-# WebFTP downloads resource
 @mcp.resource(
     uri='webftp://downloads/{region}/{workspace}',
     name='WebFTP Downloads List',

--- a/tools/webftp_tools.py
+++ b/tools/webftp_tools.py
@@ -928,16 +928,12 @@ async def webftp_sessions_resource(region: str, workspace: str) -> dict[str, Any
 
 # WebFTP downloads resource
 @mcp.resource(
-    uri='webftp://downloads/{session_id}/{region}/{workspace}',
+    uri='webftp://downloads/{region}/{workspace}',
     name='WebFTP Downloads List',
-    description='Get list of downloadable files from WebFTP session',
+    description='Get list of WebFTP download history for a workspace',
     mime_type='application/json',
 )
-async def webftp_downloads_resource(
-    session_id: str, region: str, workspace: str
-) -> dict[str, Any]:
+async def webftp_downloads_resource(region: str, workspace: str) -> dict[str, Any]:
     """Get WebFTP downloads as a resource."""
-    downloads_data = await webftp_downloads_list(
-        session_id=session_id, region=region, workspace=workspace
-    )
+    downloads_data = await webftp_downloads_list(region=region, workspace=workspace)
     return {'content': downloads_data}

--- a/tools/webftp_tools.py
+++ b/tools/webftp_tools.py
@@ -298,6 +298,15 @@ async def webftp_sessions_list(
         params=params,
     )
 
+    if err := unwrap_http_result(
+        result,
+        default_message='Failed to list WebFTP sessions',
+        server_id=server_id,
+        region=region,
+        workspace=workspace,
+    ):
+        return err
+
     return success_response(
         data=result, server_id=server_id, region=region, workspace=workspace
     )
@@ -650,6 +659,15 @@ async def webftp_uploads_list(
         params=params,
     )
 
+    if err := unwrap_http_result(
+        result,
+        default_message='Failed to list uploads',
+        server_id=server_id,
+        region=region,
+        workspace=workspace,
+    ):
+        return err
+
     return success_response(
         data=result, server_id=server_id, region=region, workspace=workspace
     )
@@ -677,6 +695,15 @@ async def webftp_downloads_list(
         token=token,
         params=params,
     )
+
+    if err := unwrap_http_result(
+        result,
+        default_message='Failed to list downloads',
+        server_id=server_id,
+        region=region,
+        workspace=workspace,
+    ):
+        return err
 
     return success_response(
         data=result, server_id=server_id, region=region, workspace=workspace
@@ -969,6 +996,15 @@ async def webftp_check_status(
         endpoint=endpoint_map[transfer_type],
         token=token,
     )
+
+    if err := unwrap_http_result(
+        result,
+        default_message='Failed to check transfer status',
+        file_id=file_id,
+        region=region,
+        workspace=workspace,
+    ):
+        return err
 
     return success_response(
         data=result,

--- a/tools/webftp_tools.py
+++ b/tools/webftp_tools.py
@@ -12,7 +12,7 @@ from typing import Any, cast
 import httpx
 
 from server import mcp
-from utils.common import error_response, success_response
+from utils.common import error_response, success_response, unwrap_http_result
 from utils.decorators import _is_auth_enabled, mcp_tool_handler
 from utils.error_handler import format_validation_error, validate_file_path
 from utils.http_client import http_client
@@ -175,6 +175,15 @@ async def _download_remote_mode(
         data=download_data,
     )
 
+    if err := unwrap_http_result(
+        result,
+        default_message='Failed to create download request',
+        server_id=server_id,
+        region=region,
+        workspace=workspace,
+    ):
+        return err
+
     file_id = result.get('id')
     download_url = result.get('download_url')
 
@@ -219,7 +228,7 @@ async def _download_remote_mode(
 
 
 @mcp_tool_handler(
-    description='Create a new WebFTP file transfer session on a server. Returns session ID and connection details. When to use: advanced session management. For simple file transfers, use webftp_upload_file or webftp_download_file directly. Related: webftp_sessions_list (view sessions), webftp_upload_file, webftp_download_file.',
+    description='Create a new WebFTP file transfer session on a server. Returns session ID and connection details. Pass session_id (a Work Session ID from work_session_create) to link this WebFTP session to a Work Session for audit—note that session_id here refers to the Work Session, not the WebFTP session being created. When to use: advanced session management. For simple file transfers, use webftp_upload_file or webftp_download_file directly. Related: webftp_sessions_list (view sessions), webftp_upload_file, webftp_download_file, work_session_create (create a Work Session).',
     annotations=ADDITIVE,
     meta={'anthropic/searchHint': 'webftp session create file transfer'},
 )
@@ -247,6 +256,15 @@ async def webftp_session_create(
         token=token,
         data=session_data,
     )
+
+    if err := unwrap_http_result(
+        result,
+        default_message='Failed to create WebFTP session',
+        server_id=server_id,
+        region=region,
+        workspace=workspace,
+    ):
+        return err
 
     return success_response(
         data=result,
@@ -286,7 +304,7 @@ async def webftp_sessions_list(
 
 
 @mcp_tool_handler(
-    description='Upload a local file to a remote server. Reads the file from a local absolute path, transfers it via S3 presigned URL, and places it at the specified remote path on the server. When to use: transferring a single file to a server. Related: webftp_bulk_upload (multiple files), webftp_download_file (download from server), webftp_uploads_list (check upload history). Note: Both local and remote paths must be absolute.',
+    description='Upload a local file to a remote server. Reads the file from a local absolute path, transfers it via S3 presigned URL, and places it at the specified remote path on the server. Pass session_id to link this upload to a Work Session for audit—maps to the work_session field in the API payload; the server enforces this for MCP OAuth and browser-based auth. When to use: transferring a single file to a server. Related: webftp_bulk_upload (multiple files), webftp_download_file (download from server), webftp_uploads_list (check upload history), work_session_create (create a Work Session). Note: Both local and remote paths must be absolute.',
     annotations=ADDITIVE,
     meta={'anthropic/searchHint': 'file upload transfer scp sftp send server'},
 )
@@ -337,6 +355,15 @@ async def webftp_upload_file(
         token=token,
         data=upload_data,
     )
+
+    if http_err := unwrap_http_result(
+        result,
+        default_message='Failed to create upload request',
+        server_id=server_id,
+        region=region,
+        workspace=workspace,
+    ):
+        return http_err
 
     if result.get('upload_url'):
         err = await _upload_bytes_to_s3(result['upload_url'], file_content)
@@ -431,6 +458,15 @@ async def webftp_upload_content(
         data=upload_data,
     )
 
+    if http_err := unwrap_http_result(
+        result,
+        default_message='Failed to create upload request',
+        server_id=server_id,
+        region=region,
+        workspace=workspace,
+    ):
+        return http_err
+
     if result.get('upload_url'):
         err = await _upload_bytes_to_s3(result['upload_url'], raw_bytes)
         if err:
@@ -474,9 +510,12 @@ async def webftp_upload_content(
         'then returns a presigned download URL valid for 24 hours — '
         'open it in a browser or run the curl command in the response. '
         'For folders, content is packaged as a ZIP archive. '
+        'Pass session_id to link this download to a Work Session for audit—maps to the work_session field in the API payload; '
+        'the server enforces this for MCP OAuth and browser-based auth. '
         'Related: webftp_bulk_download (multiple files as ZIP), '
         'webftp_upload_file (upload to server), '
-        'webftp_downloads_list (check download history). '
+        'webftp_downloads_list (check download history), '
+        'work_session_create (create a Work Session). '
         'Note: Set resource_type="folder" for directories.'
     ),
     annotations=ADDITIVE,
@@ -541,6 +580,15 @@ async def webftp_download_file(
         token=token,
         data=download_data,
     )
+
+    if err := unwrap_http_result(
+        result,
+        default_message='Failed to create download request',
+        server_id=server_id,
+        region=region,
+        workspace=workspace,
+    ):
+        return err
 
     if result.get('download_url'):
         try:
@@ -636,7 +684,7 @@ async def webftp_downloads_list(
 
 
 @mcp_tool_handler(
-    description='Upload multiple local files to a remote server in a single operation. All files are placed in the same destination directory. Uses S3 presigned URLs with concurrent uploads. When to use: uploading several files at once (more efficient than repeated webftp_upload_file calls). Related: webftp_upload_file (single file), webftp_bulk_download (download multiple). Note: All files go to the same remote directory.',
+    description='Upload multiple local files to a remote server in a single operation. All files are placed in the same destination directory. Uses S3 presigned URLs with concurrent uploads. Pass session_id to link this upload to a Work Session for audit—maps to the work_session field in the API payload; the server enforces this for MCP OAuth and browser-based auth. When to use: uploading several files at once (more efficient than repeated webftp_upload_file calls). Related: webftp_upload_file (single file), webftp_bulk_download (download multiple), work_session_create (create a Work Session). Note: All files go to the same remote directory.',
     annotations=ADDITIVE,
     meta={'anthropic/searchHint': 'bulk upload multiple files batch transfer'},
 )
@@ -689,6 +737,15 @@ async def webftp_bulk_upload(
         token=token,
         data=bulk_data,
     )
+
+    if err := unwrap_http_result(
+        result,
+        default_message='Failed to create bulk upload request',
+        server_id=server_id,
+        region=region,
+        workspace=workspace,
+    ):
+        return err
 
     file_ids = []
     upload_items = (
@@ -781,7 +838,7 @@ async def webftp_bulk_upload(
 
 
 @mcp_tool_handler(
-    description='Download multiple files or folders from a remote server as a single ZIP archive. All paths must share the same parent directory. When to use: downloading several files at once. Related: webftp_download_file (single file), webftp_bulk_upload (upload multiple), webftp_check_status (poll if still processing). Note: If ZIP is not ready, poll with webftp_check_status then retry.',
+    description='Download multiple files or folders from a remote server as a single ZIP archive. All paths must share the same parent directory. Pass session_id to link this download to a Work Session for audit—maps to the work_session field in the API payload; the server enforces this for MCP OAuth and browser-based auth. When to use: downloading several files at once. Related: webftp_download_file (single file), webftp_bulk_upload (upload multiple), webftp_check_status (poll if still processing), work_session_create (create a Work Session). Note: If ZIP is not ready, poll with webftp_check_status then retry.',
     annotations=ADDITIVE,
     meta={'anthropic/searchHint': 'bulk download multiple files zip archive batch'},
 )
@@ -835,6 +892,15 @@ async def webftp_bulk_download(
         token=token,
         data=download_data,
     )
+
+    if err := unwrap_http_result(
+        result,
+        default_message='Failed to create bulk download request',
+        server_id=server_id,
+        region=region,
+        workspace=workspace,
+    ):
+        return err
 
     download_url = result.get('download_url') if isinstance(result, dict) else None
     if download_url:

--- a/tools/webftp_tools.py
+++ b/tools/webftp_tools.py
@@ -392,10 +392,18 @@ async def webftp_upload_file(
             token=token,
         )
 
+        if trigger_err := unwrap_http_result(
+            upload_trigger,
+            default_message='File uploaded to S3 but server processing trigger failed',
+            server_id=server_id,
+            region=region,
+            workspace=workspace,
+        ):
+            return trigger_err
+
         return success_response(
             message='File uploaded successfully and processed by server',
             data=result,
-            upload_trigger=upload_trigger,
             server_id=server_id,
             local_file_path=local_file_path,
             remote_file_path=remote_file_path,
@@ -494,10 +502,18 @@ async def webftp_upload_content(
             token=token,
         )
 
+        if trigger_err := unwrap_http_result(
+            upload_trigger,
+            default_message='Content uploaded to S3 but server processing trigger failed',
+            server_id=server_id,
+            region=region,
+            workspace=workspace,
+        ):
+            return trigger_err
+
         return success_response(
             message='File content uploaded successfully and processed by server',
             data=result,
-            upload_trigger=upload_trigger,
             server_id=server_id,
             remote_file_path=remote_file_path,
             file_size=len(raw_bytes),
@@ -845,13 +861,21 @@ async def webftp_bulk_upload(
             upload_results.append(gathered)
 
     if file_ids:
-        await http_client.post(
+        trigger_result = await http_client.post(
             region=region,
             workspace=workspace,
             endpoint=_API_BULK_UPLOAD_TRIGGER,
             token=token,
             data={'ids': file_ids},
         )
+        if trigger_err := unwrap_http_result(
+            trigger_result,
+            default_message='Files uploaded but bulk processing trigger failed',
+            server_id=server_id,
+            region=region,
+            workspace=workspace,
+        ):
+            return trigger_err
 
     successful = sum(
         1 for r in upload_results if r['status'] in ['uploaded', 'created']

--- a/tools/work_session_tools.py
+++ b/tools/work_session_tools.py
@@ -12,16 +12,20 @@ _API_SESSIONS = '/api/work-sessions/sessions/'
 
 @mcp_tool_handler(
     description=(
-        'Create a WorkSession to scope infrastructure tool calls under an auditable, '
-        'approval-gated session. Required when using MCP OAuth (streamable-http mode). '
-        'Returns session ID to pass as session_id to execute_command and webftp tools. '
-        'scopes controls which operations are allowed: "command" for execute_command, '
-        '"webftp" for file transfers. servers is the list of target server UUIDs. '
+        'Create a Work Session to scope all infrastructure actions under an auditable, '
+        'approval-gated session. Every execute_command and file transfer must be linked '
+        'to a Work Session—there is no out-of-session execution path. '
+        'description is the declared intent: the WHY of the session '
+        '(e.g. "fix nginx 502 on prod-web-1"). '
+        'scopes declares which operations are allowed: '
+        '"command" (execute_command), "webftp" (file transfers), '
+        '"websh" (interactive terminal), "tunnel" (port forwarding), "sudo" (privilege elevation). '
+        'servers is the list of target server UUIDs. '
         'expires_at is an ISO 8601 datetime string. '
         'Related: work_session_close (end session), execute_command (pass session_id).'
     ),
     annotations=ADDITIVE,
-    meta={'anthropic/searchHint': 'work session create audit approval scope'},
+    meta={'anthropic/searchHint': 'work session create audit approval scope intent'},
 )
 async def work_session_create(
     workspace: str,
@@ -59,7 +63,7 @@ async def work_session_create(
 
 @mcp_tool_handler(
     description=(
-        'Mark a WorkSession as completed and trigger AI security analysis. '
+        'Mark a Work Session as completed and trigger AI security analysis (Pass 1–4). '
         'Call after all commands and file transfers for this session are done. '
         'Related: work_session_create (create session), work_session_get (check status).'
     ),
@@ -90,7 +94,7 @@ async def work_session_close(
 
 @mcp_tool_handler(
     description=(
-        'Get details of a WorkSession: status, scopes, servers, timeline, auth_method. '
+        'Get details of a Work Session: status, scopes, servers, timeline, auth_method. '
         'Related: work_session_list (list all sessions), work_session_close (end session).'
     ),
     annotations=READ_ONLY,
@@ -119,7 +123,7 @@ async def work_session_get(
 
 @mcp_tool_handler(
     description=(
-        'List WorkSessions in a workspace. Optional status filter: '
+        'List Work Sessions in a workspace. Optional status filter: '
         '"pending", "active", "completed", "rejected", "cancelled", "expired". '
         'Optional auth_method filter: "web", "cli", "service_token", "mcp_oauth". '
         'Related: work_session_create (create session), work_session_get (single session detail).'

--- a/tools/work_session_tools.py
+++ b/tools/work_session_tools.py
@@ -133,6 +133,15 @@ async def work_session_get(
         token=token,
     )
 
+    if err := unwrap_http_result(
+        result,
+        default_message='Failed to get Work Session',
+        session_id=session_id,
+        region=region,
+        workspace=workspace,
+    ):
+        return err
+
     return success_response(
         data=result, session_id=session_id, region=region, workspace=workspace
     )
@@ -172,5 +181,13 @@ async def work_session_list(
         token=token,
         params=params,
     )
+
+    if err := unwrap_http_result(
+        result,
+        default_message='Failed to list Work Sessions',
+        region=region,
+        workspace=workspace,
+    ):
+        return err
 
     return success_response(data=result, region=region, workspace=workspace)

--- a/tools/work_session_tools.py
+++ b/tools/work_session_tools.py
@@ -28,7 +28,7 @@ async def work_session_create(
     scopes: list[str],
     servers: list[str],
     expires_at: str,
-    description: str = '',
+    description: str,
     title: str = '',
     region: str = '',
     **kwargs,
@@ -41,9 +41,8 @@ async def work_session_create(
         'scopes': scopes,
         'servers': servers,
         'expires_at': expires_at,
+        'description': description,
     }
-    if description:
-        data['description'] = description
     if title:
         data['title'] = title
 
@@ -122,6 +121,7 @@ async def work_session_get(
     description=(
         'List WorkSessions in a workspace. Optional status filter: '
         '"pending", "active", "completed", "rejected", "cancelled", "expired". '
+        'Optional auth_method filter: "web", "cli", "service_token", "mcp_oauth". '
         'Related: work_session_create (create session), work_session_get (single session detail).'
     ),
     annotations=READ_ONLY,
@@ -130,16 +130,19 @@ async def work_session_get(
 async def work_session_list(
     workspace: str,
     status: str | None = None,
+    auth_method: str | None = None,
     limit: int = 20,
     region: str = '',
     **kwargs,
 ) -> dict[str, Any]:
-    """List WorkSessions with optional status filtering."""
+    """List WorkSessions with optional status and auth_method filtering."""
     token = kwargs.get('token')
 
     params: dict[str, Any] = {'page_size': limit}
     if status:
         params['status'] = status
+    if auth_method:
+        params['auth_method'] = auth_method
 
     result = await http_client.get(
         region=region,

--- a/tools/work_session_tools.py
+++ b/tools/work_session_tools.py
@@ -34,7 +34,7 @@ async def work_session_create(
     servers: list[str],
     expires_at: str,
     description: str,
-    title: str = '',
+    title: str | None = None,
     region: str = '',
     **kwargs,
 ) -> dict[str, Any]:

--- a/tools/work_session_tools.py
+++ b/tools/work_session_tools.py
@@ -1,0 +1,152 @@
+"""WorkSession management tools for Alpacon MCP server."""
+
+from typing import Any
+
+from utils.common import success_response
+from utils.decorators import mcp_tool_handler
+from utils.http_client import http_client
+from utils.tool_annotations import ADDITIVE, DESTRUCTIVE, READ_ONLY
+
+_API_SESSIONS = '/api/work-sessions/sessions/'
+
+
+@mcp_tool_handler(
+    description=(
+        'Create a WorkSession to scope infrastructure tool calls under an auditable, '
+        'approval-gated session. Required when using MCP OAuth (streamable-http mode). '
+        'Returns session ID to pass as session_id to execute_command and webftp tools. '
+        'scopes controls which operations are allowed: "command" for execute_command, '
+        '"webftp" for file transfers. servers is the list of target server UUIDs. '
+        'expires_at is an ISO 8601 datetime string. '
+        'Related: work_session_close (end session), execute_command (pass session_id).'
+    ),
+    annotations=ADDITIVE,
+    meta={'anthropic/searchHint': 'work session create audit approval scope'},
+)
+async def work_session_create(
+    workspace: str,
+    scopes: list[str],
+    servers: list[str],
+    expires_at: str,
+    description: str = '',
+    title: str = '',
+    region: str = '',
+    **kwargs,
+) -> dict[str, Any]:
+    """Create a WorkSession for auditable, approval-gated infrastructure access."""
+    token = kwargs.get('token')
+
+    data: dict[str, Any] = {
+        'requester_type': 'agent',
+        'scopes': scopes,
+        'servers': servers,
+        'expires_at': expires_at,
+    }
+    if description:
+        data['description'] = description
+    if title:
+        data['title'] = title
+
+    result = await http_client.post(
+        region=region,
+        workspace=workspace,
+        endpoint=_API_SESSIONS,
+        token=token,
+        data=data,
+    )
+
+    return success_response(data=result, region=region, workspace=workspace)
+
+
+@mcp_tool_handler(
+    description=(
+        'Mark a WorkSession as completed and trigger AI security analysis. '
+        'Call after all commands and file transfers for this session are done. '
+        'Related: work_session_create (create session), work_session_get (check status).'
+    ),
+    annotations=DESTRUCTIVE,
+    meta={'anthropic/searchHint': 'work session close complete end finish'},
+)
+async def work_session_close(
+    session_id: str,
+    workspace: str,
+    region: str = '',
+    **kwargs,
+) -> dict[str, Any]:
+    """Complete a WorkSession."""
+    token = kwargs.get('token')
+
+    result = await http_client.post(
+        region=region,
+        workspace=workspace,
+        endpoint=f'{_API_SESSIONS}{session_id}/complete/',
+        token=token,
+        data={},
+    )
+
+    return success_response(
+        data=result, session_id=session_id, region=region, workspace=workspace
+    )
+
+
+@mcp_tool_handler(
+    description=(
+        'Get details of a WorkSession: status, scopes, servers, timeline, auth_method. '
+        'Related: work_session_list (list all sessions), work_session_close (end session).'
+    ),
+    annotations=READ_ONLY,
+    meta={'anthropic/searchHint': 'work session get detail status timeline'},
+)
+async def work_session_get(
+    session_id: str,
+    workspace: str,
+    region: str = '',
+    **kwargs,
+) -> dict[str, Any]:
+    """Get detailed information about a specific WorkSession."""
+    token = kwargs.get('token')
+
+    result = await http_client.get(
+        region=region,
+        workspace=workspace,
+        endpoint=f'{_API_SESSIONS}{session_id}/',
+        token=token,
+    )
+
+    return success_response(
+        data=result, session_id=session_id, region=region, workspace=workspace
+    )
+
+
+@mcp_tool_handler(
+    description=(
+        'List WorkSessions in a workspace. Optional status filter: '
+        '"pending", "active", "completed", "rejected", "cancelled", "expired". '
+        'Related: work_session_create (create session), work_session_get (single session detail).'
+    ),
+    annotations=READ_ONLY,
+    meta={'anthropic/searchHint': 'work session list history audit'},
+)
+async def work_session_list(
+    workspace: str,
+    status: str | None = None,
+    limit: int = 20,
+    region: str = '',
+    **kwargs,
+) -> dict[str, Any]:
+    """List WorkSessions with optional status filtering."""
+    token = kwargs.get('token')
+
+    params: dict[str, Any] = {'page_size': limit}
+    if status:
+        params['status'] = status
+
+    result = await http_client.get(
+        region=region,
+        workspace=workspace,
+        endpoint=_API_SESSIONS,
+        token=token,
+        params=params,
+    )
+
+    return success_response(data=result, region=region, workspace=workspace)

--- a/tools/work_session_tools.py
+++ b/tools/work_session_tools.py
@@ -41,7 +41,7 @@ async def work_session_create(
     """Create a Work Session for auditable, approval-gated infrastructure access."""
     token = kwargs.get('token')
 
-    data: dict[str, Any] = {
+    data: dict[str, str | list[str]] = {
         'requester_type': 'agent',
         'scopes': scopes,
         'servers': servers,
@@ -169,7 +169,7 @@ async def work_session_list(
     """List Work Sessions with optional status and auth_method filtering."""
     token = kwargs.get('token')
 
-    params: dict[str, Any] = {'page_size': limit}
+    params: dict[str, str | int] = {'page_size': limit}
     if status:
         params['status'] = status
     if auth_method:

--- a/tools/work_session_tools.py
+++ b/tools/work_session_tools.py
@@ -1,8 +1,8 @@
-"""WorkSession management tools for Alpacon MCP server."""
+"""Work Session management tools for Alpacon MCP server."""
 
 from typing import Any
 
-from utils.common import success_response
+from utils.common import success_response, unwrap_http_result
 from utils.decorators import mcp_tool_handler
 from utils.http_client import http_client
 from utils.tool_annotations import ADDITIVE, DESTRUCTIVE, READ_ONLY
@@ -37,7 +37,7 @@ async def work_session_create(
     region: str = '',
     **kwargs,
 ) -> dict[str, Any]:
-    """Create a WorkSession for auditable, approval-gated infrastructure access."""
+    """Create a Work Session for auditable, approval-gated infrastructure access."""
     token = kwargs.get('token')
 
     data: dict[str, Any] = {
@@ -58,6 +58,14 @@ async def work_session_create(
         data=data,
     )
 
+    if err := unwrap_http_result(
+        result,
+        default_message='Failed to create Work Session',
+        region=region,
+        workspace=workspace,
+    ):
+        return err
+
     return success_response(data=result, region=region, workspace=workspace)
 
 
@@ -76,7 +84,7 @@ async def work_session_close(
     region: str = '',
     **kwargs,
 ) -> dict[str, Any]:
-    """Complete a WorkSession."""
+    """Complete a Work Session."""
     token = kwargs.get('token')
 
     result = await http_client.post(
@@ -86,6 +94,15 @@ async def work_session_close(
         token=token,
         data={},
     )
+
+    if err := unwrap_http_result(
+        result,
+        default_message='Failed to close Work Session',
+        session_id=session_id,
+        region=region,
+        workspace=workspace,
+    ):
+        return err
 
     return success_response(
         data=result, session_id=session_id, region=region, workspace=workspace
@@ -106,7 +123,7 @@ async def work_session_get(
     region: str = '',
     **kwargs,
 ) -> dict[str, Any]:
-    """Get detailed information about a specific WorkSession."""
+    """Get detailed information about a specific Work Session."""
     token = kwargs.get('token')
 
     result = await http_client.get(
@@ -139,7 +156,7 @@ async def work_session_list(
     region: str = '',
     **kwargs,
 ) -> dict[str, Any]:
-    """List WorkSessions with optional status and auth_method filtering."""
+    """List Work Sessions with optional status and auth_method filtering."""
     token = kwargs.get('token')
 
     params: dict[str, Any] = {'page_size': limit}

--- a/tools/work_session_tools.py
+++ b/tools/work_session_tools.py
@@ -13,8 +13,9 @@ _API_SESSIONS = '/api/work-sessions/sessions/'
 @mcp_tool_handler(
     description=(
         'Create a Work Session to scope all infrastructure actions under an auditable, '
-        'approval-gated session. Every execute_command and file transfer must be linked '
-        'to a Work Session—there is no out-of-session execution path. '
+        'approval-gated session. Every execute_command and file transfer should be linked '
+        'to a Work Session—the server enforces this for MCP OAuth and browser-based auth '
+        '(session_id is optional for other auth methods such as service tokens). '
         'description is the declared intent: the WHY of the session '
         '(e.g. "fix nginx 502 on prod-web-1"). '
         'scopes declares which operations are allowed: '


### PR DESCRIPTION
## Summary

Adds Work Session management tools to the MCP server and links all command execution and file transfer operations to Work Sessions, aligned with ADR 0001: every infrastructure action must belong to a Work Session—there is no out-of-session execution path.

Depends on: alpacon-server#2083 (Work Session backend implementation).

## Changes

### New tools (`tools/work_session_tools.py`)

| Tool | Description |
|------|-------------|
| `work_session_create` | Create a Work Session with declared intent (`description`), scopes, target servers, and expiry |
| `work_session_close` | Complete a Work Session and trigger AI security analysis (Pass 1–4) |
| `work_session_get` | Get Work Session details: status, scopes, servers, auth_method |
| `work_session_list` | List Work Sessions with optional `status` and `auth_method` filters |

### Session linking in existing tools

- `execute_command`, `execute_command_multi_server`: added `session_id` parameter, passed as `work_session` FK to the command API
- All 6 webftp tools: added `session_id` parameter, passed as `work_session` FK to transfer API
- Removed client-side `ALPACON_MCP_REQUIRE_SESSION` guard — enforcement is server-side (`validate_work_session_presence` in `work_sessions/services.py` already rejects requests without a session for MCP OAuth and browser-based auth)

### Tool descriptions aligned with handbook

- "Work Session" (two words) per handbook glossary
- `description` framed as declared intent: the WHY (e.g. `"fix nginx 502 on prod-web-1"`)
- Full scope list documented: `command`, `webftp`, `websh`, `tunnel`, `sudo`
- AI analysis Pass 1–4 referenced in `work_session_close`

### Tests

544 tests passing across the full suite.

## Verified

End-to-end integration test against `alpacax` dev workspace:

| Tool | Result |
|------|--------|
| `work_session_list` | ✅ Retrieved 109 existing sessions |
| `work_session_create` | ✅ Session created with `active` status (`requester_type: agent`, scopes and servers reflected correctly) |
| `work_session_get` | ✅ Session details retrieved successfully |
| `work_session_close` | ✅ Session closed with `completed` status |

## Usage

```python
# 1. Create a Work Session with declared intent
session = work_session_create(
    workspace="production",
    scopes=["command", "webftp"],
    servers=["<server-uuid>"],
    expires_at="2026-05-19T18:00:00+00:00",
    description="rotate logs older than 7 days on prod fleet",
)
session_id = session["data"]["id"]

# 2. Link commands and transfers to the session
execute_command(server_id="...", command="...", session_id=session_id, workspace="production")
webftp_upload_file(..., session_id=session_id)

# 3. Complete the session — triggers AI Pass 1–4 analysis
work_session_close(session_id=session_id, workspace="production")
```

## Handbook alignment

| Principle | Implementation |
|-----------|----------------|
| ADR 0001: no out-of-session path | `session_id` on all action tools; server enforces for MCP OAuth/browser auth |
| P5: Work Session as single context primitive | Commands and transfers linked via `work_session` FK |
| Intent-first (`description`) | Tool description frames it as the declared WHY of the session |
| Scopes: command/webftp/websh/tunnel/sudo | Full list documented in `work_session_create` description |
| AI analysis Pass 1–4 | Referenced in `work_session_close` description |

---

## Out-of-scope changes included in this PR

### Bug fix: missing error envelope checks on GET endpoints

`list_commands`, `webftp_sessions_list`, `webftp_uploads_list`, `webftp_downloads_list`, and `webftp_check_status` were not calling `unwrap_http_result()` after their GET calls. This meant upstream HTTP errors (e.g. 403 Forbidden) were silently passed through as success responses. Fixed to be consistent with the POST endpoints in the same file, which already had the check. Regression tests added for each affected endpoint.

### Refactor: move inline imports to module level in test files

`tests/test_command_tools.py` had no module-level imports from `tools.command_tools`—every test method imported individually. `tests/test_webftp_tools.py` had duplicate inline imports in its later test classes despite a module-level import block already at the top. Both files have been cleaned up: imports moved to the top, inline imports removed.

---

## Follow-up

**Active Work Session context (#105)**: currently the AI must pass `work_session_id` explicitly on every tool call. A follow-up PR will introduce a server-side active session context (per-connection for stdio, per-user JWT sub for remote OAuth mode) so the AI can activate a session once and have it applied automatically to subsequent operations—reducing parameter noise and the chance of missed session links in long workflows.