### PR TITLE
fix: add missing permissions to publish workflow (CodeQL #16)

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -5,6 +5,9 @@ on:
   release:
     types: [published]  # Only runs when release is published (not draft)
 
+permissions:
+  contents: read
+
 jobs:
   build:
     runs-on: ubuntu-latest


### PR DESCRIPTION
## Summary

- Resolves [CodeQL code scanning alert #16](https://github.com/alpacax/alpacon-mcp/security/code-scanning/16): `publish.yml` lacked an explicit `permissions` block, leaving the `GITHUB_TOKEN` scope governed by repository defaults (potentially read-write)
- Adds `permissions: contents: read` at the workflow level, consistent with `test.yml` and `docker.yml`
- The `publish-pypi` job retains its existing job-level `permissions: id-token: write` override required for OIDC trusted publishing

## Changes

- `.github/workflows/publish.yml`: add top-level `permissions: contents: read`

## Test plan

- [ ] Verify the CodeQL alert is dismissed after this PR merges
- [ ] Confirm a new release trigger still publishes to PyPI correctly (trusted publishing flow unchanged)