### PR TITLE
feat: API token management tools (closes #75)

### DIFF
--- a/server.py
+++ b/server.py
@@ -281,6 +281,7 @@ def run(
     import tools.security_tools  # noqa: F401
     import tools.server_tools  # noqa: F401
     import tools.system_info_tools  # noqa: F401
+    import tools.token_tools  # noqa: F401
     import tools.webftp_tools  # noqa: F401
     import tools.webhook_tools  # noqa: F401
     import tools.workspace_tools  # noqa: F401

--- a/tests/test_token_tools.py
+++ b/tests/test_token_tools.py
@@ -8,8 +8,11 @@ from tools.token_tools import (
     create_api_token,
     delete_api_token,
     duplicate_api_token,
+    get_api_token,
+    list_api_token_presets,
     list_api_token_scopes,
     list_api_tokens,
+    update_api_token,
 )
 
 
@@ -19,6 +22,7 @@ def mock_http_client():
     with patch('tools.token_tools.http_client') as mock_client:
         mock_client.get = AsyncMock()
         mock_client.post = AsyncMock()
+        mock_client.patch = AsyncMock()
         mock_client.delete = AsyncMock()
         yield mock_client
 
@@ -78,6 +82,49 @@ class TestListApiTokens:
             token='test-token',
             params={'page': 2, 'page_size': 5},
         )
+
+    @pytest.mark.asyncio
+    async def test_list_api_tokens_with_filters(
+        self, mock_http_client, mock_token_manager
+    ):
+        """Test that filter/search/ordering params are forwarded to the API."""
+        mock_http_client.get.return_value = {'count': 0, 'results': []}
+
+        result = await list_api_tokens(
+            workspace='testworkspace',
+            region='ap1',
+            name='deploy-bot',
+            enabled=True,
+            remote_ip='10.0.0.5',
+            search='deploy',
+            ordering='-updated_at',
+        )
+
+        assert result['status'] == 'success'
+        mock_http_client.get.assert_called_once_with(
+            region='ap1',
+            workspace='testworkspace',
+            endpoint='/api/auth/tokens/',
+            token='test-token',
+            params={
+                'name': 'deploy-bot',
+                'enabled': True,
+                'remote_ip': '10.0.0.5',
+                'search': 'deploy',
+                'ordering': '-updated_at',
+            },
+        )
+
+    @pytest.mark.asyncio
+    async def test_list_api_tokens_enabled_false_forwarded(
+        self, mock_http_client, mock_token_manager
+    ):
+        """Test that enabled=False is still forwarded (not treated as missing)."""
+        mock_http_client.get.return_value = {'count': 0, 'results': []}
+
+        await list_api_tokens(workspace='testworkspace', region='ap1', enabled=False)
+
+        assert mock_http_client.get.call_args[1]['params'] == {'enabled': False}
 
     @pytest.mark.asyncio
     async def test_list_api_tokens_empty(self, mock_http_client, mock_token_manager):
@@ -523,5 +570,259 @@ class TestListApiTokenScopes:
         }
 
         result = await list_api_token_scopes(workspace='testworkspace', region='ap1')
+
+        assert result['status'] == 'error'
+
+
+class TestGetApiToken:
+    """Tests for get_api_token tool."""
+
+    @pytest.mark.asyncio
+    async def test_get_api_token_success(self, mock_http_client, mock_token_manager):
+        """Test successful single API token retrieval."""
+        mock_http_client.get.return_value = {
+            'id': '550e8400-e29b-41d4-a716-446655440010',
+            'name': 'Detail Token',
+            'enabled': True,
+            'scopes': ['*'],
+        }
+
+        result = await get_api_token(
+            token_id='550e8400-e29b-41d4-a716-446655440010',
+            workspace='testworkspace',
+            region='ap1',
+        )
+
+        assert result['status'] == 'success'
+        assert result['token_id'] == '550e8400-e29b-41d4-a716-446655440010'
+        assert result['data']['name'] == 'Detail Token'
+        mock_http_client.get.assert_called_once_with(
+            region='ap1',
+            workspace='testworkspace',
+            endpoint='/api/auth/tokens/550e8400-e29b-41d4-a716-446655440010/',
+            token='test-token',
+        )
+
+    @pytest.mark.asyncio
+    async def test_get_api_token_invalid_token_id(
+        self, mock_http_client, mock_token_manager
+    ):
+        """Test that get_api_token returns error for non-UUID token_id."""
+        result = await get_api_token(
+            token_id='not-a-uuid', workspace='testworkspace', region='ap1'
+        )
+
+        assert result['status'] == 'error'
+        mock_http_client.get.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_get_api_token_not_found(self, mock_http_client, mock_token_manager):
+        """Test that get_api_token returns error when token does not exist."""
+        mock_http_client.get.return_value = {
+            'error': 'HTTP Error',
+            'status_code': 404,
+            'message': 'Not found',
+        }
+
+        result = await get_api_token(
+            token_id='550e8400-e29b-41d4-a716-446655440099',
+            workspace='testworkspace',
+            region='ap1',
+        )
+
+        assert result['status'] == 'error'
+
+
+class TestUpdateApiToken:
+    """Tests for update_api_token tool."""
+
+    @pytest.mark.asyncio
+    async def test_update_api_token_toggle_enabled(
+        self, mock_http_client, mock_token_manager
+    ):
+        """Test disabling a token via update_api_token (enabled=False)."""
+        mock_http_client.patch.return_value = {
+            'id': '550e8400-e29b-41d4-a716-446655440020',
+            'name': 'Active Token',
+            'enabled': False,
+        }
+
+        result = await update_api_token(
+            token_id='550e8400-e29b-41d4-a716-446655440020',
+            workspace='testworkspace',
+            region='ap1',
+            enabled=False,
+        )
+
+        assert result['status'] == 'success'
+        mock_http_client.patch.assert_called_once_with(
+            region='ap1',
+            workspace='testworkspace',
+            endpoint='/api/auth/tokens/550e8400-e29b-41d4-a716-446655440020/',
+            token='test-token',
+            data={'enabled': False},
+        )
+
+    @pytest.mark.asyncio
+    async def test_update_api_token_with_all_fields(
+        self, mock_http_client, mock_token_manager
+    ):
+        """Test update_api_token forwards every supplied field."""
+        mock_http_client.patch.return_value = {
+            'id': '550e8400-e29b-41d4-a716-446655440021',
+            'name': 'Renamed',
+            'enabled': True,
+            'scopes': ['server:read'],
+            'expires_at': '2027-01-01T00:00:00Z',
+        }
+
+        result = await update_api_token(
+            token_id='550e8400-e29b-41d4-a716-446655440021',
+            workspace='testworkspace',
+            region='ap1',
+            name='Renamed',
+            enabled=True,
+            expires_at='2027-01-01T00:00:00Z',
+            scopes=['server:read'],
+        )
+
+        assert result['status'] == 'success'
+        mock_http_client.patch.assert_called_once_with(
+            region='ap1',
+            workspace='testworkspace',
+            endpoint='/api/auth/tokens/550e8400-e29b-41d4-a716-446655440021/',
+            token='test-token',
+            data={
+                'name': 'Renamed',
+                'enabled': True,
+                'expires_at': '2027-01-01T00:00:00Z',
+                'scopes': ['server:read'],
+            },
+        )
+
+    @pytest.mark.asyncio
+    async def test_update_api_token_no_fields_returns_error(
+        self, mock_http_client, mock_token_manager
+    ):
+        """Test update_api_token returns error when no field is provided."""
+        result = await update_api_token(
+            token_id='550e8400-e29b-41d4-a716-446655440022',
+            workspace='testworkspace',
+            region='ap1',
+        )
+
+        assert result['status'] == 'error'
+        mock_http_client.patch.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_update_api_token_invalid_token_id(
+        self, mock_http_client, mock_token_manager
+    ):
+        """Test update_api_token returns error for non-UUID token_id."""
+        result = await update_api_token(
+            token_id='not-a-uuid',
+            workspace='testworkspace',
+            region='ap1',
+            enabled=False,
+        )
+
+        assert result['status'] == 'error'
+        mock_http_client.patch.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_update_api_token_http_error(
+        self, mock_http_client, mock_token_manager
+    ):
+        """Test update_api_token surfaces server error responses as errors.
+
+        Covers e.g. API_TOKEN_PRESETS_NOT_ALLOWED_ON_UPDATE / scope
+        ceiling rejection returned by the server.
+        """
+        mock_http_client.patch.return_value = {
+            'error': 'HTTP Error',
+            'status_code': 400,
+            'message': 'Presets are not allowed on update.',
+        }
+
+        result = await update_api_token(
+            token_id='550e8400-e29b-41d4-a716-446655440023',
+            workspace='testworkspace',
+            region='ap1',
+            scopes=['server:read'],
+        )
+
+        assert result['status'] == 'error'
+
+    @pytest.mark.asyncio
+    async def test_update_api_token_not_found(
+        self, mock_http_client, mock_token_manager
+    ):
+        """Test update_api_token returns error when token does not exist."""
+        mock_http_client.patch.return_value = {
+            'error': 'HTTP Error',
+            'status_code': 404,
+            'message': 'Not found',
+        }
+
+        result = await update_api_token(
+            token_id='550e8400-e29b-41d4-a716-446655440099',
+            workspace='testworkspace',
+            region='ap1',
+            enabled=False,
+        )
+
+        assert result['status'] == 'error'
+
+
+class TestListApiTokenPresets:
+    """Tests for list_api_token_presets tool."""
+
+    @pytest.mark.asyncio
+    async def test_list_api_token_presets_success(
+        self, mock_http_client, mock_token_manager
+    ):
+        """Test successful preset catalog retrieval."""
+        mock_http_client.get.return_value = {
+            'file_upload': {
+                'name': 'File upload',
+                'scopes': ['webftp:upload'],
+            },
+        }
+
+        result = await list_api_token_presets(workspace='testworkspace', region='ap1')
+
+        assert result['status'] == 'success'
+        assert 'file_upload' in result['data']
+        mock_http_client.get.assert_called_once_with(
+            region='ap1',
+            workspace='testworkspace',
+            endpoint='/api/auth/tokens/presets/',
+            token='test-token',
+        )
+
+    @pytest.mark.asyncio
+    async def test_list_api_token_presets_empty(
+        self, mock_http_client, mock_token_manager
+    ):
+        """Test preset catalog when workspace has no enabled presets."""
+        mock_http_client.get.return_value = {}
+
+        result = await list_api_token_presets(workspace='testworkspace', region='ap1')
+
+        assert result['status'] == 'success'
+        assert result['data'] == {}
+
+    @pytest.mark.asyncio
+    async def test_list_api_token_presets_http_error(
+        self, mock_http_client, mock_token_manager
+    ):
+        """Test list_api_token_presets surfaces API error responses as errors."""
+        mock_http_client.get.return_value = {
+            'error': 'HTTP Error',
+            'status_code': 403,
+            'message': 'Permission denied',
+        }
+
+        result = await list_api_token_presets(workspace='testworkspace', region='ap1')
 
         assert result['status'] == 'error'

--- a/tests/test_token_tools.py
+++ b/tests/test_token_tools.py
@@ -31,7 +31,7 @@ def mock_http_client():
 def mock_token_manager():
     """Mock token manager for testing."""
     with patch('utils.common.token_manager') as mock_manager:
-        mock_manager.get_token.return_value = 'test-token'
+        mock_manager.get_token.return_value = 'header.payload.signature'
         yield mock_manager
 
 
@@ -59,7 +59,7 @@ class TestListApiTokens:
             region='ap1',
             workspace='testworkspace',
             endpoint='/api/auth/tokens/',
-            token='test-token',
+            token='header.payload.signature',
             params={},
         )
 
@@ -79,7 +79,7 @@ class TestListApiTokens:
             region='ap1',
             workspace='testworkspace',
             endpoint='/api/auth/tokens/',
-            token='test-token',
+            token='header.payload.signature',
             params={'page': 2, 'page_size': 5},
         )
 
@@ -105,7 +105,7 @@ class TestListApiTokens:
             region='ap1',
             workspace='testworkspace',
             endpoint='/api/auth/tokens/',
-            token='test-token',
+            token='header.payload.signature',
             params={
                 'name': 'deploy-bot',
                 'enabled': True,
@@ -174,7 +174,7 @@ class TestCreateApiToken:
             region='ap1',
             workspace='testworkspace',
             endpoint='/api/auth/tokens/',
-            token='test-token',
+            token='header.payload.signature',
             data={'name': 'My Token'},
         )
 
@@ -199,7 +199,7 @@ class TestCreateApiToken:
             region='ap1',
             workspace='testworkspace',
             endpoint='/api/auth/tokens/',
-            token='test-token',
+            token='header.payload.signature',
             data={
                 'name': 'Full Token',
                 'scopes': ['read', 'write'],
@@ -349,7 +349,7 @@ class TestDeleteApiToken:
             region='ap1',
             workspace='testworkspace',
             endpoint='/api/auth/tokens/550e8400-e29b-41d4-a716-446655440001/',
-            token='test-token',
+            token='header.payload.signature',
         )
 
     @pytest.mark.asyncio
@@ -441,7 +441,7 @@ class TestDuplicateApiToken:
             region='ap1',
             workspace='testworkspace',
             endpoint='/api/auth/tokens/550e8400-e29b-41d4-a716-446655440003/duplicate/',
-            token='test-token',
+            token='header.payload.signature',
             data={},
         )
 
@@ -467,7 +467,7 @@ class TestDuplicateApiToken:
             region='ap1',
             workspace='testworkspace',
             endpoint='/api/auth/tokens/550e8400-e29b-41d4-a716-446655440003/duplicate/',
-            token='test-token',
+            token='header.payload.signature',
             data={'name': 'My Backup Token'},
         )
 
@@ -585,7 +585,7 @@ class TestListApiTokenScopes:
             region='ap1',
             workspace='testworkspace',
             endpoint='/api/auth/tokens/scopes/',
-            token='test-token',
+            token='header.payload.signature',
         )
 
     @pytest.mark.asyncio
@@ -642,7 +642,7 @@ class TestGetApiToken:
             region='ap1',
             workspace='testworkspace',
             endpoint='/api/auth/tokens/550e8400-e29b-41d4-a716-446655440010/',
-            token='test-token',
+            token='header.payload.signature',
         )
 
     @pytest.mark.asyncio
@@ -701,7 +701,7 @@ class TestUpdateApiToken:
             region='ap1',
             workspace='testworkspace',
             endpoint='/api/auth/tokens/550e8400-e29b-41d4-a716-446655440020/',
-            token='test-token',
+            token='header.payload.signature',
             data={'enabled': False},
         )
 
@@ -733,7 +733,7 @@ class TestUpdateApiToken:
             region='ap1',
             workspace='testworkspace',
             endpoint='/api/auth/tokens/550e8400-e29b-41d4-a716-446655440021/',
-            token='test-token',
+            token='header.payload.signature',
             data={
                 'name': 'Renamed',
                 'enabled': True,
@@ -918,7 +918,7 @@ class TestListApiTokenPresets:
             region='ap1',
             workspace='testworkspace',
             endpoint='/api/auth/tokens/presets/',
-            token='test-token',
+            token='header.payload.signature',
         )
 
     @pytest.mark.asyncio
@@ -947,3 +947,99 @@ class TestListApiTokenPresets:
         result = await list_api_token_presets(workspace='testworkspace', region='ap1')
 
         assert result['status'] == 'error'
+
+
+class TestApiTokenMutationAuthGuard:
+    """Preflight guard: the 4 mutation tools (create/update/duplicate/delete)
+    must short-circuit on the MCP side when the caller's resolved token is
+    not a JWT — because the server's APITokenObjectPermission would 403
+    every such request. The guard saves the round-trip and surfaces a
+    clearer error to the client.
+
+    Read-only tools (list/get/list_scopes/list_presets) are intentionally
+    NOT guarded — list/get because callers may legitimately enumerate
+    their own tokens with whichever auth they hold, and the catalog
+    endpoints because the server itself does not gate them with
+    APITokenObjectPermission.
+    """
+
+    @pytest.mark.asyncio
+    async def test_create_rejected_for_non_jwt_token(
+        self, mock_http_client, mock_token_manager
+    ):
+        mock_token_manager.get_token.return_value = 'opaque-api-token'
+
+        result = await create_api_token(
+            workspace='testworkspace', region='ap1', name='New token'
+        )
+
+        assert result['status'] == 'error'
+        assert 'JWT' in result['message']
+        mock_http_client.post.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_update_rejected_for_non_jwt_token(
+        self, mock_http_client, mock_token_manager
+    ):
+        mock_token_manager.get_token.return_value = 'opaque-api-token'
+
+        result = await update_api_token(
+            workspace='testworkspace',
+            region='ap1',
+            token_id='550e8400-e29b-41d4-a716-446655440000',
+            name='Renamed',
+        )
+
+        assert result['status'] == 'error'
+        assert 'JWT' in result['message']
+        mock_http_client.patch.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_duplicate_rejected_for_non_jwt_token(
+        self, mock_http_client, mock_token_manager
+    ):
+        mock_token_manager.get_token.return_value = 'opaque-api-token'
+
+        result = await duplicate_api_token(
+            workspace='testworkspace',
+            region='ap1',
+            token_id='550e8400-e29b-41d4-a716-446655440000',
+        )
+
+        assert result['status'] == 'error'
+        assert 'JWT' in result['message']
+        mock_http_client.post.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_delete_rejected_for_non_jwt_token(
+        self, mock_http_client, mock_token_manager
+    ):
+        mock_token_manager.get_token.return_value = 'opaque-api-token'
+
+        result = await delete_api_token(
+            workspace='testworkspace',
+            region='ap1',
+            token_id='550e8400-e29b-41d4-a716-446655440000',
+        )
+
+        assert result['status'] == 'error'
+        assert 'JWT' in result['message']
+        mock_http_client.delete.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_jwt_token_passes_guard(self, mock_http_client, mock_token_manager):
+        """JWT-shaped token (3 dotted non-empty parts) bypasses the guard
+        and reaches the underlying HTTP call."""
+        mock_token_manager.get_token.return_value = 'header.payload.signature'
+        mock_http_client.post.return_value = {
+            'id': 'tok-new',
+            'name': 'New token',
+            'key': 'alpat-secret',
+        }
+
+        result = await create_api_token(
+            workspace='testworkspace', region='ap1', name='New token'
+        )
+
+        assert result['status'] == 'success'
+        mock_http_client.post.assert_called_once()

--- a/tests/test_token_tools.py
+++ b/tests/test_token_tools.py
@@ -1,0 +1,265 @@
+"""Unit tests for API token management tools."""
+
+from unittest.mock import AsyncMock, patch
+
+import pytest
+
+from tools.token_tools import (
+    create_api_token,
+    delete_api_token,
+    duplicate_api_token,
+    list_api_token_scopes,
+    list_api_tokens,
+)
+
+
+@pytest.fixture
+def mock_http_client():
+    """Mock HTTP client for testing."""
+    with patch('tools.token_tools.http_client') as mock_client:
+        mock_client.get = AsyncMock()
+        mock_client.post = AsyncMock()
+        mock_client.delete = AsyncMock()
+        yield mock_client
+
+
+@pytest.fixture
+def mock_token_manager():
+    """Mock token manager for testing."""
+    with patch('utils.common.token_manager') as mock_manager:
+        mock_manager.get_token.return_value = 'test-token'
+        yield mock_manager
+
+
+class TestListApiTokens:
+    """Tests for list_api_tokens tool."""
+
+    @pytest.mark.asyncio
+    async def test_list_api_tokens_success(self, mock_http_client, mock_token_manager):
+        """Test successful API tokens list retrieval."""
+        mock_http_client.get.return_value = {
+            'count': 2,
+            'results': [{'id': 'tok-1', 'name': 'Token A'}, {'id': 'tok-2', 'name': 'Token B'}],
+        }
+
+        result = await list_api_tokens(workspace='testworkspace', region='ap1')
+
+        assert result['status'] == 'success'
+        assert result['data']['count'] == 2
+        mock_http_client.get.assert_called_once_with(
+            region='ap1',
+            workspace='testworkspace',
+            endpoint='/api/apitoken/tokens/',
+            token='test-token',
+            params={},
+        )
+
+    @pytest.mark.asyncio
+    async def test_list_api_tokens_with_pagination(self, mock_http_client, mock_token_manager):
+        """Test list_api_tokens with pagination parameters."""
+        mock_http_client.get.return_value = {'count': 10, 'results': []}
+
+        result = await list_api_tokens(
+            workspace='testworkspace', region='ap1', page=2, page_size=5
+        )
+
+        assert result['status'] == 'success'
+        mock_http_client.get.assert_called_once_with(
+            region='ap1',
+            workspace='testworkspace',
+            endpoint='/api/apitoken/tokens/',
+            token='test-token',
+            params={'page': 2, 'page_size': 5},
+        )
+
+    @pytest.mark.asyncio
+    async def test_list_api_tokens_empty(self, mock_http_client, mock_token_manager):
+        """Test list_api_tokens with no tokens."""
+        mock_http_client.get.return_value = {'count': 0, 'results': []}
+
+        result = await list_api_tokens(workspace='testworkspace', region='ap1')
+
+        assert result['status'] == 'success'
+        assert result['data']['count'] == 0
+
+
+class TestCreateApiToken:
+    """Tests for create_api_token tool."""
+
+    @pytest.mark.asyncio
+    async def test_create_api_token_success(self, mock_http_client, mock_token_manager):
+        """Test successful API token creation."""
+        mock_http_client.post.return_value = {
+            'id': 'tok-new',
+            'name': 'My Token',
+            'key': 'secret-key-value',
+        }
+
+        result = await create_api_token(
+            workspace='testworkspace', region='ap1', name='My Token'
+        )
+
+        assert result['status'] == 'success'
+        assert result['data']['name'] == 'My Token'
+        mock_http_client.post.assert_called_once_with(
+            region='ap1',
+            workspace='testworkspace',
+            endpoint='/api/apitoken/tokens/',
+            token='test-token',
+            data={'name': 'My Token'},
+        )
+
+    @pytest.mark.asyncio
+    async def test_create_api_token_with_all_params(self, mock_http_client, mock_token_manager):
+        """Test create_api_token with all optional parameters."""
+        mock_http_client.post.return_value = {'id': 'tok-full', 'name': 'Full Token'}
+
+        result = await create_api_token(
+            workspace='testworkspace',
+            region='ap1',
+            name='Full Token',
+            scopes=['read', 'write'],
+            description='A fully configured token',
+            expires_at='2026-12-31T23:59:59Z',
+        )
+
+        assert result['status'] == 'success'
+        mock_http_client.post.assert_called_once_with(
+            region='ap1',
+            workspace='testworkspace',
+            endpoint='/api/apitoken/tokens/',
+            token='test-token',
+            data={
+                'name': 'Full Token',
+                'scopes': ['read', 'write'],
+                'description': 'A fully configured token',
+                'expires_at': '2026-12-31T23:59:59Z',
+            },
+        )
+
+    @pytest.mark.asyncio
+    async def test_create_api_token_with_scopes_only(self, mock_http_client, mock_token_manager):
+        """Test create_api_token with scopes but no other optional params."""
+        mock_http_client.post.return_value = {'id': 'tok-scoped', 'name': 'Scoped Token'}
+
+        result = await create_api_token(
+            workspace='testworkspace',
+            region='ap1',
+            name='Scoped Token',
+            scopes=['servers:read'],
+        )
+
+        assert result['status'] == 'success'
+        call_data = mock_http_client.post.call_args[1]['data']
+        assert call_data['scopes'] == ['servers:read']
+        assert 'description' not in call_data
+        assert 'expires_at' not in call_data
+
+
+class TestDeleteApiToken:
+    """Tests for delete_api_token tool."""
+
+    @pytest.mark.asyncio
+    async def test_delete_api_token_success(self, mock_http_client, mock_token_manager):
+        """Test successful API token deletion."""
+        mock_http_client.delete.return_value = {}
+
+        result = await delete_api_token(
+            token_id='tok-123', workspace='testworkspace', region='ap1'
+        )
+
+        assert result['status'] == 'success'
+        mock_http_client.delete.assert_called_once_with(
+            region='ap1',
+            workspace='testworkspace',
+            endpoint='/api/apitoken/tokens/tok-123/',
+            token='test-token',
+        )
+
+    @pytest.mark.asyncio
+    async def test_delete_api_token_includes_token_id_in_response(
+        self, mock_http_client, mock_token_manager
+    ):
+        """Test that delete_api_token includes token_id in response metadata."""
+        mock_http_client.delete.return_value = {}
+
+        result = await delete_api_token(
+            token_id='tok-abc', workspace='testworkspace', region='ap1'
+        )
+
+        assert result['status'] == 'success'
+        assert result['token_id'] == 'tok-abc'
+
+
+class TestDuplicateApiToken:
+    """Tests for duplicate_api_token tool."""
+
+    @pytest.mark.asyncio
+    async def test_duplicate_api_token_success(self, mock_http_client, mock_token_manager):
+        """Test successful API token duplication."""
+        mock_http_client.post.return_value = {
+            'id': 'tok-copy',
+            'name': 'My Token (copy)',
+            'key': 'new-secret-key',
+        }
+
+        result = await duplicate_api_token(
+            token_id='tok-original', workspace='testworkspace', region='ap1'
+        )
+
+        assert result['status'] == 'success'
+        assert result['data']['name'] == 'My Token (copy)'
+        mock_http_client.post.assert_called_once_with(
+            region='ap1',
+            workspace='testworkspace',
+            endpoint='/api/apitoken/tokens/tok-original/duplicate/',
+            token='test-token',
+            data={},
+        )
+
+    @pytest.mark.asyncio
+    async def test_duplicate_api_token_includes_token_id_in_response(
+        self, mock_http_client, mock_token_manager
+    ):
+        """Test that duplicate_api_token includes token_id in response metadata."""
+        mock_http_client.post.return_value = {'id': 'tok-dup', 'name': 'Token (copy)'}
+
+        result = await duplicate_api_token(
+            token_id='tok-source', workspace='testworkspace', region='ap1'
+        )
+
+        assert result['status'] == 'success'
+        assert result['token_id'] == 'tok-source'
+
+
+class TestListApiTokenScopes:
+    """Tests for list_api_token_scopes tool."""
+
+    @pytest.mark.asyncio
+    async def test_list_api_token_scopes_success(self, mock_http_client, mock_token_manager):
+        """Test successful API token scopes retrieval."""
+        mock_http_client.get.return_value = [
+            {'name': 'servers:read', 'description': 'Read server information'},
+            {'name': 'commands:execute', 'description': 'Execute commands on servers'},
+        ]
+
+        result = await list_api_token_scopes(workspace='testworkspace', region='ap1')
+
+        assert result['status'] == 'success'
+        assert len(result['data']) == 2
+        mock_http_client.get.assert_called_once_with(
+            region='ap1',
+            workspace='testworkspace',
+            endpoint='/api/apitoken/tokens/scopes/',
+            token='test-token',
+        )
+
+    @pytest.mark.asyncio
+    async def test_list_api_token_scopes_empty(self, mock_http_client, mock_token_manager):
+        """Test list_api_token_scopes when no scopes are available."""
+        mock_http_client.get.return_value = []
+
+        result = await list_api_token_scopes(workspace='testworkspace', region='ap1')
+
+        assert result['status'] == 'success'
+        assert result['data'] == []

--- a/tests/test_token_tools.py
+++ b/tests/test_token_tools.py
@@ -87,6 +87,21 @@ class TestListApiTokens:
         assert result['status'] == 'success'
         assert result['data']['count'] == 0
 
+    @pytest.mark.asyncio
+    async def test_list_api_tokens_http_error(
+        self, mock_http_client, mock_token_manager
+    ):
+        """Test that list_api_tokens surfaces API error responses as errors."""
+        mock_http_client.get.return_value = {
+            'error': 'HTTP Error',
+            'status_code': 403,
+            'message': 'Permission denied',
+        }
+
+        result = await list_api_tokens(workspace='testworkspace', region='ap1')
+
+        assert result['status'] == 'error'
+
 
 class TestCreateApiToken:
     """Tests for create_api_token tool."""
@@ -163,6 +178,45 @@ class TestCreateApiToken:
         call_data = mock_http_client.post.call_args[1]['data']
         assert call_data['scopes'] == ['servers:read']
         assert 'expires_at' not in call_data
+
+    @pytest.mark.asyncio
+    async def test_create_api_token_with_enabled_false(
+        self, mock_http_client, mock_token_manager
+    ):
+        """Test create_api_token with enabled=False creates a disabled token."""
+        mock_http_client.post.return_value = {
+            'id': 'tok-disabled',
+            'name': 'Disabled Token',
+            'enabled': False,
+        }
+
+        result = await create_api_token(
+            workspace='testworkspace',
+            region='ap1',
+            name='Disabled Token',
+            enabled=False,
+        )
+
+        assert result['status'] == 'success'
+        call_data = mock_http_client.post.call_args[1]['data']
+        assert call_data['enabled'] is False
+
+    @pytest.mark.asyncio
+    async def test_create_api_token_http_error(
+        self, mock_http_client, mock_token_manager
+    ):
+        """Test that create_api_token surfaces API error responses as errors."""
+        mock_http_client.post.return_value = {
+            'error': 'HTTP Error',
+            'status_code': 400,
+            'message': 'Token name already exists',
+        }
+
+        result = await create_api_token(
+            workspace='testworkspace', region='ap1', name='Duplicate Token'
+        )
+
+        assert result['status'] == 'error'
 
 
 class TestDeleteApiToken:
@@ -347,3 +401,18 @@ class TestListApiTokenScopes:
 
         assert result['status'] == 'success'
         assert result['data'] == {'resources': [], 'wildcards': []}
+
+    @pytest.mark.asyncio
+    async def test_list_api_token_scopes_http_error(
+        self, mock_http_client, mock_token_manager
+    ):
+        """Test that list_api_token_scopes surfaces API error responses as errors."""
+        mock_http_client.get.return_value = {
+            'error': 'HTTP Error',
+            'status_code': 403,
+            'message': 'Permission denied',
+        }
+
+        result = await list_api_token_scopes(workspace='testworkspace', region='ap1')
+
+        assert result['status'] == 'error'

--- a/tests/test_token_tools.py
+++ b/tests/test_token_tools.py
@@ -49,7 +49,7 @@ class TestListApiTokens:
         mock_http_client.get.assert_called_once_with(
             region='ap1',
             workspace='testworkspace',
-            endpoint='/api/apitoken/tokens/',
+            endpoint='/api/auth/tokens/',
             token='test-token',
             params={},
         )
@@ -67,7 +67,7 @@ class TestListApiTokens:
         mock_http_client.get.assert_called_once_with(
             region='ap1',
             workspace='testworkspace',
-            endpoint='/api/apitoken/tokens/',
+            endpoint='/api/auth/tokens/',
             token='test-token',
             params={'page': 2, 'page_size': 5},
         )
@@ -104,7 +104,7 @@ class TestCreateApiToken:
         mock_http_client.post.assert_called_once_with(
             region='ap1',
             workspace='testworkspace',
-            endpoint='/api/apitoken/tokens/',
+            endpoint='/api/auth/tokens/',
             token='test-token',
             data={'name': 'My Token'},
         )
@@ -119,7 +119,6 @@ class TestCreateApiToken:
             region='ap1',
             name='Full Token',
             scopes=['read', 'write'],
-            description='A fully configured token',
             expires_at='2026-12-31T23:59:59Z',
         )
 
@@ -127,12 +126,11 @@ class TestCreateApiToken:
         mock_http_client.post.assert_called_once_with(
             region='ap1',
             workspace='testworkspace',
-            endpoint='/api/apitoken/tokens/',
+            endpoint='/api/auth/tokens/',
             token='test-token',
             data={
                 'name': 'Full Token',
                 'scopes': ['read', 'write'],
-                'description': 'A fully configured token',
                 'expires_at': '2026-12-31T23:59:59Z',
             },
         )
@@ -172,7 +170,7 @@ class TestDeleteApiToken:
         mock_http_client.delete.assert_called_once_with(
             region='ap1',
             workspace='testworkspace',
-            endpoint='/api/apitoken/tokens/550e8400-e29b-41d4-a716-446655440001/',
+            endpoint='/api/auth/tokens/550e8400-e29b-41d4-a716-446655440001/',
             token='test-token',
         )
 
@@ -235,7 +233,7 @@ class TestDuplicateApiToken:
         mock_http_client.post.assert_called_once_with(
             region='ap1',
             workspace='testworkspace',
-            endpoint='/api/apitoken/tokens/550e8400-e29b-41d4-a716-446655440003/duplicate/',
+            endpoint='/api/auth/tokens/550e8400-e29b-41d4-a716-446655440003/duplicate/',
             token='test-token',
             data={},
         )
@@ -284,28 +282,32 @@ class TestListApiTokenScopes:
     @pytest.mark.asyncio
     async def test_list_api_token_scopes_success(self, mock_http_client, mock_token_manager):
         """Test successful API token scopes retrieval."""
-        mock_http_client.get.return_value = [
-            {'name': 'servers:read', 'description': 'Read server information'},
-            {'name': 'commands:execute', 'description': 'Execute commands on servers'},
-        ]
+        mock_http_client.get.return_value = {
+            'resources': [
+                {'name': 'servers:read', 'description': 'Read server information'},
+                {'name': 'commands:execute', 'description': 'Execute commands on servers'},
+            ],
+            'wildcards': ['*'],
+        }
 
         result = await list_api_token_scopes(workspace='testworkspace', region='ap1')
 
         assert result['status'] == 'success'
-        assert len(result['data']) == 2
+        assert len(result['data']['resources']) == 2
+        assert result['data']['wildcards'] == ['*']
         mock_http_client.get.assert_called_once_with(
             region='ap1',
             workspace='testworkspace',
-            endpoint='/api/apitoken/tokens/scopes/',
+            endpoint='/api/auth/tokens/scopes/',
             token='test-token',
         )
 
     @pytest.mark.asyncio
     async def test_list_api_token_scopes_empty(self, mock_http_client, mock_token_manager):
         """Test list_api_token_scopes when no scopes are available."""
-        mock_http_client.get.return_value = []
+        mock_http_client.get.return_value = {'resources': [], 'wildcards': []}
 
         result = await list_api_token_scopes(workspace='testworkspace', region='ap1')
 
         assert result['status'] == 'success'
-        assert result['data'] == []
+        assert result['data'] == {'resources': [], 'wildcards': []}

--- a/tests/test_token_tools.py
+++ b/tests/test_token_tools.py
@@ -49,6 +49,8 @@ class TestListApiTokens:
 
         assert result['status'] == 'success'
         assert result['data']['count'] == 2
+        assert result['region'] == 'ap1'
+        assert result['workspace'] == 'testworkspace'
         mock_http_client.get.assert_called_once_with(
             region='ap1',
             workspace='testworkspace',
@@ -224,6 +226,23 @@ class TestCreateApiToken:
         call_data = mock_http_client.post.call_args[1]['data']
         assert call_data['presets'] == ['file_upload']
         assert 'scopes' not in call_data
+
+    @pytest.mark.asyncio
+    async def test_create_api_token_empty_name_returns_server_error(
+        self, mock_http_client, mock_token_manager
+    ):
+        """Test that create_api_token with empty name surfaces the server 400 as error."""
+        mock_http_client.post.return_value = {
+            'error': 'HTTP Error',
+            'status_code': 400,
+            'message': 'This field may not be blank.',
+        }
+
+        result = await create_api_token(
+            workspace='testworkspace', region='ap1', name=''
+        )
+
+        assert result['status'] == 'error'
 
     @pytest.mark.asyncio
     async def test_create_api_token_http_error(
@@ -471,6 +490,8 @@ class TestListApiTokenScopes:
         assert result['status'] == 'success'
         assert len(result['data']['resources']) == 2
         assert result['data']['wildcards'] == ['*']
+        assert result['region'] == 'ap1'
+        assert result['workspace'] == 'testworkspace'
         mock_http_client.get.assert_called_once_with(
             region='ap1',
             workspace='testworkspace',

--- a/tests/test_token_tools.py
+++ b/tests/test_token_tools.py
@@ -284,6 +284,25 @@ class TestDeleteApiToken:
 
         assert result['status'] == 'error'
 
+    @pytest.mark.asyncio
+    async def test_delete_api_token_not_found(
+        self, mock_http_client, mock_token_manager
+    ):
+        """Test that delete_api_token returns error when token does not exist (404)."""
+        mock_http_client.delete.return_value = {
+            'error': 'HTTP Error',
+            'status_code': 404,
+            'message': 'Not found',
+        }
+
+        result = await delete_api_token(
+            token_id='550e8400-e29b-41d4-a716-446655440099',
+            workspace='testworkspace',
+            region='ap1',
+        )
+
+        assert result['status'] == 'error'
+
 
 class TestDuplicateApiToken:
     """Tests for duplicate_api_token tool."""
@@ -352,6 +371,25 @@ class TestDuplicateApiToken:
 
         result = await duplicate_api_token(
             token_id='550e8400-e29b-41d4-a716-446655440000',
+            workspace='testworkspace',
+            region='ap1',
+        )
+
+        assert result['status'] == 'error'
+
+    @pytest.mark.asyncio
+    async def test_duplicate_api_token_not_found(
+        self, mock_http_client, mock_token_manager
+    ):
+        """Test that duplicate_api_token returns error when source token does not exist (404)."""
+        mock_http_client.post.return_value = {
+            'error': 'HTTP Error',
+            'status_code': 404,
+            'message': 'Not found',
+        }
+
+        result = await duplicate_api_token(
+            token_id='550e8400-e29b-41d4-a716-446655440099',
             workspace='testworkspace',
             region='ap1',
         )

--- a/tests/test_token_tools.py
+++ b/tests/test_token_tools.py
@@ -253,6 +253,27 @@ class TestCreateApiToken:
         assert call_data['enabled'] is False
 
     @pytest.mark.asyncio
+    async def test_create_api_token_with_enabled_true(
+        self, mock_http_client, mock_token_manager
+    ):
+        """Test create_api_token forwards enabled=True (guards against falsy bugs)."""
+        mock_http_client.post.return_value = {
+            'id': 'tok-enabled',
+            'name': 'Enabled Token',
+            'enabled': True,
+        }
+
+        await create_api_token(
+            workspace='testworkspace',
+            region='ap1',
+            name='Enabled Token',
+            enabled=True,
+        )
+
+        call_data = mock_http_client.post.call_args[1]['data']
+        assert call_data['enabled'] is True
+
+    @pytest.mark.asyncio
     async def test_create_api_token_with_presets_only(
         self, mock_http_client, mock_token_manager
     ):
@@ -449,6 +470,27 @@ class TestDuplicateApiToken:
             token='test-token',
             data={'name': 'My Backup Token'},
         )
+
+    @pytest.mark.asyncio
+    async def test_duplicate_api_token_with_empty_name_forwarded(
+        self, mock_http_client, mock_token_manager
+    ):
+        """Test duplicate_api_token forwards empty string name (server treats it
+        as 'auto-generate' via APITokenDuplicateSerializer.allow_blank=True)."""
+        mock_http_client.post.return_value = {
+            'id': 'tok-blank',
+            'name': 'Source (copy)',
+        }
+
+        await duplicate_api_token(
+            token_id='550e8400-e29b-41d4-a716-446655440005',
+            workspace='testworkspace',
+            region='ap1',
+            name='',
+        )
+
+        call_data = mock_http_client.post.call_args[1]['data']
+        assert call_data == {'name': ''}
 
     @pytest.mark.asyncio
     async def test_duplicate_api_token_includes_token_id_in_response(

--- a/tests/test_token_tools.py
+++ b/tests/test_token_tools.py
@@ -165,14 +165,14 @@ class TestDeleteApiToken:
         mock_http_client.delete.return_value = {}
 
         result = await delete_api_token(
-            token_id='tok-123', workspace='testworkspace', region='ap1'
+            token_id='550e8400-e29b-41d4-a716-446655440001', workspace='testworkspace', region='ap1'
         )
 
         assert result['status'] == 'success'
         mock_http_client.delete.assert_called_once_with(
             region='ap1',
             workspace='testworkspace',
-            endpoint='/api/apitoken/tokens/tok-123/',
+            endpoint='/api/apitoken/tokens/550e8400-e29b-41d4-a716-446655440001/',
             token='test-token',
         )
 
@@ -184,11 +184,34 @@ class TestDeleteApiToken:
         mock_http_client.delete.return_value = {}
 
         result = await delete_api_token(
-            token_id='tok-abc', workspace='testworkspace', region='ap1'
+            token_id='550e8400-e29b-41d4-a716-446655440002', workspace='testworkspace', region='ap1'
         )
 
         assert result['status'] == 'success'
-        assert result['token_id'] == 'tok-abc'
+        assert result['token_id'] == '550e8400-e29b-41d4-a716-446655440002'
+
+    @pytest.mark.asyncio
+    async def test_delete_api_token_invalid_token_id(self, mock_http_client, mock_token_manager):
+        """Test that delete_api_token returns error for non-UUID token_id."""
+        result = await delete_api_token(
+            token_id='not-a-uuid', workspace='testworkspace', region='ap1'
+        )
+
+        assert result['status'] == 'error'
+        mock_http_client.delete.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_delete_api_token_http_exception(self, mock_http_client, mock_token_manager):
+        """Test that delete_api_token returns error when http_client raises an exception."""
+        mock_http_client.delete.side_effect = Exception('Network failure')
+
+        result = await delete_api_token(
+            token_id='550e8400-e29b-41d4-a716-446655440000',
+            workspace='testworkspace',
+            region='ap1',
+        )
+
+        assert result['status'] == 'error'
 
 
 class TestDuplicateApiToken:
@@ -204,7 +227,7 @@ class TestDuplicateApiToken:
         }
 
         result = await duplicate_api_token(
-            token_id='tok-original', workspace='testworkspace', region='ap1'
+            token_id='550e8400-e29b-41d4-a716-446655440003', workspace='testworkspace', region='ap1'
         )
 
         assert result['status'] == 'success'
@@ -212,7 +235,7 @@ class TestDuplicateApiToken:
         mock_http_client.post.assert_called_once_with(
             region='ap1',
             workspace='testworkspace',
-            endpoint='/api/apitoken/tokens/tok-original/duplicate/',
+            endpoint='/api/apitoken/tokens/550e8400-e29b-41d4-a716-446655440003/duplicate/',
             token='test-token',
             data={},
         )
@@ -225,11 +248,34 @@ class TestDuplicateApiToken:
         mock_http_client.post.return_value = {'id': 'tok-dup', 'name': 'Token (copy)'}
 
         result = await duplicate_api_token(
-            token_id='tok-source', workspace='testworkspace', region='ap1'
+            token_id='550e8400-e29b-41d4-a716-446655440004', workspace='testworkspace', region='ap1'
         )
 
         assert result['status'] == 'success'
-        assert result['token_id'] == 'tok-source'
+        assert result['token_id'] == '550e8400-e29b-41d4-a716-446655440004'
+
+    @pytest.mark.asyncio
+    async def test_duplicate_api_token_invalid_token_id(self, mock_http_client, mock_token_manager):
+        """Test that duplicate_api_token returns error for non-UUID token_id."""
+        result = await duplicate_api_token(
+            token_id='not-a-uuid', workspace='testworkspace', region='ap1'
+        )
+
+        assert result['status'] == 'error'
+        mock_http_client.post.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_duplicate_api_token_http_exception(self, mock_http_client, mock_token_manager):
+        """Test that duplicate_api_token returns error when http_client raises an exception."""
+        mock_http_client.post.side_effect = Exception('Network failure')
+
+        result = await duplicate_api_token(
+            token_id='550e8400-e29b-41d4-a716-446655440000',
+            workspace='testworkspace',
+            region='ap1',
+        )
+
+        assert result['status'] == 'error'
 
 
 class TestListApiTokenScopes:

--- a/tests/test_token_tools.py
+++ b/tests/test_token_tools.py
@@ -39,7 +39,10 @@ class TestListApiTokens:
         """Test successful API tokens list retrieval."""
         mock_http_client.get.return_value = {
             'count': 2,
-            'results': [{'id': 'tok-1', 'name': 'Token A'}, {'id': 'tok-2', 'name': 'Token B'}],
+            'results': [
+                {'id': 'tok-1', 'name': 'Token A'},
+                {'id': 'tok-2', 'name': 'Token B'},
+            ],
         }
 
         result = await list_api_tokens(workspace='testworkspace', region='ap1')
@@ -55,7 +58,9 @@ class TestListApiTokens:
         )
 
     @pytest.mark.asyncio
-    async def test_list_api_tokens_with_pagination(self, mock_http_client, mock_token_manager):
+    async def test_list_api_tokens_with_pagination(
+        self, mock_http_client, mock_token_manager
+    ):
         """Test list_api_tokens with pagination parameters."""
         mock_http_client.get.return_value = {'count': 10, 'results': []}
 
@@ -110,7 +115,9 @@ class TestCreateApiToken:
         )
 
     @pytest.mark.asyncio
-    async def test_create_api_token_with_all_params(self, mock_http_client, mock_token_manager):
+    async def test_create_api_token_with_all_params(
+        self, mock_http_client, mock_token_manager
+    ):
         """Test create_api_token with all optional parameters."""
         mock_http_client.post.return_value = {'id': 'tok-full', 'name': 'Full Token'}
 
@@ -136,9 +143,14 @@ class TestCreateApiToken:
         )
 
     @pytest.mark.asyncio
-    async def test_create_api_token_with_scopes_only(self, mock_http_client, mock_token_manager):
+    async def test_create_api_token_with_scopes_only(
+        self, mock_http_client, mock_token_manager
+    ):
         """Test create_api_token with scopes but no other optional params."""
-        mock_http_client.post.return_value = {'id': 'tok-scoped', 'name': 'Scoped Token'}
+        mock_http_client.post.return_value = {
+            'id': 'tok-scoped',
+            'name': 'Scoped Token',
+        }
 
         result = await create_api_token(
             workspace='testworkspace',
@@ -150,7 +162,6 @@ class TestCreateApiToken:
         assert result['status'] == 'success'
         call_data = mock_http_client.post.call_args[1]['data']
         assert call_data['scopes'] == ['servers:read']
-        assert 'description' not in call_data
         assert 'expires_at' not in call_data
 
 
@@ -163,7 +174,9 @@ class TestDeleteApiToken:
         mock_http_client.delete.return_value = {}
 
         result = await delete_api_token(
-            token_id='550e8400-e29b-41d4-a716-446655440001', workspace='testworkspace', region='ap1'
+            token_id='550e8400-e29b-41d4-a716-446655440001',
+            workspace='testworkspace',
+            region='ap1',
         )
 
         assert result['status'] == 'success'
@@ -182,14 +195,18 @@ class TestDeleteApiToken:
         mock_http_client.delete.return_value = {}
 
         result = await delete_api_token(
-            token_id='550e8400-e29b-41d4-a716-446655440002', workspace='testworkspace', region='ap1'
+            token_id='550e8400-e29b-41d4-a716-446655440002',
+            workspace='testworkspace',
+            region='ap1',
         )
 
         assert result['status'] == 'success'
         assert result['token_id'] == '550e8400-e29b-41d4-a716-446655440002'
 
     @pytest.mark.asyncio
-    async def test_delete_api_token_invalid_token_id(self, mock_http_client, mock_token_manager):
+    async def test_delete_api_token_invalid_token_id(
+        self, mock_http_client, mock_token_manager
+    ):
         """Test that delete_api_token returns error for non-UUID token_id."""
         result = await delete_api_token(
             token_id='not-a-uuid', workspace='testworkspace', region='ap1'
@@ -199,7 +216,9 @@ class TestDeleteApiToken:
         mock_http_client.delete.assert_not_called()
 
     @pytest.mark.asyncio
-    async def test_delete_api_token_http_exception(self, mock_http_client, mock_token_manager):
+    async def test_delete_api_token_http_exception(
+        self, mock_http_client, mock_token_manager
+    ):
         """Test that delete_api_token returns error when http_client raises an exception."""
         mock_http_client.delete.side_effect = Exception('Network failure')
 
@@ -216,7 +235,9 @@ class TestDuplicateApiToken:
     """Tests for duplicate_api_token tool."""
 
     @pytest.mark.asyncio
-    async def test_duplicate_api_token_success(self, mock_http_client, mock_token_manager):
+    async def test_duplicate_api_token_success(
+        self, mock_http_client, mock_token_manager
+    ):
         """Test successful API token duplication."""
         mock_http_client.post.return_value = {
             'id': 'tok-copy',
@@ -225,7 +246,9 @@ class TestDuplicateApiToken:
         }
 
         result = await duplicate_api_token(
-            token_id='550e8400-e29b-41d4-a716-446655440003', workspace='testworkspace', region='ap1'
+            token_id='550e8400-e29b-41d4-a716-446655440003',
+            workspace='testworkspace',
+            region='ap1',
         )
 
         assert result['status'] == 'success'
@@ -246,14 +269,18 @@ class TestDuplicateApiToken:
         mock_http_client.post.return_value = {'id': 'tok-dup', 'name': 'Token (copy)'}
 
         result = await duplicate_api_token(
-            token_id='550e8400-e29b-41d4-a716-446655440004', workspace='testworkspace', region='ap1'
+            token_id='550e8400-e29b-41d4-a716-446655440004',
+            workspace='testworkspace',
+            region='ap1',
         )
 
         assert result['status'] == 'success'
         assert result['token_id'] == '550e8400-e29b-41d4-a716-446655440004'
 
     @pytest.mark.asyncio
-    async def test_duplicate_api_token_invalid_token_id(self, mock_http_client, mock_token_manager):
+    async def test_duplicate_api_token_invalid_token_id(
+        self, mock_http_client, mock_token_manager
+    ):
         """Test that duplicate_api_token returns error for non-UUID token_id."""
         result = await duplicate_api_token(
             token_id='not-a-uuid', workspace='testworkspace', region='ap1'
@@ -263,7 +290,9 @@ class TestDuplicateApiToken:
         mock_http_client.post.assert_not_called()
 
     @pytest.mark.asyncio
-    async def test_duplicate_api_token_http_exception(self, mock_http_client, mock_token_manager):
+    async def test_duplicate_api_token_http_exception(
+        self, mock_http_client, mock_token_manager
+    ):
         """Test that duplicate_api_token returns error when http_client raises an exception."""
         mock_http_client.post.side_effect = Exception('Network failure')
 
@@ -280,12 +309,17 @@ class TestListApiTokenScopes:
     """Tests for list_api_token_scopes tool."""
 
     @pytest.mark.asyncio
-    async def test_list_api_token_scopes_success(self, mock_http_client, mock_token_manager):
+    async def test_list_api_token_scopes_success(
+        self, mock_http_client, mock_token_manager
+    ):
         """Test successful API token scopes retrieval."""
         mock_http_client.get.return_value = {
             'resources': [
                 {'name': 'servers:read', 'description': 'Read server information'},
-                {'name': 'commands:execute', 'description': 'Execute commands on servers'},
+                {
+                    'name': 'commands:execute',
+                    'description': 'Execute commands on servers',
+                },
             ],
             'wildcards': ['*'],
         }
@@ -303,7 +337,9 @@ class TestListApiTokenScopes:
         )
 
     @pytest.mark.asyncio
-    async def test_list_api_token_scopes_empty(self, mock_http_client, mock_token_manager):
+    async def test_list_api_token_scopes_empty(
+        self, mock_http_client, mock_token_manager
+    ):
         """Test list_api_token_scopes when no scopes are available."""
         mock_http_client.get.return_value = {'resources': [], 'wildcards': []}
 

--- a/tests/test_token_tools.py
+++ b/tests/test_token_tools.py
@@ -142,6 +142,7 @@ class TestCreateApiToken:
             name='Full Token',
             scopes=['read', 'write'],
             expires_at='2026-12-31T23:59:59Z',
+            presets=['file_upload'],
         )
 
         assert result['status'] == 'success'
@@ -154,6 +155,7 @@ class TestCreateApiToken:
                 'name': 'Full Token',
                 'scopes': ['read', 'write'],
                 'expires_at': '2026-12-31T23:59:59Z',
+                'presets': ['file_upload'],
             },
         )
 
@@ -200,6 +202,28 @@ class TestCreateApiToken:
         assert result['status'] == 'success'
         call_data = mock_http_client.post.call_args[1]['data']
         assert call_data['enabled'] is False
+
+    @pytest.mark.asyncio
+    async def test_create_api_token_with_presets_only(
+        self, mock_http_client, mock_token_manager
+    ):
+        """Test create_api_token with presets but no explicit scopes."""
+        mock_http_client.post.return_value = {
+            'id': 'tok-preset',
+            'name': 'Preset Token',
+        }
+
+        result = await create_api_token(
+            workspace='testworkspace',
+            region='ap1',
+            name='Preset Token',
+            presets=['file_upload'],
+        )
+
+        assert result['status'] == 'success'
+        call_data = mock_http_client.post.call_args[1]['data']
+        assert call_data['presets'] == ['file_upload']
+        assert 'scopes' not in call_data
 
     @pytest.mark.asyncio
     async def test_create_api_token_http_error(
@@ -332,6 +356,32 @@ class TestDuplicateApiToken:
             endpoint='/api/auth/tokens/550e8400-e29b-41d4-a716-446655440003/duplicate/',
             token='test-token',
             data={},
+        )
+
+    @pytest.mark.asyncio
+    async def test_duplicate_api_token_with_custom_name(
+        self, mock_http_client, mock_token_manager
+    ):
+        """Test duplicate_api_token forwards optional name to the API."""
+        mock_http_client.post.return_value = {
+            'id': 'tok-named',
+            'name': 'My Backup Token',
+        }
+
+        result = await duplicate_api_token(
+            token_id='550e8400-e29b-41d4-a716-446655440003',
+            workspace='testworkspace',
+            region='ap1',
+            name='My Backup Token',
+        )
+
+        assert result['status'] == 'success'
+        mock_http_client.post.assert_called_once_with(
+            region='ap1',
+            workspace='testworkspace',
+            endpoint='/api/auth/tokens/550e8400-e29b-41d4-a716-446655440003/duplicate/',
+            token='test-token',
+            data={'name': 'My Backup Token'},
         )
 
     @pytest.mark.asyncio

--- a/tests/test_token_tools.py
+++ b/tests/test_token_tools.py
@@ -764,6 +764,28 @@ class TestUpdateApiToken:
         assert call_data == {'expires_at': None}
 
     @pytest.mark.asyncio
+    async def test_update_api_token_clear_expires_at_with_other_fields(
+        self, mock_http_client, mock_token_manager
+    ):
+        """Test clear_expires_at combines with other fields in a single PATCH."""
+        mock_http_client.patch.return_value = {
+            'id': '550e8400-e29b-41d4-a716-446655440027',
+            'name': 'Renamed',
+            'expires_at': None,
+        }
+
+        await update_api_token(
+            token_id='550e8400-e29b-41d4-a716-446655440027',
+            workspace='testworkspace',
+            region='ap1',
+            name='Renamed',
+            clear_expires_at=True,
+        )
+
+        call_data = mock_http_client.patch.call_args[1]['data']
+        assert call_data == {'name': 'Renamed', 'expires_at': None}
+
+    @pytest.mark.asyncio
     async def test_update_api_token_clear_and_set_expires_at_conflicts(
         self, mock_http_client, mock_token_manager
     ):

--- a/tests/test_token_tools.py
+++ b/tests/test_token_tools.py
@@ -743,6 +743,63 @@ class TestUpdateApiToken:
         )
 
     @pytest.mark.asyncio
+    async def test_update_api_token_clear_expires_at(
+        self, mock_http_client, mock_token_manager
+    ):
+        """Test clear_expires_at=True sends expires_at=null to remove the expiry."""
+        mock_http_client.patch.return_value = {
+            'id': '550e8400-e29b-41d4-a716-446655440024',
+            'expires_at': None,
+        }
+
+        result = await update_api_token(
+            token_id='550e8400-e29b-41d4-a716-446655440024',
+            workspace='testworkspace',
+            region='ap1',
+            clear_expires_at=True,
+        )
+
+        assert result['status'] == 'success'
+        call_data = mock_http_client.patch.call_args[1]['data']
+        assert call_data == {'expires_at': None}
+
+    @pytest.mark.asyncio
+    async def test_update_api_token_clear_and_set_expires_at_conflicts(
+        self, mock_http_client, mock_token_manager
+    ):
+        """Test mutual exclusion of expires_at and clear_expires_at."""
+        result = await update_api_token(
+            token_id='550e8400-e29b-41d4-a716-446655440025',
+            workspace='testworkspace',
+            region='ap1',
+            expires_at='2027-01-01T00:00:00Z',
+            clear_expires_at=True,
+        )
+
+        assert result['status'] == 'error'
+        mock_http_client.patch.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_update_api_token_clear_expires_at_false_is_noop(
+        self, mock_http_client, mock_token_manager
+    ):
+        """Test clear_expires_at=False (default) does not inject expires_at."""
+        mock_http_client.patch.return_value = {
+            'id': '550e8400-e29b-41d4-a716-446655440026',
+            'enabled': False,
+        }
+
+        await update_api_token(
+            token_id='550e8400-e29b-41d4-a716-446655440026',
+            workspace='testworkspace',
+            region='ap1',
+            enabled=False,
+        )
+
+        call_data = mock_http_client.patch.call_args[1]['data']
+        assert 'expires_at' not in call_data
+
+    @pytest.mark.asyncio
     async def test_update_api_token_no_fields_returns_error(
         self, mock_http_client, mock_token_manager
     ):

--- a/tools/token_tools.py
+++ b/tools/token_tools.py
@@ -1,0 +1,191 @@
+"""API token management tools for Alpacon MCP server."""
+
+from typing import Any
+
+from utils.common import success_response
+from utils.decorators import mcp_tool_handler
+from utils.http_client import http_client
+from utils.tool_annotations import ADDITIVE, DESTRUCTIVE, READ_ONLY
+
+
+@mcp_tool_handler(
+    description='List API tokens in the workspace. When to use: reviewing existing API tokens or auditing access. Related: create_api_token (create new), delete_api_token (remove), list_api_token_scopes (available scopes).',
+    annotations=READ_ONLY,
+    meta={'anthropic/searchHint': 'api token list credentials access'},
+)
+async def list_api_tokens(
+    workspace: str,
+    region: str = '',
+    page: int | None = None,
+    page_size: int | None = None,
+    **kwargs,
+) -> dict[str, Any]:
+    """List API tokens.
+
+    Args:
+        workspace: Workspace name. Required parameter
+        region: Region (ap1, us1, eu1). Auto-detected if not provided
+        page: Page number for pagination (optional)
+        page_size: Number of items per page (optional)
+
+    Returns:
+        API tokens list response
+    """
+    token = kwargs.get('token')
+
+    params: dict[str, Any] = {}
+    if page is not None:
+        params['page'] = page
+    if page_size is not None:
+        params['page_size'] = page_size
+
+    result = await http_client.get(
+        region=region,
+        workspace=workspace,
+        endpoint='/api/apitoken/tokens/',
+        token=token,
+        params=params,
+    )
+    return success_response(data=result, region=region, workspace=workspace)
+
+
+@mcp_tool_handler(
+    description='Create a new API token in the workspace. When to use: generating credentials for programmatic access or integrations. Related: list_api_tokens (view existing), delete_api_token (remove), list_api_token_scopes (check available scopes).',
+    annotations=ADDITIVE,
+    meta={'anthropic/searchHint': 'api token create generate credentials'},
+)
+async def create_api_token(
+    workspace: str,
+    name: str,
+    scopes: list[str] | None = None,
+    description: str | None = None,
+    expires_at: str | None = None,
+    region: str = '',
+    **kwargs,
+) -> dict[str, Any]:
+    """Create a new API token.
+
+    Args:
+        workspace: Workspace name. Required parameter
+        name: Name of the API token
+        scopes: List of permission scopes for the token (optional)
+        description: Description of the API token (optional)
+        expires_at: Expiration datetime in ISO 8601 format (optional)
+        region: Region (ap1, us1, eu1). Auto-detected if not provided
+
+    Returns:
+        API token creation response
+    """
+    token = kwargs.get('token')
+
+    token_data: dict[str, Any] = {'name': name}
+    if scopes is not None:
+        token_data['scopes'] = scopes
+    if description is not None:
+        token_data['description'] = description
+    if expires_at is not None:
+        token_data['expires_at'] = expires_at
+
+    result = await http_client.post(
+        region=region,
+        workspace=workspace,
+        endpoint='/api/apitoken/tokens/',
+        token=token,
+        data=token_data,
+    )
+    return success_response(data=result, region=region, workspace=workspace)
+
+
+@mcp_tool_handler(
+    description='Delete an API token permanently. When to use: revoking access for a specific token. Related: list_api_tokens (find token ID), duplicate_api_token (create a copy before deleting). Note: This cannot be undone.',
+    annotations=DESTRUCTIVE,
+    meta={'anthropic/searchHint': 'api token delete revoke remove'},
+)
+async def delete_api_token(
+    token_id: str,
+    workspace: str,
+    region: str = '',
+    **kwargs,
+) -> dict[str, Any]:
+    """Delete an API token.
+
+    Args:
+        token_id: ID of the API token to delete
+        workspace: Workspace name. Required parameter
+        region: Region (ap1, us1, eu1). Auto-detected if not provided
+
+    Returns:
+        API token deletion response
+    """
+    token = kwargs.get('token')
+
+    result = await http_client.delete(
+        region=region,
+        workspace=workspace,
+        endpoint=f'/api/apitoken/tokens/{token_id}/',
+        token=token,
+    )
+    return success_response(data=result, token_id=token_id, region=region, workspace=workspace)
+
+
+@mcp_tool_handler(
+    description='Duplicate an existing API token to create a copy with the same configuration. When to use: creating a backup token or rotating credentials. Related: list_api_tokens (find token ID), create_api_token (create from scratch), delete_api_token (remove old token after rotation).',
+    annotations=ADDITIVE,
+    meta={'anthropic/searchHint': 'api token duplicate copy clone rotate'},
+)
+async def duplicate_api_token(
+    token_id: str,
+    workspace: str,
+    region: str = '',
+    **kwargs,
+) -> dict[str, Any]:
+    """Duplicate an API token.
+
+    Args:
+        token_id: ID of the API token to duplicate
+        workspace: Workspace name. Required parameter
+        region: Region (ap1, us1, eu1). Auto-detected if not provided
+
+    Returns:
+        Duplicated API token response
+    """
+    token = kwargs.get('token')
+
+    result = await http_client.post(
+        region=region,
+        workspace=workspace,
+        endpoint=f'/api/apitoken/tokens/{token_id}/duplicate/',
+        token=token,
+        data={},
+    )
+    return success_response(data=result, token_id=token_id, region=region, workspace=workspace)
+
+
+@mcp_tool_handler(
+    description='List available API token scopes. When to use: before creating a token, to see which permission scopes can be assigned. Related: create_api_token (use scopes when creating), list_api_tokens (view tokens and their scopes).',
+    annotations=READ_ONLY,
+    meta={'anthropic/searchHint': 'api token scopes permissions available'},
+)
+async def list_api_token_scopes(
+    workspace: str,
+    region: str = '',
+    **kwargs,
+) -> dict[str, Any]:
+    """List available API token scopes.
+
+    Args:
+        workspace: Workspace name. Required parameter
+        region: Region (ap1, us1, eu1). Auto-detected if not provided
+
+    Returns:
+        Available API token scopes response
+    """
+    token = kwargs.get('token')
+
+    result = await http_client.get(
+        region=region,
+        workspace=workspace,
+        endpoint='/api/apitoken/tokens/scopes/',
+        token=token,
+    )
+    return success_response(data=result, region=region, workspace=workspace)

--- a/tools/token_tools.py
+++ b/tools/token_tools.py
@@ -182,17 +182,19 @@ async def delete_api_token(
 async def duplicate_api_token(
     token_id: str,
     workspace: str,
+    name: str | None = None,
     region: str = '',
     **kwargs,
 ) -> dict[str, Any]:
     """Duplicate an API token.
 
-    The duplicate inherits all configuration (name, scopes, expiry) from the
-    source token. The server auto-generates the copy name (e.g. "Token (copy)").
+    The duplicate inherits all configuration (scopes, expiry) from the source
+    token. If name is omitted, the server generates one (e.g. "Token (copy)").
 
     Args:
         token_id: ID of the API token to duplicate
         workspace: Workspace name. Required parameter
+        name: Name for the duplicated token (optional; server auto-generates if omitted)
         region: Region (ap1, us1, eu1). Auto-detected if not provided
 
     Returns:
@@ -207,12 +209,16 @@ async def duplicate_api_token(
             'Must be a valid UUID. Example: 550e8400-e29b-41d4-a716-446655440000',
         )
 
+    data: dict[str, Any] = {}
+    if name is not None:
+        data['name'] = name
+
     result = await http_client.post(
         region=region,
         workspace=workspace,
         endpoint=f'/api/auth/tokens/{token_id}/duplicate/',
         token=token,
-        data={},
+        data=data,
     )
 
     err = unwrap_http_result(

--- a/tools/token_tools.py
+++ b/tools/token_tools.py
@@ -24,6 +24,10 @@ from utils.tool_annotations import (
     READ_ONLY,
 )
 
+_API_TOKENS = '/api/auth/tokens/'
+_API_TOKEN_SCOPES = f'{_API_TOKENS}scopes/'
+_API_TOKEN_PRESETS = f'{_API_TOKENS}presets/'
+
 _JWT_REQUIRED_NOTE = (
     "Returns 403 Forbidden when called with a source='api' API token; "
     'use JWT/OAuth, a browser session, or a login-source token instead.'
@@ -102,7 +106,7 @@ async def list_api_tokens(
     result = await http_client.get(
         region=region,
         workspace=workspace,
-        endpoint='/api/auth/tokens/',
+        endpoint=_API_TOKENS,
         token=token,
         params=params,
     )
@@ -153,7 +157,7 @@ async def get_api_token(
     result = await http_client.get(
         region=region,
         workspace=workspace,
-        endpoint=f'/api/auth/tokens/{token_id}/',
+        endpoint=f'{_API_TOKENS}{token_id}/',
         token=token,
     )
 
@@ -224,7 +228,7 @@ async def create_api_token(
     result = await http_client.post(
         region=region,
         workspace=workspace,
-        endpoint='/api/auth/tokens/',
+        endpoint=_API_TOKENS,
         token=token,
         data=token_data,
     )
@@ -314,7 +318,7 @@ async def update_api_token(
     result = await http_client.patch(
         region=region,
         workspace=workspace,
-        endpoint=f'/api/auth/tokens/{token_id}/',
+        endpoint=f'{_API_TOKENS}{token_id}/',
         token=token,
         data=update_data,
     )
@@ -369,7 +373,7 @@ async def delete_api_token(
     result = await http_client.delete(
         region=region,
         workspace=workspace,
-        endpoint=f'/api/auth/tokens/{token_id}/',
+        endpoint=f'{_API_TOKENS}{token_id}/',
         token=token,
     )
 
@@ -433,7 +437,7 @@ async def duplicate_api_token(
     result = await http_client.post(
         region=region,
         workspace=workspace,
-        endpoint=f'/api/auth/tokens/{token_id}/duplicate/',
+        endpoint=f'{_API_TOKENS}{token_id}/duplicate/',
         token=token,
         data=data,
     )
@@ -477,7 +481,7 @@ async def list_api_token_scopes(
     result = await http_client.get(
         region=region,
         workspace=workspace,
-        endpoint='/api/auth/tokens/scopes/',
+        endpoint=_API_TOKEN_SCOPES,
         token=token,
     )
 
@@ -517,7 +521,7 @@ async def list_api_token_presets(
     result = await http_client.get(
         region=region,
         workspace=workspace,
-        endpoint='/api/auth/tokens/presets/',
+        endpoint=_API_TOKEN_PRESETS,
         token=token,
     )
 

--- a/tools/token_tools.py
+++ b/tools/token_tools.py
@@ -47,6 +47,16 @@ async def list_api_tokens(
         token=token,
         params=params,
     )
+
+    err = unwrap_http_result(
+        result,
+        default_message='Failed to list API tokens',
+        region=region,
+        workspace=workspace,
+    )
+    if err:
+        return err
+
     return success_response(data=result, region=region, workspace=workspace)
 
 
@@ -60,6 +70,7 @@ async def create_api_token(
     name: str,
     scopes: list[str] | None = None,
     expires_at: str | None = None,
+    enabled: bool | None = None,
     region: str = '',
     **kwargs,
 ) -> dict[str, Any]:
@@ -70,6 +81,7 @@ async def create_api_token(
         name: Name of the API token
         scopes: List of permission scopes for the token (optional)
         expires_at: Expiration datetime in ISO 8601 format (optional)
+        enabled: Whether the token is active. Defaults to True on the server (optional)
         region: Region (ap1, us1, eu1). Auto-detected if not provided
 
     Returns:
@@ -82,6 +94,8 @@ async def create_api_token(
         token_data['scopes'] = scopes
     if expires_at is not None:
         token_data['expires_at'] = expires_at
+    if enabled is not None:
+        token_data['enabled'] = enabled
 
     result = await http_client.post(
         region=region,
@@ -90,6 +104,16 @@ async def create_api_token(
         token=token,
         data=token_data,
     )
+
+    err = unwrap_http_result(
+        result,
+        default_message='Failed to create API token',
+        region=region,
+        workspace=workspace,
+    )
+    if err:
+        return err
+
     return success_response(data=result, region=region, workspace=workspace)
 
 
@@ -159,7 +183,7 @@ async def duplicate_api_token(
     """Duplicate an API token.
 
     The duplicate inherits all configuration (name, scopes, expiry) from the
-    source token; overrides are not supported.
+    source token. The server auto-generates the copy name (e.g. "Token (copy)").
 
     Args:
         token_id: ID of the API token to duplicate
@@ -228,4 +252,14 @@ async def list_api_token_scopes(
         endpoint='/api/auth/tokens/scopes/',
         token=token,
     )
+
+    err = unwrap_http_result(
+        result,
+        default_message='Failed to list API token scopes',
+        region=region,
+        workspace=workspace,
+    )
+    if err:
+        return err
+
     return success_response(data=result, region=region, workspace=workspace)

--- a/tools/token_tools.py
+++ b/tools/token_tools.py
@@ -43,7 +43,7 @@ async def list_api_tokens(
     result = await http_client.get(
         region=region,
         workspace=workspace,
-        endpoint='/api/apitoken/tokens/',
+        endpoint='/api/auth/tokens/',
         token=token,
         params=params,
     )
@@ -59,7 +59,6 @@ async def create_api_token(
     workspace: str,
     name: str,
     scopes: list[str] | None = None,
-    description: str | None = None,
     expires_at: str | None = None,
     region: str = '',
     **kwargs,
@@ -70,7 +69,6 @@ async def create_api_token(
         workspace: Workspace name. Required parameter
         name: Name of the API token
         scopes: List of permission scopes for the token (optional)
-        description: Description of the API token (optional)
         expires_at: Expiration datetime in ISO 8601 format (optional)
         region: Region (ap1, us1, eu1). Auto-detected if not provided
 
@@ -82,15 +80,13 @@ async def create_api_token(
     token_data: dict[str, Any] = {'name': name}
     if scopes is not None:
         token_data['scopes'] = scopes
-    if description is not None:
-        token_data['description'] = description
     if expires_at is not None:
         token_data['expires_at'] = expires_at
 
     result = await http_client.post(
         region=region,
         workspace=workspace,
-        endpoint='/api/apitoken/tokens/',
+        endpoint='/api/auth/tokens/',
         token=token,
         data=token_data,
     )
@@ -128,7 +124,7 @@ async def delete_api_token(
     result = await http_client.delete(
         region=region,
         workspace=workspace,
-        endpoint=f'/api/apitoken/tokens/{token_id}/',
+        endpoint=f'/api/auth/tokens/{token_id}/',
         token=token,
     )
     return success_response(data=result, token_id=token_id, region=region, workspace=workspace)
@@ -169,7 +165,7 @@ async def duplicate_api_token(
     result = await http_client.post(
         region=region,
         workspace=workspace,
-        endpoint=f'/api/apitoken/tokens/{token_id}/duplicate/',
+        endpoint=f'/api/auth/tokens/{token_id}/duplicate/',
         token=token,
         data={},
     )
@@ -200,7 +196,7 @@ async def list_api_token_scopes(
     result = await http_client.get(
         region=region,
         workspace=workspace,
-        endpoint='/api/apitoken/tokens/scopes/',
+        endpoint='/api/auth/tokens/scopes/',
         token=token,
     )
     return success_response(data=result, region=region, workspace=workspace)

--- a/tools/token_tools.py
+++ b/tools/token_tools.py
@@ -71,6 +71,7 @@ async def create_api_token(
     scopes: list[str] | None = None,
     expires_at: str | None = None,
     enabled: bool | None = None,
+    presets: list[str] | None = None,
     region: str = '',
     **kwargs,
 ) -> dict[str, Any]:
@@ -82,6 +83,8 @@ async def create_api_token(
         scopes: List of permission scopes for the token (optional)
         expires_at: Expiration datetime in ISO 8601 format (optional)
         enabled: Whether the token is active. Defaults to True on the server (optional)
+        presets: Preset scope keys resolved server-side (e.g. "file_upload"). Merged
+            with explicit scopes; stored as granular scope strings (optional)
         region: Region (ap1, us1, eu1). Auto-detected if not provided
 
     Returns:
@@ -96,6 +99,8 @@ async def create_api_token(
         token_data['expires_at'] = expires_at
     if enabled is not None:
         token_data['enabled'] = enabled
+    if presets is not None:
+        token_data['presets'] = presets
 
     result = await http_client.post(
         region=region,

--- a/tools/token_tools.py
+++ b/tools/token_tools.py
@@ -2,9 +2,9 @@
 
 from typing import Any
 
-from utils.common import error_response, success_response
+from utils.common import success_response, unwrap_http_result
 from utils.decorators import mcp_tool_handler
-from utils.error_handler import validate_server_id_format
+from utils.error_handler import format_validation_error, validate_server_id_format
 from utils.http_client import http_client
 from utils.tool_annotations import ADDITIVE, DESTRUCTIVE, READ_ONLY
 
@@ -117,8 +117,10 @@ async def delete_api_token(
     token = kwargs.get('token')
 
     if not validate_server_id_format(token_id):
-        return error_response(
-            f"Invalid token_id format: '{token_id}'. Must be a valid UUID."
+        return format_validation_error(
+            'token_id',
+            token_id,
+            'Must be a valid UUID. Example: 550e8400-e29b-41d4-a716-446655440000',
         )
 
     result = await http_client.delete(
@@ -127,7 +129,20 @@ async def delete_api_token(
         endpoint=f'/api/auth/tokens/{token_id}/',
         token=token,
     )
-    return success_response(data=result, token_id=token_id, region=region, workspace=workspace)
+
+    err = unwrap_http_result(
+        result,
+        default_message='Failed to delete API token',
+        token_id=token_id,
+        region=region,
+        workspace=workspace,
+    )
+    if err:
+        return err
+
+    return success_response(
+        data=result, token_id=token_id, region=region, workspace=workspace
+    )
 
 
 @mcp_tool_handler(
@@ -143,9 +158,8 @@ async def duplicate_api_token(
 ) -> dict[str, Any]:
     """Duplicate an API token.
 
-    No additional parameters are accepted for duplication; the new token
-    inherits all configuration (name, scopes, description, expiry) from
-    the source token.
+    The duplicate inherits all configuration (name, scopes, expiry) from the
+    source token; overrides are not supported.
 
     Args:
         token_id: ID of the API token to duplicate
@@ -158,8 +172,10 @@ async def duplicate_api_token(
     token = kwargs.get('token')
 
     if not validate_server_id_format(token_id):
-        return error_response(
-            f"Invalid token_id format: '{token_id}'. Must be a valid UUID."
+        return format_validation_error(
+            'token_id',
+            token_id,
+            'Must be a valid UUID. Example: 550e8400-e29b-41d4-a716-446655440000',
         )
 
     result = await http_client.post(
@@ -169,7 +185,20 @@ async def duplicate_api_token(
         token=token,
         data={},
     )
-    return success_response(data=result, token_id=token_id, region=region, workspace=workspace)
+
+    err = unwrap_http_result(
+        result,
+        default_message='Failed to duplicate API token',
+        token_id=token_id,
+        region=region,
+        workspace=workspace,
+    )
+    if err:
+        return err
+
+    return success_response(
+        data=result, token_id=token_id, region=region, workspace=workspace
+    )
 
 
 @mcp_tool_handler(

--- a/tools/token_tools.py
+++ b/tools/token_tools.py
@@ -1,13 +1,14 @@
 """API token management tools for Alpacon MCP server.
 
-Authentication note: the server rejects API token mutating operations
-when the request is itself authenticated with a ``source='api'``
-APIToken (``api/apitoken/permissions.py:APITokenObjectPermission``).
-The list/retrieve/create/update/delete/duplicate tools below therefore
-require JWT/OAuth authentication (streamable-http remote mode) to
-succeed; stdio mode using a token from ``token.json`` will receive
-``403 Forbidden`` for those tools. The scopes and presets catalog
-endpoints are not subject to this restriction.
+Authentication note: ``api/apitoken/permissions.py:APITokenObjectPermission``
+rejects any request whose ``request.auth`` is an ``APIToken`` with
+``source='api'``. The list/retrieve/create/update/delete/duplicate
+tools below therefore return ``403 Forbidden`` when called from stdio
+mode using a token from ``token.json`` (which is a ``source='api'``
+token). Other authentication paths (JWT/OAuth in streamable-http
+remote mode, browser session, ``source='login'`` token) pass the
+check. The scopes and presets catalog endpoints are not subject to
+this restriction.
 """
 
 from typing import Any
@@ -24,8 +25,8 @@ from utils.tool_annotations import (
 )
 
 _JWT_REQUIRED_NOTE = (
-    'Requires JWT/OAuth authentication; calls authenticated with a '
-    "source='api' API token receive 403 Forbidden from the server."
+    "Returns 403 Forbidden when called with a source='api' API token; "
+    'use JWT/OAuth, a browser session, or a login-source token instead.'
 )
 
 
@@ -72,8 +73,10 @@ async def list_api_tokens(
         enabled: Filter by enabled status (optional)
         remote_ip: Filter by remote IP that last used the token (optional)
         search: Free-text search across name, user_agent, remote_ip (optional)
-        ordering: Sort field; one of "added_at", "-added_at", "updated_at",
-            "-updated_at" (optional)
+        ordering: Sort field, e.g. "-updated_at" (server default), "added_at".
+            Multiple fields may be comma-separated. Available fields:
+            updated_at, added_at. Not validated client-side - the server
+            rejects unknown fields (optional)
 
     Returns:
         API tokens list response
@@ -197,8 +200,8 @@ async def create_api_token(
         scopes: List of permission scopes for the token (optional)
         expires_at: Expiration datetime in ISO 8601 format (optional)
         enabled: Whether the token is active. Defaults to True on the server (optional)
-        presets: Preset scope keys resolved server-side (e.g. "file_upload"). Merged
-            with explicit scopes; stored as granular scope strings. Use
+        presets: Preset scope keys resolved server-side. Merged with explicit
+            scopes; stored as granular scope strings. Call
             list_api_token_presets to discover available keys (optional)
         region: Region (ap1, us1, eu1). Auto-detected if not provided
 
@@ -270,8 +273,11 @@ async def update_api_token(
         workspace: Workspace name. Required parameter
         name: New token name (optional)
         enabled: Toggle the token's enabled state (optional)
-        expires_at: New expiration datetime in ISO 8601 format. Pass null
-            is not supported; omit to leave unchanged (optional)
+        expires_at: New expiration datetime in ISO 8601 format. Omit to
+            leave unchanged. The server's model accepts null to clear
+            the expiry, but this tool's signature has no way to express
+            that distinctly from "omit"; call the API directly if you
+            need to remove an existing expiry (optional)
         scopes: Replacement scope list. Re-validated against the caller's
             RBAC ceiling (optional)
         region: Region (ap1, us1, eu1). Auto-detected if not provided

--- a/tools/token_tools.py
+++ b/tools/token_tools.py
@@ -14,7 +14,7 @@ this restriction.
 from typing import Any
 
 from utils.common import error_response, success_response, unwrap_http_result
-from utils.decorators import mcp_tool_handler
+from utils.decorators import mcp_tool_handler, require_jwt_auth
 from utils.error_handler import format_validation_error, validate_server_id_format
 from utils.http_client import http_client
 from utils.tool_annotations import (
@@ -182,6 +182,7 @@ async def get_api_token(
     annotations=ADDITIVE,
     meta={'anthropic/searchHint': 'api token create generate credentials'},
 )
+@require_jwt_auth
 async def create_api_token(
     workspace: str,
     name: str,
@@ -252,6 +253,7 @@ async def create_api_token(
         'anthropic/searchHint': 'api token update modify enable disable expire rename'
     },
 )
+@require_jwt_auth
 async def update_api_token(
     token_id: str,
     workspace: str,
@@ -341,6 +343,7 @@ async def update_api_token(
     annotations=DESTRUCTIVE,
     meta={'anthropic/searchHint': 'api token delete revoke remove'},
 )
+@require_jwt_auth
 async def delete_api_token(
     token_id: str,
     workspace: str,
@@ -395,6 +398,7 @@ async def delete_api_token(
     annotations=ADDITIVE,
     meta={'anthropic/searchHint': 'api token duplicate copy clone rotate'},
 )
+@require_jwt_auth
 async def duplicate_api_token(
     token_id: str,
     workspace: str,

--- a/tools/token_tools.py
+++ b/tools/token_tools.py
@@ -1,12 +1,32 @@
-"""API token management tools for Alpacon MCP server."""
+"""API token management tools for Alpacon MCP server.
+
+Authentication note: the server rejects API token mutating operations
+when the request is itself authenticated with a ``source='api'``
+APIToken (``api/apitoken/permissions.py:APITokenObjectPermission``).
+The list/retrieve/create/update/delete/duplicate tools below therefore
+require JWT/OAuth authentication (streamable-http remote mode) to
+succeed; stdio mode using a token from ``token.json`` will receive
+``403 Forbidden`` for those tools. The scopes and presets catalog
+endpoints are not subject to this restriction.
+"""
 
 from typing import Any
 
-from utils.common import success_response, unwrap_http_result
+from utils.common import error_response, success_response, unwrap_http_result
 from utils.decorators import mcp_tool_handler
 from utils.error_handler import format_validation_error, validate_server_id_format
 from utils.http_client import http_client
-from utils.tool_annotations import ADDITIVE, DESTRUCTIVE, READ_ONLY
+from utils.tool_annotations import (
+    ADDITIVE,
+    DESTRUCTIVE,
+    IDEMPOTENT_WRITE,
+    READ_ONLY,
+)
+
+_JWT_REQUIRED_NOTE = (
+    'Requires JWT/OAuth authentication; calls authenticated with a '
+    "source='api' API token receive 403 Forbidden from the server."
+)
 
 
 def _validate_token_id(token_id: str) -> dict[str, Any] | None:
@@ -20,7 +40,12 @@ def _validate_token_id(token_id: str) -> dict[str, Any] | None:
 
 
 @mcp_tool_handler(
-    description='List API tokens in the workspace. When to use: reviewing existing API tokens or auditing access. Related: create_api_token (create new), delete_api_token (remove), list_api_token_scopes (available scopes).',
+    description=(
+        'List API tokens in the workspace. When to use: reviewing existing API tokens or auditing access. '
+        'Related: get_api_token (detail), create_api_token (create new), update_api_token (modify), '
+        'delete_api_token (remove), list_api_token_scopes (available scopes). '
+        f'{_JWT_REQUIRED_NOTE}'
+    ),
     annotations=READ_ONLY,
     meta={'anthropic/searchHint': 'api token list credentials access'},
 )
@@ -29,6 +54,11 @@ async def list_api_tokens(
     region: str = '',
     page: int | None = None,
     page_size: int | None = None,
+    name: str | None = None,
+    enabled: bool | None = None,
+    remote_ip: str | None = None,
+    search: str | None = None,
+    ordering: str | None = None,
     **kwargs,
 ) -> dict[str, Any]:
     """List API tokens.
@@ -38,6 +68,12 @@ async def list_api_tokens(
         region: Region (ap1, us1, eu1). Auto-detected if not provided
         page: Page number for pagination (optional)
         page_size: Number of items per page (optional)
+        name: Filter by exact token name (optional)
+        enabled: Filter by enabled status (optional)
+        remote_ip: Filter by remote IP that last used the token (optional)
+        search: Free-text search across name, user_agent, remote_ip (optional)
+        ordering: Sort field; one of "added_at", "-added_at", "updated_at",
+            "-updated_at" (optional)
 
     Returns:
         API tokens list response
@@ -49,6 +85,16 @@ async def list_api_tokens(
         params['page'] = page
     if page_size is not None:
         params['page_size'] = page_size
+    if name is not None:
+        params['name'] = name
+    if enabled is not None:
+        params['enabled'] = enabled
+    if remote_ip is not None:
+        params['remote_ip'] = remote_ip
+    if search is not None:
+        params['search'] = search
+    if ordering is not None:
+        params['ordering'] = ordering
 
     result = await http_client.get(
         region=region,
@@ -71,7 +117,65 @@ async def list_api_tokens(
 
 
 @mcp_tool_handler(
-    description='Create a new API token in the workspace. When to use: generating credentials for programmatic access or integrations. Related: list_api_tokens (view existing), delete_api_token (remove), list_api_token_scopes (check available scopes).',
+    description=(
+        "Get detailed information about a specific API token by ID. When to use: inspecting a token's "
+        'scopes, expiry, or enabled status. Related: list_api_tokens (find token ID), update_api_token '
+        f'(modify), delete_api_token (remove). {_JWT_REQUIRED_NOTE}'
+    ),
+    annotations=READ_ONLY,
+    meta={'anthropic/searchHint': 'api token get detail retrieve'},
+)
+async def get_api_token(
+    token_id: str,
+    workspace: str,
+    region: str = '',
+    **kwargs,
+) -> dict[str, Any]:
+    """Get a single API token.
+
+    Args:
+        token_id: ID of the API token to retrieve
+        workspace: Workspace name. Required parameter
+        region: Region (ap1, us1, eu1). Auto-detected if not provided
+
+    Returns:
+        API token detail response
+    """
+    token = kwargs.get('token')
+
+    err = _validate_token_id(token_id)
+    if err:
+        return err
+
+    result = await http_client.get(
+        region=region,
+        workspace=workspace,
+        endpoint=f'/api/auth/tokens/{token_id}/',
+        token=token,
+    )
+
+    err = unwrap_http_result(
+        result,
+        default_message='Failed to get API token',
+        token_id=token_id,
+        region=region,
+        workspace=workspace,
+    )
+    if err:
+        return err
+
+    return success_response(
+        data=result, token_id=token_id, region=region, workspace=workspace
+    )
+
+
+@mcp_tool_handler(
+    description=(
+        'Create a new API token in the workspace. When to use: generating credentials for programmatic '
+        'access or integrations. Related: list_api_tokens (view existing), update_api_token (modify), '
+        'delete_api_token (remove), list_api_token_scopes (check available scopes), '
+        f'list_api_token_presets (preset catalog). {_JWT_REQUIRED_NOTE}'
+    ),
     annotations=ADDITIVE,
     meta={'anthropic/searchHint': 'api token create generate credentials'},
 )
@@ -94,7 +198,8 @@ async def create_api_token(
         expires_at: Expiration datetime in ISO 8601 format (optional)
         enabled: Whether the token is active. Defaults to True on the server (optional)
         presets: Preset scope keys resolved server-side (e.g. "file_upload"). Merged
-            with explicit scopes; stored as granular scope strings (optional)
+            with explicit scopes; stored as granular scope strings. Use
+            list_api_token_presets to discover available keys (optional)
         region: Region (ap1, us1, eu1). Auto-detected if not provided
 
     Returns:
@@ -133,7 +238,95 @@ async def create_api_token(
 
 
 @mcp_tool_handler(
-    description='Delete an API token permanently. When to use: revoking access for a specific token. Related: list_api_tokens (find token ID), duplicate_api_token (create a copy before deleting). Note: This cannot be undone.',
+    description=(
+        'Update an existing API token. When to use: toggling enabled status, changing the expiration '
+        'time, renaming, or narrowing scopes without rotating the key. Related: get_api_token (read '
+        'current state), create_api_token (create new), delete_api_token (remove). '
+        f'Note: presets are create-only and rejected on update. {_JWT_REQUIRED_NOTE}'
+    ),
+    annotations=IDEMPOTENT_WRITE,
+    meta={
+        'anthropic/searchHint': 'api token update modify enable disable expire rename'
+    },
+)
+async def update_api_token(
+    token_id: str,
+    workspace: str,
+    name: str | None = None,
+    enabled: bool | None = None,
+    expires_at: str | None = None,
+    scopes: list[str] | None = None,
+    region: str = '',
+    **kwargs,
+) -> dict[str, Any]:
+    """Update an API token via PATCH.
+
+    Only the fields you pass are sent; everything else is left untouched
+    on the server. The server enforces the caller's RBAC scope ceiling
+    when ``scopes`` is included.
+
+    Args:
+        token_id: ID of the API token to update
+        workspace: Workspace name. Required parameter
+        name: New token name (optional)
+        enabled: Toggle the token's enabled state (optional)
+        expires_at: New expiration datetime in ISO 8601 format. Pass null
+            is not supported; omit to leave unchanged (optional)
+        scopes: Replacement scope list. Re-validated against the caller's
+            RBAC ceiling (optional)
+        region: Region (ap1, us1, eu1). Auto-detected if not provided
+
+    Returns:
+        API token update response
+    """
+    token = kwargs.get('token')
+
+    err = _validate_token_id(token_id)
+    if err:
+        return err
+
+    update_data: dict[str, Any] = {}
+    if name is not None:
+        update_data['name'] = name
+    if enabled is not None:
+        update_data['enabled'] = enabled
+    if expires_at is not None:
+        update_data['expires_at'] = expires_at
+    if scopes is not None:
+        update_data['scopes'] = scopes
+
+    if not update_data:
+        return error_response('No update data provided')
+
+    result = await http_client.patch(
+        region=region,
+        workspace=workspace,
+        endpoint=f'/api/auth/tokens/{token_id}/',
+        token=token,
+        data=update_data,
+    )
+
+    err = unwrap_http_result(
+        result,
+        default_message='Failed to update API token',
+        token_id=token_id,
+        region=region,
+        workspace=workspace,
+    )
+    if err:
+        return err
+
+    return success_response(
+        data=result, token_id=token_id, region=region, workspace=workspace
+    )
+
+
+@mcp_tool_handler(
+    description=(
+        'Delete an API token permanently. When to use: revoking access for a specific token. '
+        'Related: list_api_tokens (find token ID), update_api_token (disable instead of deleting), '
+        f'duplicate_api_token (create a copy before deleting). Note: This cannot be undone. {_JWT_REQUIRED_NOTE}'
+    ),
     annotations=DESTRUCTIVE,
     meta={'anthropic/searchHint': 'api token delete revoke remove'},
 )
@@ -182,7 +375,12 @@ async def delete_api_token(
 
 
 @mcp_tool_handler(
-    description='Duplicate an existing API token to create a copy with the same configuration. When to use: creating a backup token or rotating credentials. Related: list_api_tokens (find token ID), create_api_token (create from scratch), delete_api_token (remove old token after rotation).',
+    description=(
+        'Duplicate an existing API token to create a copy with the same configuration. When to use: '
+        'creating a backup token or rotating credentials. Related: list_api_tokens (find token ID), '
+        'create_api_token (create from scratch), delete_api_token (remove old token after rotation). '
+        f'{_JWT_REQUIRED_NOTE}'
+    ),
     annotations=ADDITIVE,
     meta={'anthropic/searchHint': 'api token duplicate copy clone rotate'},
 )
@@ -241,7 +439,7 @@ async def duplicate_api_token(
 
 
 @mcp_tool_handler(
-    description='List available API token scopes. When to use: before creating a token, to see which permission scopes can be assigned. Related: create_api_token (use scopes when creating), list_api_tokens (view tokens and their scopes).',
+    description='List available API token scopes. When to use: before creating a token, to see which permission scopes can be assigned. Related: create_api_token (use scopes when creating), list_api_token_presets (bundled preset keys), list_api_tokens (view tokens and their scopes).',
     annotations=READ_ONLY,
     meta={'anthropic/searchHint': 'api token scopes permissions available'},
 )
@@ -271,6 +469,46 @@ async def list_api_token_scopes(
     err = unwrap_http_result(
         result,
         default_message='Failed to list API token scopes',
+        region=region,
+        workspace=workspace,
+    )
+    if err:
+        return err
+
+    return success_response(data=result, region=region, workspace=workspace)
+
+
+@mcp_tool_handler(
+    description='List available API token scope presets. When to use: before creating a token, to discover bundled scope shortcuts (e.g. "file_upload") that can be passed to create_api_token. Related: list_api_token_scopes (granular scopes), create_api_token (use presets when creating).',
+    annotations=READ_ONLY,
+    meta={'anthropic/searchHint': 'api token preset scopes bundle catalog'},
+)
+async def list_api_token_presets(
+    workspace: str,
+    region: str = '',
+    **kwargs,
+) -> dict[str, Any]:
+    """List available API token scope presets.
+
+    Args:
+        workspace: Workspace name. Required parameter
+        region: Region (ap1, us1, eu1). Auto-detected if not provided
+
+    Returns:
+        Available API token presets response
+    """
+    token = kwargs.get('token')
+
+    result = await http_client.get(
+        region=region,
+        workspace=workspace,
+        endpoint='/api/auth/tokens/presets/',
+        token=token,
+    )
+
+    err = unwrap_http_result(
+        result,
+        default_message='Failed to list API token presets',
         region=region,
         workspace=workspace,
     )

--- a/tools/token_tools.py
+++ b/tools/token_tools.py
@@ -9,6 +9,16 @@ from utils.http_client import http_client
 from utils.tool_annotations import ADDITIVE, DESTRUCTIVE, READ_ONLY
 
 
+def _validate_token_id(token_id: str) -> dict[str, Any] | None:
+    if not validate_server_id_format(token_id):
+        return format_validation_error(
+            'token_id',
+            token_id,
+            'Must be a valid UUID. Example: 550e8400-e29b-41d4-a716-446655440000',
+        )
+    return None
+
+
 @mcp_tool_handler(
     description='List API tokens in the workspace. When to use: reviewing existing API tokens or auditing access. Related: create_api_token (create new), delete_api_token (remove), list_api_token_scopes (available scopes).',
     annotations=READ_ONLY,
@@ -145,12 +155,9 @@ async def delete_api_token(
     """
     token = kwargs.get('token')
 
-    if not validate_server_id_format(token_id):
-        return format_validation_error(
-            'token_id',
-            token_id,
-            'Must be a valid UUID. Example: 550e8400-e29b-41d4-a716-446655440000',
-        )
+    err = _validate_token_id(token_id)
+    if err:
+        return err
 
     result = await http_client.delete(
         region=region,
@@ -202,12 +209,9 @@ async def duplicate_api_token(
     """
     token = kwargs.get('token')
 
-    if not validate_server_id_format(token_id):
-        return format_validation_error(
-            'token_id',
-            token_id,
-            'Must be a valid UUID. Example: 550e8400-e29b-41d4-a716-446655440000',
-        )
+    err = _validate_token_id(token_id)
+    if err:
+        return err
 
     data: dict[str, Any] = {}
     if name is not None:

--- a/tools/token_tools.py
+++ b/tools/token_tools.py
@@ -258,6 +258,7 @@ async def update_api_token(
     name: str | None = None,
     enabled: bool | None = None,
     expires_at: str | None = None,
+    clear_expires_at: bool = False,
     scopes: list[str] | None = None,
     region: str = '',
     **kwargs,
@@ -273,11 +274,10 @@ async def update_api_token(
         workspace: Workspace name. Required parameter
         name: New token name (optional)
         enabled: Toggle the token's enabled state (optional)
-        expires_at: New expiration datetime in ISO 8601 format. Omit to
-            leave unchanged. The server's model accepts null to clear
-            the expiry, but this tool's signature has no way to express
-            that distinctly from "omit"; call the API directly if you
-            need to remove an existing expiry (optional)
+        expires_at: New expiration datetime in ISO 8601 format. Mutually
+            exclusive with clear_expires_at (optional)
+        clear_expires_at: When True, remove the expiry so the token never
+            expires. Mutually exclusive with expires_at (optional)
         scopes: Replacement scope list. Re-validated against the caller's
             RBAC ceiling (optional)
         region: Region (ap1, us1, eu1). Auto-detected if not provided
@@ -291,6 +291,9 @@ async def update_api_token(
     if err:
         return err
 
+    if expires_at is not None and clear_expires_at:
+        return error_response('expires_at and clear_expires_at are mutually exclusive')
+
     update_data: dict[str, Any] = {}
     if name is not None:
         update_data['name'] = name
@@ -298,6 +301,8 @@ async def update_api_token(
         update_data['enabled'] = enabled
     if expires_at is not None:
         update_data['expires_at'] = expires_at
+    elif clear_expires_at:
+        update_data['expires_at'] = None
     if scopes is not None:
         update_data['scopes'] = scopes
 

--- a/tools/token_tools.py
+++ b/tools/token_tools.py
@@ -2,8 +2,9 @@
 
 from typing import Any
 
-from utils.common import success_response
+from utils.common import error_response, success_response
 from utils.decorators import mcp_tool_handler
+from utils.error_handler import validate_server_id_format
 from utils.http_client import http_client
 from utils.tool_annotations import ADDITIVE, DESTRUCTIVE, READ_ONLY
 
@@ -119,6 +120,11 @@ async def delete_api_token(
     """
     token = kwargs.get('token')
 
+    if not validate_server_id_format(token_id):
+        return error_response(
+            f"Invalid token_id format: '{token_id}'. Must be a valid UUID."
+        )
+
     result = await http_client.delete(
         region=region,
         workspace=workspace,
@@ -141,6 +147,10 @@ async def duplicate_api_token(
 ) -> dict[str, Any]:
     """Duplicate an API token.
 
+    No additional parameters are accepted for duplication; the new token
+    inherits all configuration (name, scopes, description, expiry) from
+    the source token.
+
     Args:
         token_id: ID of the API token to duplicate
         workspace: Workspace name. Required parameter
@@ -150,6 +160,11 @@ async def duplicate_api_token(
         Duplicated API token response
     """
     token = kwargs.get('token')
+
+    if not validate_server_id_format(token_id):
+        return error_response(
+            f"Invalid token_id format: '{token_id}'. Must be a valid UUID."
+        )
 
     result = await http_client.post(
         region=region,

--- a/utils/decorators.py
+++ b/utils/decorators.py
@@ -459,6 +459,38 @@ def with_logging(func: Callable) -> Callable:
     return wrapper
 
 
+def require_jwt_auth(func: Callable) -> Callable:
+    """Reject non-JWT (API) tokens before any upstream call.
+
+    Stack INSIDE ``@mcp_tool_handler`` so the resolved token is already
+    in the wrapped function's ``**kwargs`` when this guard runs. Used on
+    tools whose endpoint ``APITokenObjectPermission`` would 403 for
+    ``source='api'`` requests — short-circuiting here skips the wasted
+    round-trip and returns a clearer error.
+
+    Usage::
+
+        @mcp_tool_handler(description='...')
+        @require_jwt_auth
+        async def create_api_token(...): ...
+    """
+
+    @wraps(func)
+    async def wrapper(*args, **kwargs):
+        from utils.http_client import AlpaconHTTPClient
+
+        token = kwargs.get('token')
+        if token and not AlpaconHTTPClient._is_jwt(token):
+            return error_response(
+                f'{func.__name__} requires JWT (OAuth/SSO) authentication; '
+                'API tokens cannot manage other API tokens. '
+                'Re-authenticate via browser-based SSO and retry.'
+            )
+        return await func(*args, **kwargs)
+
+    return wrapper
+
+
 def mcp_tool_handler(
     description: str,
     annotations: ToolAnnotations | None = None,

--- a/utils/decorators.py
+++ b/utils/decorators.py
@@ -18,6 +18,7 @@ from utils.error_handler import (
     validate_server_id_format,
     validate_workspace_format,
 )
+from utils.http_client import AlpaconHTTPClient
 from utils.logger import get_logger
 
 logger = get_logger('decorators')
@@ -477,8 +478,6 @@ def require_jwt_auth(func: Callable) -> Callable:
 
     @wraps(func)
     async def wrapper(*args, **kwargs):
-        from utils.http_client import AlpaconHTTPClient
-
         token = kwargs.get('token')
         if token and not AlpaconHTTPClient._is_jwt(token):
             return error_response(


### PR DESCRIPTION
## Summary

Add MCP tools for managing Alpacon API tokens, aligned with the server-side `APITokenViewSet` contract.

## Tools added

| Tool | Purpose |
|---|---|
| `list_api_tokens` | List the workspace's API tokens with filters and pagination. |
| `get_api_token` | Retrieve a single token by ID. |
| `create_api_token` | Create a token. Accepts explicit `scopes` and/or `presets` (write-only; resolved server-side into granular scopes by `APITokenCreateSerializer`). |
| `update_api_token` | PATCH `name`, `enabled`, `expires_at`, or `scopes`. Includes a `clear_expires_at` flag to null the field, with a mutual-exclusion guard against `expires_at`. |
| `duplicate_api_token` | Copy a token (scopes + ACLs). Optional `name` override; otherwise the server auto-generates `"<name> (copy)"`. |
| `delete_api_token` | Permanently revoke a token. |
| `list_api_token_scopes` | Read-only catalog of scope resources and wildcard patterns. Not gated by `APITokenObjectPermission`. |
| `list_api_token_presets` | Read-only catalog of scope presets available to the workspace. Not gated by `APITokenObjectPermission`. |

## Behavior notes

- **List filters**: `name`, `enabled`, `remote_ip`, `search`, `ordering` (server fields: `added_at`, `updated_at`; default `-updated_at`) and pagination via `page`/`page_size` — mirrors `APITokenViewSet.filterset_fields` / `search_fields` / `ordering_fields`.
- **Server-side permission caveat**: `APITokenObjectPermission.has_permission` rejects requests whose own auth `source == 'api'` for **all** `/api/auth/tokens/` operations (list/get/create/update/delete/duplicate) — not only mutations — because the check is method-agnostic. The scopes and presets catalog endpoints are not gated by this permission. Tool descriptions surface this so callers know MFA-bound JWT (or another non-`source='api'` auth path) is required for every token-management call.
- **MCP-side preflight on mutations**: `create_api_token`, `update_api_token`, `duplicate_api_token`, and `delete_api_token` are decorated with `@require_jwt_auth`. The guard inspects the resolved caller token via `AlpaconHTTPClient._is_jwt` (the same shape check the HTTP client uses to pick `Bearer` vs `token=`) and short-circuits with a clear error before any upstream request — saving the inevitable 403 round-trip when a non-JWT (API) token is in play. Read-only tools (`list_*`, `get_api_token`) intentionally skip the guard so callers may still enumerate their own tokens with whichever auth they hold; the server is the final authority for those.

## Manual testing

End-to-end validation requires OAuth (browser-based SSO) authentication because `source='api'` tokens are rejected by `APITokenObjectPermission`. Real-environment testing will be performed in the **dev** environment, where the OAuth re-auth flow is wired up.

## Test plan

- [x] `pytest tests/test_token_tools.py` — 50 tests pass (45 existing + 5 new for `@require_jwt_auth`)
- [x] Full suite (`pytest tests/`) — 617 tests pass
- [x] Cross-checked against `alpacon-server/main` (`api/apitoken/views.py`, `serializers.py`, `permissions.py`, `urls.py`)
- [x] 5 review rounds converged (BLOCKER/HIGH = 0 across last 4 rounds)

## Verification commands

```bash
.venv/bin/pytest tests/test_token_tools.py -v
.venv/bin/pytest tests/
```
