### PR TITLE
feat: complete IAM tools with group, membership, and application management

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -338,15 +338,33 @@ All validators are defined in `utils/error_handler.py` and return user-friendly 
 **User management**:
 - `list_iam_users`: List all IAM users in workspace with pagination support
 - `get_iam_user`: Get detailed information about a specific IAM user
-- `create_iam_user`: Create new IAM user with groups assignment
-- `update_iam_user`: Update existing IAM user (email, name, active status, groups)
+- `create_iam_user`: Create new IAM user (username, email, name, active status)
+- `update_iam_user`: Update existing IAM user (email, name, active status)
 - `delete_iam_user`: Delete IAM user from workspace
+- `invite_workspace_user`: Send an email invitation to join the workspace (Auth0-enabled deployments only)
 
 **Group management**:
 - `list_iam_groups`: List all IAM groups in workspace with pagination support
-- `create_iam_group`: Create new IAM group
+- `create_iam_group`: Create new IAM group (name, display name, description)
+- `get_iam_group`: Get detailed information about a specific IAM group
+- `update_iam_group`: Update an IAM group (display name, description; group name is immutable)
+- `delete_iam_group`: Permanently delete an IAM group
 
-**IAM architecture**: Basic identity management supporting users and groups with workspace-level isolation. Group-based permission management.
+**Membership management**:
+- `list_iam_memberships`: List group memberships, optionally filtered by group
+- `add_iam_member`: Add a user to a group with a role (member, manager, or owner)
+- `remove_iam_member`: Remove a membership by membership ID
+
+**Application management** (machine service accounts):
+- `list_iam_applications`: List IAM applications with pagination support
+- `create_iam_application`: Create an IAM application (name, description, service type)
+- `get_iam_application`: Get detailed information about a specific application
+- `update_iam_application`: Update an application (name, description)
+- `delete_iam_application`: Permanently delete an application
+- `assign_application_system_users`: Bind system users to an application as service accounts
+- `unassign_application_system_users`: Release system users from an application
+
+**IAM architecture**: Identity management supporting users, groups, memberships, and machine applications with workspace-level isolation. Group membership is managed through the memberships API (users have no writable groups field).
 
 **Note**: Role and permission management endpoints are not currently implemented in the Alpacon server. The following tools have been removed:
 - ~~`list_iam_roles`~~: Not available

--- a/tests/integration/test_tool_end_to_end.py
+++ b/tests/integration/test_tool_end_to_end.py
@@ -27,6 +27,7 @@ from tools.server_tools import (
 pytestmark = [pytest.mark.integration, pytest.mark.asyncio]
 
 SERVER_UUID = '550e8400-e29b-41d4-a716-446655440001'
+IAM_USER_UUID = '550e8400-e29b-41d4-a716-446655440002'
 
 
 class TestServerToolsEndToEnd:
@@ -187,7 +188,7 @@ class TestIAMToolsEndToEnd:
         patched_http_client.set_handler(handler)
 
         result = await update_iam_user(
-            user_id='user-001',
+            user_id=IAM_USER_UUID,
             workspace='production',
             email='updated@example.com',
             region='ap1',
@@ -206,13 +207,13 @@ class TestIAMToolsEndToEnd:
 
         def handler(request: httpx.Request) -> httpx.Response:
             captured_method.append(request.method)
-            assert '/api/iam/users/user-001/' in str(request.url)
+            assert f'/api/iam/users/{IAM_USER_UUID}/' in str(request.url)
             return httpx.Response(204, text='')
 
         patched_http_client.set_handler(handler)
 
         result = await delete_iam_user(
-            user_id='user-001', workspace='production', region='ap1'
+            user_id=IAM_USER_UUID, workspace='production', region='ap1'
         )
 
         assert result['status'] == 'success'

--- a/tests/test_iam_tools.py
+++ b/tests/test_iam_tools.py
@@ -533,6 +533,20 @@ class TestIAMGroupExtendedManagement:
         mock_http_client.patch.assert_not_called()
 
     @pytest.mark.asyncio
+    async def test_update_iam_group_invalid_id(
+        self, mock_http_client, mock_token_manager
+    ):
+        """Test group update rejects a non-UUID group ID locally."""
+        result = await update_iam_group(
+            group_id='not-a-uuid',
+            display_name='Senior Admins',
+            workspace='testworkspace',
+        )
+
+        assert result['status'] == 'error'
+        mock_http_client.patch.assert_not_called()
+
+    @pytest.mark.asyncio
     async def test_delete_iam_group_success(self, mock_http_client, mock_token_manager):
         """Test successful group deletion."""
         mock_http_client.delete.return_value = {'message': 'Group deleted successfully'}
@@ -548,6 +562,18 @@ class TestIAMGroupExtendedManagement:
             endpoint=f'/api/iam/groups/{GROUP_ID}/',
             token='test-token',
         )
+
+    @pytest.mark.asyncio
+    async def test_delete_iam_group_invalid_id(
+        self, mock_http_client, mock_token_manager
+    ):
+        """Test group deletion rejects a non-UUID group ID locally."""
+        result = await delete_iam_group(
+            group_id='not-a-uuid', workspace='testworkspace'
+        )
+
+        assert result['status'] == 'error'
+        mock_http_client.delete.assert_not_called()
 
 
 class TestIAMMembershipManagement:
@@ -1042,6 +1068,34 @@ class TestIAMApplicationManagement:
         result = await assign_application_system_users(
             app_id=APP_ID,
             system_user_ids=[],
+            workspace='testworkspace',
+        )
+
+        assert result['status'] == 'error'
+        mock_http_client.post.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_assign_application_system_users_invalid_system_user_id(
+        self, mock_http_client, mock_token_manager
+    ):
+        """Test assignment rejects a non-UUID system user ID locally."""
+        result = await assign_application_system_users(
+            app_id=APP_ID,
+            system_user_ids=['not-a-uuid'],
+            workspace='testworkspace',
+        )
+
+        assert result['status'] == 'error'
+        mock_http_client.post.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_unassign_application_system_users_invalid_system_user_id(
+        self, mock_http_client, mock_token_manager
+    ):
+        """Test unassignment rejects a non-UUID system user ID locally."""
+        result = await unassign_application_system_users(
+            app_id=APP_ID,
+            system_user_ids=['not-a-uuid'],
             workspace='testworkspace',
         )
 

--- a/tests/test_iam_tools.py
+++ b/tests/test_iam_tools.py
@@ -699,6 +699,34 @@ class TestIAMMembershipManagement:
         mock_http_client.post.assert_not_called()
 
     @pytest.mark.asyncio
+    async def test_add_iam_member_invalid_group_id(
+        self, mock_http_client, mock_token_manager
+    ):
+        """Test member addition rejects a non-UUID group ID locally."""
+        result = await add_iam_member(
+            group_id='not-a-uuid',
+            user_id=USER_ID,
+            workspace='testworkspace',
+        )
+
+        assert result['status'] == 'error'
+        mock_http_client.post.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_add_iam_member_invalid_user_id(
+        self, mock_http_client, mock_token_manager
+    ):
+        """Test member addition rejects a non-UUID user ID locally."""
+        result = await add_iam_member(
+            group_id=GROUP_ID,
+            user_id='not-a-uuid',
+            workspace='testworkspace',
+        )
+
+        assert result['status'] == 'error'
+        mock_http_client.post.assert_not_called()
+
+    @pytest.mark.asyncio
     async def test_remove_iam_member_success(
         self, mock_http_client, mock_token_manager
     ):
@@ -1097,6 +1125,34 @@ class TestIAMApplicationManagement:
         result = await unassign_application_system_users(
             app_id=APP_ID,
             system_user_ids=['not-a-uuid'],
+            workspace='testworkspace',
+        )
+
+        assert result['status'] == 'error'
+        mock_http_client.post.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_assign_application_system_users_invalid_app_id(
+        self, mock_http_client, mock_token_manager
+    ):
+        """Test assignment rejects a non-UUID application ID locally."""
+        result = await assign_application_system_users(
+            app_id='not-a-uuid',
+            system_user_ids=[SYSTEM_USER_ID],
+            workspace='testworkspace',
+        )
+
+        assert result['status'] == 'error'
+        mock_http_client.post.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_unassign_application_system_users_invalid_app_id(
+        self, mock_http_client, mock_token_manager
+    ):
+        """Test unassignment rejects a non-UUID application ID locally."""
+        result = await unassign_application_system_users(
+            app_id='not-a-uuid',
+            system_user_ids=[SYSTEM_USER_ID],
             workspace='testworkspace',
         )
 

--- a/tests/test_iam_tools.py
+++ b/tests/test_iam_tools.py
@@ -37,6 +37,7 @@ GROUP_ID = '11111111-1111-1111-1111-111111111111'
 USER_ID = '22222222-2222-2222-2222-222222222222'
 USER_ID_2 = '33333333-3333-3333-3333-333333333333'
 MEMBERSHIP_ID = '44444444-4444-4444-4444-444444444444'
+MEMBERSHIP_ID_2 = '77777777-7777-7777-7777-777777777777'
 APP_ID = '55555555-5555-5555-5555-555555555555'
 SYSTEM_USER_ID = '66666666-6666-6666-6666-666666666666'
 
@@ -587,8 +588,8 @@ class TestIAMMembershipManagement:
         memberships_data = {
             'count': 2,
             'results': [
-                {'id': 'mem-1', 'group': GROUP_ID, 'user': 'user-1'},
-                {'id': 'mem-2', 'group': GROUP_ID, 'user': 'user-2'},
+                {'id': MEMBERSHIP_ID, 'group': GROUP_ID, 'user': USER_ID},
+                {'id': MEMBERSHIP_ID_2, 'group': GROUP_ID, 'user': USER_ID_2},
             ],
         }
         mock_http_client.get.return_value = memberships_data
@@ -641,7 +642,7 @@ class TestIAMMembershipManagement:
     @pytest.mark.asyncio
     async def test_add_iam_member_success(self, mock_http_client, mock_token_manager):
         """Test successful member addition to group."""
-        membership_data = {'id': 'mem-1', 'group': GROUP_ID, 'user': USER_ID}
+        membership_data = {'id': MEMBERSHIP_ID, 'group': GROUP_ID, 'user': USER_ID}
         mock_http_client.post.return_value = membership_data
 
         result = await add_iam_member(
@@ -664,7 +665,7 @@ class TestIAMMembershipManagement:
     @pytest.mark.asyncio
     async def test_add_iam_member_with_role(self, mock_http_client, mock_token_manager):
         """Test member addition with an explicit role."""
-        mock_http_client.post.return_value = {'id': 'mem-2', 'role': 'manager'}
+        mock_http_client.post.return_value = {'id': MEMBERSHIP_ID_2, 'role': 'manager'}
 
         result = await add_iam_member(
             group_id=GROUP_ID,

--- a/tests/test_iam_tools.py
+++ b/tests/test_iam_tools.py
@@ -167,7 +167,7 @@ class TestIAMUsersManagement:
         """Test successful user retrieval."""
         mock_http_client.get.return_value = sample_user
 
-        result = await get_iam_user(user_id='user-123', workspace='testworkspace')
+        result = await get_iam_user(user_id=USER_ID, workspace='testworkspace')
 
         assert result['status'] == 'success'
         assert result['data'] == sample_user
@@ -175,9 +175,17 @@ class TestIAMUsersManagement:
         mock_http_client.get.assert_called_once_with(
             region='ap1',
             workspace='testworkspace',
-            endpoint='/api/iam/users/user-123/',
+            endpoint=f'/api/iam/users/{USER_ID}/',
             token='test-token',
         )
+
+    @pytest.mark.asyncio
+    async def test_get_iam_user_invalid_id(self, mock_http_client, mock_token_manager):
+        """Test user retrieval rejects a non-UUID user ID locally."""
+        result = await get_iam_user(user_id='not-a-uuid', workspace='testworkspace')
+
+        assert result['status'] == 'error'
+        mock_http_client.get.assert_not_called()
 
     @pytest.mark.asyncio
     async def test_create_iam_user_success(
@@ -223,7 +231,7 @@ class TestIAMUsersManagement:
         mock_http_client.patch.return_value = updated_user
 
         result = await update_iam_user(
-            user_id='user-123',
+            user_id=USER_ID,
             workspace='testworkspace',
             first_name='Updated',
             is_active=True,
@@ -237,28 +245,50 @@ class TestIAMUsersManagement:
         mock_http_client.patch.assert_called_once_with(
             region='ap1',
             workspace='testworkspace',
-            endpoint='/api/iam/users/user-123/',
+            endpoint=f'/api/iam/users/{USER_ID}/',
             token='test-token',
             data=expected_data,
         )
+
+    @pytest.mark.asyncio
+    async def test_update_iam_user_invalid_id(
+        self, mock_http_client, mock_token_manager
+    ):
+        """Test user update rejects a non-UUID user ID locally."""
+        result = await update_iam_user(
+            user_id='not-a-uuid', workspace='testworkspace', first_name='Updated'
+        )
+
+        assert result['status'] == 'error'
+        mock_http_client.patch.assert_not_called()
 
     @pytest.mark.asyncio
     async def test_delete_iam_user_success(self, mock_http_client, mock_token_manager):
         """Test successful user deletion."""
         mock_http_client.delete.return_value = {'message': 'User deleted successfully'}
 
-        result = await delete_iam_user(user_id='user-123', workspace='testworkspace')
+        result = await delete_iam_user(user_id=USER_ID, workspace='testworkspace')
 
         assert result['status'] == 'success'
         assert result['data']['message'] == 'User deleted successfully'
-        assert result['user_id'] == 'user-123'
+        assert result['user_id'] == USER_ID
 
         mock_http_client.delete.assert_called_once_with(
             region='ap1',
             workspace='testworkspace',
-            endpoint='/api/iam/users/user-123/',
+            endpoint=f'/api/iam/users/{USER_ID}/',
             token='test-token',
         )
+
+    @pytest.mark.asyncio
+    async def test_delete_iam_user_invalid_id(
+        self, mock_http_client, mock_token_manager
+    ):
+        """Test user deletion rejects a non-UUID user ID locally."""
+        result = await delete_iam_user(user_id='not-a-uuid', workspace='testworkspace')
+
+        assert result['status'] == 'error'
+        mock_http_client.delete.assert_not_called()
 
 
 class TestIAMGroupsManagement:
@@ -335,7 +365,7 @@ class TestErrorHandling:
         """Test HTTP error handling."""
         mock_http_client.get.side_effect = Exception('HTTP 404: Not Found')
 
-        result = await get_iam_user(user_id='nonexistent', workspace='testworkspace')
+        result = await get_iam_user(user_id=USER_ID, workspace='testworkspace')
 
         assert result['status'] == 'error'
         assert 'HTTP 404' in result['message']
@@ -555,6 +585,18 @@ class TestIAMMembershipManagement:
             token='test-token',
             params={'group': GROUP_ID, 'page': 1, 'page_size': 10},
         )
+
+    @pytest.mark.asyncio
+    async def test_list_iam_memberships_invalid_group_filter(
+        self, mock_http_client, mock_token_manager
+    ):
+        """Test membership listing rejects a non-UUID group filter locally."""
+        result = await list_iam_memberships(
+            workspace='testworkspace', group_id='not-a-uuid'
+        )
+
+        assert result['status'] == 'error'
+        mock_http_client.get.assert_not_called()
 
     @pytest.mark.asyncio
     async def test_add_iam_member_success(self, mock_http_client, mock_token_manager):

--- a/tests/test_iam_tools.py
+++ b/tests/test_iam_tools.py
@@ -692,6 +692,18 @@ class TestIAMMembershipManagement:
             token='test-token',
         )
 
+    @pytest.mark.asyncio
+    async def test_remove_iam_member_invalid_id(
+        self, mock_http_client, mock_token_manager
+    ):
+        """Test member removal rejects a non-UUID membership ID locally."""
+        result = await remove_iam_member(
+            membership_id='not-a-uuid', workspace='testworkspace'
+        )
+
+        assert result['status'] == 'error'
+        mock_http_client.delete.assert_not_called()
+
 
 class TestWorkspaceUserInvitation:
     """Test workspace user invitation function."""
@@ -906,11 +918,35 @@ class TestIAMApplicationManagement:
         )
 
     @pytest.mark.asyncio
+    async def test_get_iam_application_invalid_id(
+        self, mock_http_client, mock_token_manager
+    ):
+        """Test application retrieval rejects a non-UUID app ID locally."""
+        result = await get_iam_application(
+            app_id='not-a-uuid', workspace='testworkspace'
+        )
+
+        assert result['status'] == 'error'
+        mock_http_client.get.assert_not_called()
+
+    @pytest.mark.asyncio
     async def test_update_iam_application_no_data(
         self, mock_http_client, mock_token_manager
     ):
         """Test update application with no fields returns error."""
         result = await update_iam_application(app_id=APP_ID, workspace='testworkspace')
+
+        assert result['status'] == 'error'
+        mock_http_client.patch.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_update_iam_application_invalid_id(
+        self, mock_http_client, mock_token_manager
+    ):
+        """Test application update rejects a non-UUID app ID locally."""
+        result = await update_iam_application(
+            app_id='not-a-uuid', workspace='testworkspace', name='new-name'
+        )
 
         assert result['status'] == 'error'
         mock_http_client.patch.assert_not_called()
@@ -933,6 +969,18 @@ class TestIAMApplicationManagement:
             endpoint=f'/api/iam/applications/{APP_ID}/',
             token='test-token',
         )
+
+    @pytest.mark.asyncio
+    async def test_delete_iam_application_invalid_id(
+        self, mock_http_client, mock_token_manager
+    ):
+        """Test application deletion rejects a non-UUID app ID locally."""
+        result = await delete_iam_application(
+            app_id='not-a-uuid', workspace='testworkspace'
+        )
+
+        assert result['status'] == 'error'
+        mock_http_client.delete.assert_not_called()
 
     @pytest.mark.asyncio
     async def test_assign_application_system_users_success(

--- a/tests/test_iam_tools.py
+++ b/tests/test_iam_tools.py
@@ -356,6 +356,20 @@ class TestIAMGroupsManagement:
             data=expected_data,
         )
 
+    @pytest.mark.asyncio
+    async def test_create_iam_group_invalid_name(
+        self, mock_http_client, mock_token_manager
+    ):
+        """Test group creation rejects an invalid name locally."""
+        for invalid_name in ('Developers', 'dev team', 'dev.team', ''):
+            result = await create_iam_group(
+                name=invalid_name, workspace='testworkspace'
+            )
+
+            assert result['status'] == 'error'
+
+        mock_http_client.post.assert_not_called()
+
 
 class TestErrorHandling:
     """Test error handling across IAM functions."""

--- a/tests/test_iam_tools.py
+++ b/tests/test_iam_tools.py
@@ -10,6 +10,7 @@ import pytest
 
 from tools.iam_tools import (
     add_iam_member,
+    assign_application_system_users,
     create_iam_application,
     create_iam_group,
     create_iam_user,
@@ -19,17 +20,25 @@ from tools.iam_tools import (
     get_iam_application,
     get_iam_group,
     get_iam_user,
-    invite_iam_user,
+    invite_workspace_user,
     list_iam_applications,
     list_iam_groups,
     list_iam_memberships,
     list_iam_users,
-    provision_service_account,
     remove_iam_member,
+    unassign_application_system_users,
     update_iam_application,
     update_iam_group,
     update_iam_user,
 )
+
+# Valid UUIDs for tools that validate ID format before calling the API
+GROUP_ID = '11111111-1111-1111-1111-111111111111'
+USER_ID = '22222222-2222-2222-2222-222222222222'
+USER_ID_2 = '33333333-3333-3333-3333-333333333333'
+MEMBERSHIP_ID = '44444444-4444-4444-4444-444444444444'
+APP_ID = '55555555-5555-5555-5555-555555555555'
+SYSTEM_USER_ID = '66666666-6666-6666-6666-666666666666'
 
 
 @pytest.fixture
@@ -61,7 +70,7 @@ def sample_user():
         'first_name': 'Test',
         'last_name': 'User',
         'is_active': True,
-        'groups': ['group-1'],
+        'num_groups': 1,
         'date_joined': '2024-01-01T00:00:00Z',
     }
 
@@ -81,7 +90,7 @@ def sample_users_list():
                 'first_name': 'Test',
                 'last_name': 'User1',
                 'is_active': True,
-                'groups': ['group-1'],
+                'num_groups': 1,
             },
             {
                 'id': 'user-456',
@@ -90,7 +99,7 @@ def sample_users_list():
                 'first_name': 'Test',
                 'last_name': 'User2',
                 'is_active': True,
-                'groups': ['group-2'],
+                'num_groups': 1,
             },
         ],
     }
@@ -183,7 +192,6 @@ class TestIAMUsersManagement:
             first_name='Test',
             last_name='User',
             workspace='testworkspace',
-            groups=['group-1'],
         )
 
         assert result['status'] == 'success'
@@ -195,7 +203,6 @@ class TestIAMUsersManagement:
             'first_name': 'Test',
             'last_name': 'User',
             'is_active': True,
-            'groups': ['group-1'],
         }
 
         mock_http_client.post.assert_called_once_with(
@@ -263,9 +270,9 @@ class TestIAMGroupsManagement:
         groups_data = {
             'count': 3,
             'results': [
-                {'id': 'group-1', 'name': 'admins', 'permissions': ['servers.view']},
-                {'id': 'group-2', 'name': 'users', 'permissions': ['servers.view']},
-                {'id': 'group-3', 'name': 'guests', 'permissions': []},
+                {'id': 'group-1', 'name': 'admins', 'num_members': 2},
+                {'id': 'group-2', 'name': 'users', 'num_members': 5},
+                {'id': 'group-3', 'name': 'guests', 'num_members': 0},
             ],
         }
         mock_http_client.get.return_value = groups_data
@@ -288,16 +295,18 @@ class TestIAMGroupsManagement:
     async def test_create_iam_group_success(self, mock_http_client, mock_token_manager):
         """Test successful group creation."""
         group_data = {
-            'id': 'group-123',
+            'id': GROUP_ID,
             'name': 'developers',
-            'permissions': ['servers.view', 'code.deploy'],
+            'display_name': 'Developers',
+            'description': 'Development team',
         }
         mock_http_client.post.return_value = group_data
 
         result = await create_iam_group(
             name='developers',
             workspace='testworkspace',
-            permissions=['servers.view', 'code.deploy'],
+            display_name='Developers',
+            description='Development team',
         )
 
         assert result['status'] == 'success'
@@ -305,7 +314,8 @@ class TestIAMGroupsManagement:
 
         expected_data = {
             'name': 'developers',
-            'permissions': ['servers.view', 'code.deploy'],
+            'display_name': 'Developers',
+            'description': 'Development team',
         }
 
         mock_http_client.post.assert_called_once_with(
@@ -410,22 +420,22 @@ class TestIAMGroupExtendedManagement:
     async def test_get_iam_group_success(self, mock_http_client, mock_token_manager):
         """Test successful group retrieval."""
         group_data = {
-            'id': 'group-123',
+            'id': GROUP_ID,
             'name': 'admins',
             'description': 'Administrators group',
         }
         mock_http_client.get.return_value = group_data
 
-        result = await get_iam_group(group_id='group-123', workspace='testworkspace')
+        result = await get_iam_group(group_id=GROUP_ID, workspace='testworkspace')
 
         assert result['status'] == 'success'
         assert result['data'] == group_data
-        assert result['group_id'] == 'group-123'
+        assert result['group_id'] == GROUP_ID
 
         mock_http_client.get.assert_called_once_with(
             region='ap1',
             workspace='testworkspace',
-            endpoint='/api/iam/groups/group-123/',
+            endpoint=f'/api/iam/groups/{GROUP_ID}/',
             token='test-token',
         )
 
@@ -433,35 +443,47 @@ class TestIAMGroupExtendedManagement:
     async def test_update_iam_group_success(self, mock_http_client, mock_token_manager):
         """Test successful group update."""
         updated_group = {
-            'id': 'group-123',
-            'name': 'senior-admins',
+            'id': GROUP_ID,
+            'name': 'admins',
+            'display_name': 'Senior Admins',
             'description': 'Senior administrators group',
         }
         mock_http_client.patch.return_value = updated_group
 
         result = await update_iam_group(
-            group_id='group-123',
+            group_id=GROUP_ID,
             workspace='testworkspace',
-            name='senior-admins',
+            display_name='Senior Admins',
             description='Senior administrators group',
         )
 
         assert result['status'] == 'success'
         assert result['data'] == updated_group
-        assert result['group_id'] == 'group-123'
+        assert result['group_id'] == GROUP_ID
 
         mock_http_client.patch.assert_called_once_with(
             region='ap1',
             workspace='testworkspace',
-            endpoint='/api/iam/groups/group-123/',
+            endpoint=f'/api/iam/groups/{GROUP_ID}/',
             token='test-token',
-            data={'name': 'senior-admins', 'description': 'Senior administrators group'},
+            data={
+                'display_name': 'Senior Admins',
+                'description': 'Senior administrators group',
+            },
         )
+
+    @pytest.mark.asyncio
+    async def test_get_iam_group_invalid_id(self, mock_http_client, mock_token_manager):
+        """Test group retrieval rejects a non-UUID group ID locally."""
+        result = await get_iam_group(group_id='not-a-uuid', workspace='testworkspace')
+
+        assert result['status'] == 'error'
+        mock_http_client.get.assert_not_called()
 
     @pytest.mark.asyncio
     async def test_update_iam_group_no_data(self, mock_http_client, mock_token_manager):
         """Test update group with no fields returns error."""
-        result = await update_iam_group(group_id='group-123', workspace='testworkspace')
+        result = await update_iam_group(group_id=GROUP_ID, workspace='testworkspace')
 
         assert result['status'] == 'error'
         mock_http_client.patch.assert_not_called()
@@ -471,15 +493,15 @@ class TestIAMGroupExtendedManagement:
         """Test successful group deletion."""
         mock_http_client.delete.return_value = {'message': 'Group deleted successfully'}
 
-        result = await delete_iam_group(group_id='group-123', workspace='testworkspace')
+        result = await delete_iam_group(group_id=GROUP_ID, workspace='testworkspace')
 
         assert result['status'] == 'success'
-        assert result['group_id'] == 'group-123'
+        assert result['group_id'] == GROUP_ID
 
         mock_http_client.delete.assert_called_once_with(
             region='ap1',
             workspace='testworkspace',
-            endpoint='/api/iam/groups/group-123/',
+            endpoint=f'/api/iam/groups/{GROUP_ID}/',
             token='test-token',
         )
 
@@ -488,13 +510,15 @@ class TestIAMMembershipManagement:
     """Test IAM membership management functions."""
 
     @pytest.mark.asyncio
-    async def test_list_iam_memberships_success(self, mock_http_client, mock_token_manager):
+    async def test_list_iam_memberships_success(
+        self, mock_http_client, mock_token_manager
+    ):
         """Test successful memberships list retrieval."""
         memberships_data = {
             'count': 2,
             'results': [
-                {'id': 'mem-1', 'group': 'group-123', 'user': 'user-1'},
-                {'id': 'mem-2', 'group': 'group-123', 'user': 'user-2'},
+                {'id': 'mem-1', 'group': GROUP_ID, 'user': 'user-1'},
+                {'id': 'mem-2', 'group': GROUP_ID, 'user': 'user-2'},
             ],
         }
         mock_http_client.get.return_value = memberships_data
@@ -521,7 +545,7 @@ class TestIAMMembershipManagement:
         mock_http_client.get.return_value = {'count': 1, 'results': []}
 
         await list_iam_memberships(
-            workspace='testworkspace', group_id='group-123', page=1, page_size=10
+            workspace='testworkspace', group_id=GROUP_ID, page=1, page_size=10
         )
 
         mock_http_client.get.assert_called_once_with(
@@ -529,88 +553,126 @@ class TestIAMMembershipManagement:
             workspace='testworkspace',
             endpoint='/api/iam/memberships/',
             token='test-token',
-            params={'group': 'group-123', 'page': 1, 'page_size': 10},
+            params={'group': GROUP_ID, 'page': 1, 'page_size': 10},
         )
 
     @pytest.mark.asyncio
     async def test_add_iam_member_success(self, mock_http_client, mock_token_manager):
         """Test successful member addition to group."""
-        membership_data = {'id': 'mem-1', 'group': 'group-123', 'user': 'user-456'}
+        membership_data = {'id': 'mem-1', 'group': GROUP_ID, 'user': USER_ID}
         mock_http_client.post.return_value = membership_data
 
         result = await add_iam_member(
-            group_id='group-123', user_id='user-456', workspace='testworkspace'
+            group_id=GROUP_ID, user_id=USER_ID, workspace='testworkspace'
         )
 
         assert result['status'] == 'success'
         assert result['data'] == membership_data
-        assert result['group_id'] == 'group-123'
-        assert result['user_id'] == 'user-456'
+        assert result['group_id'] == GROUP_ID
+        assert result['user_id'] == USER_ID
 
         mock_http_client.post.assert_called_once_with(
             region='ap1',
             workspace='testworkspace',
             endpoint='/api/iam/memberships/',
             token='test-token',
-            data={'group': 'group-123', 'user': 'user-456'},
+            data={'group': GROUP_ID, 'user': USER_ID, 'role': 'member'},
         )
 
     @pytest.mark.asyncio
-    async def test_remove_iam_member_success(self, mock_http_client, mock_token_manager):
+    async def test_add_iam_member_with_role(self, mock_http_client, mock_token_manager):
+        """Test member addition with an explicit role."""
+        mock_http_client.post.return_value = {'id': 'mem-2', 'role': 'manager'}
+
+        result = await add_iam_member(
+            group_id=GROUP_ID,
+            user_id=USER_ID_2,
+            workspace='testworkspace',
+            role='manager',
+        )
+
+        assert result['status'] == 'success'
+        mock_http_client.post.assert_called_once_with(
+            region='ap1',
+            workspace='testworkspace',
+            endpoint='/api/iam/memberships/',
+            token='test-token',
+            data={'group': GROUP_ID, 'user': USER_ID_2, 'role': 'manager'},
+        )
+
+    @pytest.mark.asyncio
+    async def test_add_iam_member_invalid_role(
+        self, mock_http_client, mock_token_manager
+    ):
+        """Test member addition rejects an unknown role locally."""
+        result = await add_iam_member(
+            group_id=GROUP_ID,
+            user_id=USER_ID,
+            workspace='testworkspace',
+            role='admin',
+        )
+
+        assert result['status'] == 'error'
+        mock_http_client.post.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_remove_iam_member_success(
+        self, mock_http_client, mock_token_manager
+    ):
         """Test successful member removal from group."""
         mock_http_client.delete.return_value = {'message': 'Membership removed'}
 
         result = await remove_iam_member(
-            membership_id='mem-1', workspace='testworkspace'
+            membership_id=MEMBERSHIP_ID, workspace='testworkspace'
         )
 
         assert result['status'] == 'success'
-        assert result['membership_id'] == 'mem-1'
+        assert result['membership_id'] == MEMBERSHIP_ID
 
         mock_http_client.delete.assert_called_once_with(
             region='ap1',
             workspace='testworkspace',
-            endpoint='/api/iam/memberships/mem-1/',
+            endpoint=f'/api/iam/memberships/{MEMBERSHIP_ID}/',
             token='test-token',
         )
 
 
-class TestIAMUserInvitation:
-    """Test IAM user invitation function."""
+class TestWorkspaceUserInvitation:
+    """Test workspace user invitation function."""
 
     @pytest.mark.asyncio
-    async def test_invite_iam_user_success(self, mock_http_client, mock_token_manager):
-        """Test successful user invitation."""
-        invite_data = {'message': 'Invitation sent', 'email': 'newuser@example.com'}
+    async def test_invite_workspace_user_success(
+        self, mock_http_client, mock_token_manager
+    ):
+        """Test successful workspace invitation."""
+        invite_data = {'detail': ['User invitation sent.']}
         mock_http_client.post.return_value = invite_data
 
-        result = await invite_iam_user(
-            user_id='user-123',
+        result = await invite_workspace_user(
             email='newuser@example.com',
             workspace='testworkspace',
         )
 
         assert result['status'] == 'success'
         assert result['data'] == invite_data
-        assert result['user_id'] == 'user-123'
+        assert result['email'] == 'newuser@example.com'
 
         mock_http_client.post.assert_called_once_with(
             region='ap1',
             workspace='testworkspace',
-            endpoint='/api/iam/users/user-123/invite/',
+            endpoint='/api/workspaces/users/invite/',
             token='test-token',
             data={'email': 'newuser@example.com'},
         )
 
     @pytest.mark.asyncio
-    async def test_invite_iam_user_different_region(
+    async def test_invite_workspace_user_different_region(
         self, mock_http_client, mock_token_manager
     ):
-        """Test user invitation with a specific region."""
-        mock_http_client.post.return_value = {'message': 'Invitation sent'}
+        """Test workspace invitation with a specific region."""
+        mock_http_client.post.return_value = {'detail': ['User invitation sent.']}
 
-        result = await invite_iam_user(
-            user_id='user-456',
+        result = await invite_workspace_user(
             email='user@example.com',
             workspace='testworkspace',
             region='us1',
@@ -620,7 +682,7 @@ class TestIAMUserInvitation:
         mock_http_client.post.assert_called_once_with(
             region='us1',
             workspace='testworkspace',
-            endpoint='/api/iam/users/user-456/invite/',
+            endpoint='/api/workspaces/users/invite/',
             token='test-token',
             data={'email': 'user@example.com'},
         )
@@ -633,10 +695,10 @@ class TestIAMApplicationManagement:
     def sample_application(self):
         """Sample application data for testing."""
         return {
-            'id': 'app-123',
+            'id': APP_ID,
             'name': 'my-service',
             'description': 'My service application',
-            'created_at': '2024-01-01T00:00:00Z',
+            'added_at': '2024-01-01T00:00:00Z',
         }
 
     @pytest.mark.asyncio
@@ -727,22 +789,36 @@ class TestIAMApplicationManagement:
         )
 
     @pytest.mark.asyncio
+    async def test_create_iam_application_invalid_service_type(
+        self, mock_http_client, mock_token_manager
+    ):
+        """Test application creation rejects an unknown service type locally."""
+        result = await create_iam_application(
+            name='my-service',
+            workspace='testworkspace',
+            service_type='oauth',
+        )
+
+        assert result['status'] == 'error'
+        mock_http_client.post.assert_not_called()
+
+    @pytest.mark.asyncio
     async def test_get_iam_application_success(
         self, mock_http_client, mock_token_manager, sample_application
     ):
         """Test successful application retrieval."""
         mock_http_client.get.return_value = sample_application
 
-        result = await get_iam_application(app_id='app-123', workspace='testworkspace')
+        result = await get_iam_application(app_id=APP_ID, workspace='testworkspace')
 
         assert result['status'] == 'success'
         assert result['data'] == sample_application
-        assert result['app_id'] == 'app-123'
+        assert result['app_id'] == APP_ID
 
         mock_http_client.get.assert_called_once_with(
             region='ap1',
             workspace='testworkspace',
-            endpoint='/api/iam/applications/app-123/',
+            endpoint=f'/api/iam/applications/{APP_ID}/',
             token='test-token',
         )
 
@@ -756,19 +832,19 @@ class TestIAMApplicationManagement:
         mock_http_client.patch.return_value = updated_app
 
         result = await update_iam_application(
-            app_id='app-123',
+            app_id=APP_ID,
             workspace='testworkspace',
             name='my-service-v2',
         )
 
         assert result['status'] == 'success'
         assert result['data']['name'] == 'my-service-v2'
-        assert result['app_id'] == 'app-123'
+        assert result['app_id'] == APP_ID
 
         mock_http_client.patch.assert_called_once_with(
             region='ap1',
             workspace='testworkspace',
-            endpoint='/api/iam/applications/app-123/',
+            endpoint=f'/api/iam/applications/{APP_ID}/',
             token='test-token',
             data={'name': 'my-service-v2'},
         )
@@ -778,7 +854,7 @@ class TestIAMApplicationManagement:
         self, mock_http_client, mock_token_manager
     ):
         """Test update application with no fields returns error."""
-        result = await update_iam_application(app_id='app-123', workspace='testworkspace')
+        result = await update_iam_application(app_id=APP_ID, workspace='testworkspace')
 
         assert result['status'] == 'error'
         mock_http_client.patch.assert_not_called()
@@ -790,47 +866,83 @@ class TestIAMApplicationManagement:
         """Test successful application deletion."""
         mock_http_client.delete.return_value = {'message': 'Application deleted'}
 
-        result = await delete_iam_application(
-            app_id='app-123', workspace='testworkspace'
-        )
+        result = await delete_iam_application(app_id=APP_ID, workspace='testworkspace')
 
         assert result['status'] == 'success'
-        assert result['app_id'] == 'app-123'
+        assert result['app_id'] == APP_ID
 
         mock_http_client.delete.assert_called_once_with(
             region='ap1',
             workspace='testworkspace',
-            endpoint='/api/iam/applications/app-123/',
+            endpoint=f'/api/iam/applications/{APP_ID}/',
             token='test-token',
         )
 
     @pytest.mark.asyncio
-    async def test_provision_service_account_success(
+    async def test_assign_application_system_users_success(
         self, mock_http_client, mock_token_manager
     ):
-        """Test successful service account provisioning."""
-        provision_data = {
-            'id': 'svc-acct-1',
-            'app_id': 'app-123',
-            'username': 'svc-my-service',
-            'created_at': '2024-01-01T00:00:00Z',
-        }
-        mock_http_client.post.return_value = provision_data
+        """Test successful system user assignment to an application."""
+        assigned = [{'id': SYSTEM_USER_ID, 'username': 'svc-my-service'}]
+        mock_http_client.post.return_value = assigned
 
-        result = await provision_service_account(
-            app_id='app-123', workspace='testworkspace'
+        result = await assign_application_system_users(
+            app_id=APP_ID,
+            system_user_ids=[SYSTEM_USER_ID],
+            workspace='testworkspace',
         )
 
         assert result['status'] == 'success'
-        assert result['data'] == provision_data
-        assert result['app_id'] == 'app-123'
+        assert result['data'] == assigned
+        assert result['app_id'] == APP_ID
 
         mock_http_client.post.assert_called_once_with(
             region='ap1',
             workspace='testworkspace',
-            endpoint='/api/iam/applications/app-123/provision-account/',
+            endpoint=f'/api/iam/applications/{APP_ID}/system-users/',
             token='test-token',
+            data={'system_user_ids': [SYSTEM_USER_ID]},
         )
+
+    @pytest.mark.asyncio
+    async def test_unassign_application_system_users_success(
+        self, mock_http_client, mock_token_manager
+    ):
+        """Test successful system user unassignment from an application."""
+        unassigned = {'unassigned': 1, 'system_user_ids': [SYSTEM_USER_ID]}
+        mock_http_client.post.return_value = unassigned
+
+        result = await unassign_application_system_users(
+            app_id=APP_ID,
+            system_user_ids=[SYSTEM_USER_ID],
+            workspace='testworkspace',
+        )
+
+        assert result['status'] == 'success'
+        assert result['data'] == unassigned
+        assert result['app_id'] == APP_ID
+
+        mock_http_client.post.assert_called_once_with(
+            region='ap1',
+            workspace='testworkspace',
+            endpoint=f'/api/iam/applications/{APP_ID}/system-users/unassign/',
+            token='test-token',
+            data={'system_user_ids': [SYSTEM_USER_ID]},
+        )
+
+    @pytest.mark.asyncio
+    async def test_assign_application_system_users_empty_list(
+        self, mock_http_client, mock_token_manager
+    ):
+        """Test assignment rejects an empty system user list locally."""
+        result = await assign_application_system_users(
+            app_id=APP_ID,
+            system_user_ids=[],
+            workspace='testworkspace',
+        )
+
+        assert result['status'] == 'error'
+        mock_http_client.post.assert_not_called()
 
 
 if __name__ == '__main__':

--- a/tests/test_iam_tools.py
+++ b/tests/test_iam_tools.py
@@ -830,7 +830,6 @@ class TestIAMApplicationManagement:
             workspace='testworkspace',
             endpoint='/api/iam/applications/app-123/provision-account/',
             token='test-token',
-            data={},
         )
 
 

--- a/tests/test_iam_tools.py
+++ b/tests/test_iam_tools.py
@@ -65,7 +65,7 @@ def mock_token_manager():
 def sample_user():
     """Sample user data for testing."""
     return {
-        'id': 'user-123',
+        'id': USER_ID,
         'username': 'testuser',
         'email': 'test@example.com',
         'first_name': 'Test',
@@ -85,7 +85,7 @@ def sample_users_list():
         'previous': None,
         'results': [
             {
-                'id': 'user-123',
+                'id': USER_ID,
                 'username': 'testuser1',
                 'email': 'test1@example.com',
                 'first_name': 'Test',
@@ -94,7 +94,7 @@ def sample_users_list():
                 'num_groups': 1,
             },
             {
-                'id': 'user-456',
+                'id': USER_ID_2,
                 'username': 'testuser2',
                 'email': 'test2@example.com',
                 'first_name': 'Test',

--- a/tests/test_iam_tools.py
+++ b/tests/test_iam_tools.py
@@ -9,12 +9,25 @@ from unittest.mock import AsyncMock, patch
 import pytest
 
 from tools.iam_tools import (
+    add_iam_member,
+    create_iam_application,
     create_iam_group,
     create_iam_user,
+    delete_iam_application,
+    delete_iam_group,
     delete_iam_user,
+    get_iam_application,
+    get_iam_group,
     get_iam_user,
+    invite_iam_user,
+    list_iam_applications,
     list_iam_groups,
+    list_iam_memberships,
     list_iam_users,
+    provision_service_account,
+    remove_iam_member,
+    update_iam_application,
+    update_iam_group,
     update_iam_user,
 )
 
@@ -387,6 +400,437 @@ class TestParameterValidation:
             endpoint='/api/iam/users/',
             token='test-token',
             params={},
+        )
+
+
+class TestIAMGroupExtendedManagement:
+    """Test extended group management functions (get, update, delete)."""
+
+    @pytest.mark.asyncio
+    async def test_get_iam_group_success(self, mock_http_client, mock_token_manager):
+        """Test successful group retrieval."""
+        group_data = {
+            'id': 'group-123',
+            'name': 'admins',
+            'description': 'Administrators group',
+        }
+        mock_http_client.get.return_value = group_data
+
+        result = await get_iam_group(group_id='group-123', workspace='testworkspace')
+
+        assert result['status'] == 'success'
+        assert result['data'] == group_data
+        assert result['group_id'] == 'group-123'
+
+        mock_http_client.get.assert_called_once_with(
+            region='ap1',
+            workspace='testworkspace',
+            endpoint='/api/iam/groups/group-123/',
+            token='test-token',
+        )
+
+    @pytest.mark.asyncio
+    async def test_update_iam_group_success(self, mock_http_client, mock_token_manager):
+        """Test successful group update."""
+        updated_group = {
+            'id': 'group-123',
+            'name': 'senior-admins',
+            'description': 'Senior administrators group',
+        }
+        mock_http_client.patch.return_value = updated_group
+
+        result = await update_iam_group(
+            group_id='group-123',
+            workspace='testworkspace',
+            name='senior-admins',
+            description='Senior administrators group',
+        )
+
+        assert result['status'] == 'success'
+        assert result['data'] == updated_group
+        assert result['group_id'] == 'group-123'
+
+        mock_http_client.patch.assert_called_once_with(
+            region='ap1',
+            workspace='testworkspace',
+            endpoint='/api/iam/groups/group-123/',
+            token='test-token',
+            data={'name': 'senior-admins', 'description': 'Senior administrators group'},
+        )
+
+    @pytest.mark.asyncio
+    async def test_update_iam_group_no_data(self, mock_http_client, mock_token_manager):
+        """Test update group with no fields returns error."""
+        result = await update_iam_group(group_id='group-123', workspace='testworkspace')
+
+        assert result['status'] == 'error'
+        mock_http_client.patch.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_delete_iam_group_success(self, mock_http_client, mock_token_manager):
+        """Test successful group deletion."""
+        mock_http_client.delete.return_value = {'message': 'Group deleted successfully'}
+
+        result = await delete_iam_group(group_id='group-123', workspace='testworkspace')
+
+        assert result['status'] == 'success'
+        assert result['group_id'] == 'group-123'
+
+        mock_http_client.delete.assert_called_once_with(
+            region='ap1',
+            workspace='testworkspace',
+            endpoint='/api/iam/groups/group-123/',
+            token='test-token',
+        )
+
+
+class TestIAMMembershipManagement:
+    """Test IAM membership management functions."""
+
+    @pytest.mark.asyncio
+    async def test_list_iam_memberships_success(self, mock_http_client, mock_token_manager):
+        """Test successful memberships list retrieval."""
+        memberships_data = {
+            'count': 2,
+            'results': [
+                {'id': 'mem-1', 'group': 'group-123', 'user': 'user-1'},
+                {'id': 'mem-2', 'group': 'group-123', 'user': 'user-2'},
+            ],
+        }
+        mock_http_client.get.return_value = memberships_data
+
+        result = await list_iam_memberships(workspace='testworkspace')
+
+        assert result['status'] == 'success'
+        assert result['data'] == memberships_data
+        assert len(result['data']['results']) == 2
+
+        mock_http_client.get.assert_called_once_with(
+            region='ap1',
+            workspace='testworkspace',
+            endpoint='/api/iam/memberships/',
+            token='test-token',
+            params={},
+        )
+
+    @pytest.mark.asyncio
+    async def test_list_iam_memberships_with_group_filter(
+        self, mock_http_client, mock_token_manager
+    ):
+        """Test memberships list filtered by group ID."""
+        mock_http_client.get.return_value = {'count': 1, 'results': []}
+
+        await list_iam_memberships(
+            workspace='testworkspace', group_id='group-123', page=1, page_size=10
+        )
+
+        mock_http_client.get.assert_called_once_with(
+            region='ap1',
+            workspace='testworkspace',
+            endpoint='/api/iam/memberships/',
+            token='test-token',
+            params={'group': 'group-123', 'page': 1, 'page_size': 10},
+        )
+
+    @pytest.mark.asyncio
+    async def test_add_iam_member_success(self, mock_http_client, mock_token_manager):
+        """Test successful member addition to group."""
+        membership_data = {'id': 'mem-1', 'group': 'group-123', 'user': 'user-456'}
+        mock_http_client.post.return_value = membership_data
+
+        result = await add_iam_member(
+            group_id='group-123', user_id='user-456', workspace='testworkspace'
+        )
+
+        assert result['status'] == 'success'
+        assert result['data'] == membership_data
+        assert result['group_id'] == 'group-123'
+        assert result['user_id'] == 'user-456'
+
+        mock_http_client.post.assert_called_once_with(
+            region='ap1',
+            workspace='testworkspace',
+            endpoint='/api/iam/memberships/',
+            token='test-token',
+            data={'group': 'group-123', 'user': 'user-456'},
+        )
+
+    @pytest.mark.asyncio
+    async def test_remove_iam_member_success(self, mock_http_client, mock_token_manager):
+        """Test successful member removal from group."""
+        mock_http_client.delete.return_value = {'message': 'Membership removed'}
+
+        result = await remove_iam_member(
+            membership_id='mem-1', workspace='testworkspace'
+        )
+
+        assert result['status'] == 'success'
+        assert result['membership_id'] == 'mem-1'
+
+        mock_http_client.delete.assert_called_once_with(
+            region='ap1',
+            workspace='testworkspace',
+            endpoint='/api/iam/memberships/mem-1/',
+            token='test-token',
+        )
+
+
+class TestIAMUserInvitation:
+    """Test IAM user invitation function."""
+
+    @pytest.mark.asyncio
+    async def test_invite_iam_user_success(self, mock_http_client, mock_token_manager):
+        """Test successful user invitation."""
+        invite_data = {'message': 'Invitation sent', 'email': 'newuser@example.com'}
+        mock_http_client.post.return_value = invite_data
+
+        result = await invite_iam_user(
+            user_id='user-123',
+            email='newuser@example.com',
+            workspace='testworkspace',
+        )
+
+        assert result['status'] == 'success'
+        assert result['data'] == invite_data
+        assert result['user_id'] == 'user-123'
+
+        mock_http_client.post.assert_called_once_with(
+            region='ap1',
+            workspace='testworkspace',
+            endpoint='/api/iam/users/user-123/invite/',
+            token='test-token',
+            data={'email': 'newuser@example.com'},
+        )
+
+    @pytest.mark.asyncio
+    async def test_invite_iam_user_different_region(
+        self, mock_http_client, mock_token_manager
+    ):
+        """Test user invitation with a specific region."""
+        mock_http_client.post.return_value = {'message': 'Invitation sent'}
+
+        result = await invite_iam_user(
+            user_id='user-456',
+            email='user@example.com',
+            workspace='testworkspace',
+            region='us1',
+        )
+
+        assert result['status'] == 'success'
+        mock_http_client.post.assert_called_once_with(
+            region='us1',
+            workspace='testworkspace',
+            endpoint='/api/iam/users/user-456/invite/',
+            token='test-token',
+            data={'email': 'user@example.com'},
+        )
+
+
+class TestIAMApplicationManagement:
+    """Test IAM application management functions."""
+
+    @pytest.fixture
+    def sample_application(self):
+        """Sample application data for testing."""
+        return {
+            'id': 'app-123',
+            'name': 'my-service',
+            'description': 'My service application',
+            'created_at': '2024-01-01T00:00:00Z',
+        }
+
+    @pytest.mark.asyncio
+    async def test_list_iam_applications_success(
+        self, mock_http_client, mock_token_manager
+    ):
+        """Test successful applications list retrieval."""
+        apps_data = {
+            'count': 2,
+            'results': [
+                {'id': 'app-1', 'name': 'service-a'},
+                {'id': 'app-2', 'name': 'service-b'},
+            ],
+        }
+        mock_http_client.get.return_value = apps_data
+
+        result = await list_iam_applications(workspace='testworkspace')
+
+        assert result['status'] == 'success'
+        assert result['data'] == apps_data
+        assert len(result['data']['results']) == 2
+
+        mock_http_client.get.assert_called_once_with(
+            region='ap1',
+            workspace='testworkspace',
+            endpoint='/api/iam/applications/',
+            token='test-token',
+            params={},
+        )
+
+    @pytest.mark.asyncio
+    async def test_list_iam_applications_pagination(
+        self, mock_http_client, mock_token_manager
+    ):
+        """Test applications list with pagination parameters."""
+        mock_http_client.get.return_value = {'count': 0, 'results': []}
+
+        await list_iam_applications(workspace='testworkspace', page=2, page_size=5)
+
+        mock_http_client.get.assert_called_once_with(
+            region='ap1',
+            workspace='testworkspace',
+            endpoint='/api/iam/applications/',
+            token='test-token',
+            params={'page': 2, 'page_size': 5},
+        )
+
+    @pytest.mark.asyncio
+    async def test_create_iam_application_success(
+        self, mock_http_client, mock_token_manager, sample_application
+    ):
+        """Test successful application creation."""
+        mock_http_client.post.return_value = sample_application
+
+        result = await create_iam_application(
+            name='my-service',
+            workspace='testworkspace',
+            description='My service application',
+        )
+
+        assert result['status'] == 'success'
+        assert result['data'] == sample_application
+        assert result['app_name'] == 'my-service'
+
+        mock_http_client.post.assert_called_once_with(
+            region='ap1',
+            workspace='testworkspace',
+            endpoint='/api/iam/applications/',
+            token='test-token',
+            data={'name': 'my-service', 'description': 'My service application'},
+        )
+
+    @pytest.mark.asyncio
+    async def test_create_iam_application_no_description(
+        self, mock_http_client, mock_token_manager, sample_application
+    ):
+        """Test application creation without optional description."""
+        mock_http_client.post.return_value = sample_application
+
+        await create_iam_application(name='my-service', workspace='testworkspace')
+
+        mock_http_client.post.assert_called_once_with(
+            region='ap1',
+            workspace='testworkspace',
+            endpoint='/api/iam/applications/',
+            token='test-token',
+            data={'name': 'my-service'},
+        )
+
+    @pytest.mark.asyncio
+    async def test_get_iam_application_success(
+        self, mock_http_client, mock_token_manager, sample_application
+    ):
+        """Test successful application retrieval."""
+        mock_http_client.get.return_value = sample_application
+
+        result = await get_iam_application(app_id='app-123', workspace='testworkspace')
+
+        assert result['status'] == 'success'
+        assert result['data'] == sample_application
+        assert result['app_id'] == 'app-123'
+
+        mock_http_client.get.assert_called_once_with(
+            region='ap1',
+            workspace='testworkspace',
+            endpoint='/api/iam/applications/app-123/',
+            token='test-token',
+        )
+
+    @pytest.mark.asyncio
+    async def test_update_iam_application_success(
+        self, mock_http_client, mock_token_manager, sample_application
+    ):
+        """Test successful application update."""
+        updated_app = sample_application.copy()
+        updated_app['name'] = 'my-service-v2'
+        mock_http_client.patch.return_value = updated_app
+
+        result = await update_iam_application(
+            app_id='app-123',
+            workspace='testworkspace',
+            name='my-service-v2',
+        )
+
+        assert result['status'] == 'success'
+        assert result['data']['name'] == 'my-service-v2'
+        assert result['app_id'] == 'app-123'
+
+        mock_http_client.patch.assert_called_once_with(
+            region='ap1',
+            workspace='testworkspace',
+            endpoint='/api/iam/applications/app-123/',
+            token='test-token',
+            data={'name': 'my-service-v2'},
+        )
+
+    @pytest.mark.asyncio
+    async def test_update_iam_application_no_data(
+        self, mock_http_client, mock_token_manager
+    ):
+        """Test update application with no fields returns error."""
+        result = await update_iam_application(app_id='app-123', workspace='testworkspace')
+
+        assert result['status'] == 'error'
+        mock_http_client.patch.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_delete_iam_application_success(
+        self, mock_http_client, mock_token_manager
+    ):
+        """Test successful application deletion."""
+        mock_http_client.delete.return_value = {'message': 'Application deleted'}
+
+        result = await delete_iam_application(
+            app_id='app-123', workspace='testworkspace'
+        )
+
+        assert result['status'] == 'success'
+        assert result['app_id'] == 'app-123'
+
+        mock_http_client.delete.assert_called_once_with(
+            region='ap1',
+            workspace='testworkspace',
+            endpoint='/api/iam/applications/app-123/',
+            token='test-token',
+        )
+
+    @pytest.mark.asyncio
+    async def test_provision_service_account_success(
+        self, mock_http_client, mock_token_manager
+    ):
+        """Test successful service account provisioning."""
+        provision_data = {
+            'id': 'svc-acct-1',
+            'app_id': 'app-123',
+            'username': 'svc-my-service',
+            'created_at': '2024-01-01T00:00:00Z',
+        }
+        mock_http_client.post.return_value = provision_data
+
+        result = await provision_service_account(
+            app_id='app-123', workspace='testworkspace'
+        )
+
+        assert result['status'] == 'success'
+        assert result['data'] == provision_data
+        assert result['app_id'] == 'app-123'
+
+        mock_http_client.post.assert_called_once_with(
+            region='ap1',
+            workspace='testworkspace',
+            endpoint='/api/iam/applications/app-123/provision-account/',
+            token='test-token',
+            data={},
         )
 
 

--- a/tools/iam_tools.py
+++ b/tools/iam_tools.py
@@ -310,7 +310,7 @@ async def list_iam_groups(
 
 
 @mcp_tool_handler(
-    description='Create a new IAM permission group in the workspace. Requires a group name (lowercase letters, digits, -/_ only). Optionally set a display name and description. Users can then be added to this group via add_iam_member.',
+    description='Create a new IAM permission group in the workspace. Requires a group name (lowercase letters, digits, hyphens, and underscores only). Optionally set a display name and description. Users can then be added to this group via add_iam_member.',
     annotations=ADDITIVE,
     meta={'anthropic/searchHint': 'iam group create add new'},
 )
@@ -325,7 +325,7 @@ async def create_iam_group(
     """Create a new IAM group.
 
     Args:
-        name: Name for the new group (lowercase letters, digits, -/_ only)
+        name: Name for the new group (lowercase letters, digits, hyphens, and underscores only)
         workspace: Workspace name. Required parameter
         display_name: Human-readable display name (optional)
         description: Description of the group (optional)

--- a/tools/iam_tools.py
+++ b/tools/iam_tools.py
@@ -5,8 +5,23 @@ from typing import Any
 from server import mcp
 from utils.common import error_response, success_response
 from utils.decorators import mcp_tool_handler
+from utils.error_handler import format_validation_error, validate_server_id_format
 from utils.http_client import http_client
 from utils.tool_annotations import ADDITIVE, DESTRUCTIVE, IDEMPOTENT_WRITE, READ_ONLY
+
+VALID_MEMBERSHIP_ROLES = frozenset({'member', 'manager', 'owner'})
+VALID_SERVICE_TYPES = frozenset({'ci_cd', 'monitoring', 'automation', 'integration'})
+
+
+def _validate_uuid(field: str, value: str) -> dict[str, Any] | None:
+    if not validate_server_id_format(value):
+        return format_validation_error(
+            field,
+            value,
+            'Must be a valid UUID. Example: 550e8400-e29b-41d4-a716-446655440000',
+        )
+    return None
+
 
 # ===============================
 # USER MANAGEMENT TOOLS
@@ -14,7 +29,7 @@ from utils.tool_annotations import ADDITIVE, DESTRUCTIVE, IDEMPOTENT_WRITE, READ
 
 
 @mcp_tool_handler(
-    description='List all IAM users in a workspace. Returns username, email, active status, and group memberships for each user. Supports pagination for large user lists. Related: get_iam_user (details), create_iam_user, list_system_users (OS-level users, not IAM).',
+    description='List all IAM users in a workspace. Returns username, email, active status, and group count (num_groups) for each user. Supports pagination for large user lists. Related: get_iam_user (details), create_iam_user, list_system_users (OS-level users, not IAM).',
     annotations=READ_ONLY,
     meta={'anthropic/searchHint': 'iam users list workspace identity access'},
 )
@@ -88,7 +103,7 @@ async def get_iam_user(
 
 
 @mcp_tool_handler(
-    description='Create a new IAM user account in the workspace. Requires username and email. Optionally assign the user to groups and set first/last name. The user is active by default. Related: list_iam_groups (find groups to assign), update_iam_user, delete_iam_user.',
+    description='Create a new IAM user account in the workspace. Requires username and email. Optionally set first/last name. The user is active by default. Use add_iam_member to assign the user to groups after creation. Related: update_iam_user, delete_iam_user, add_iam_member.',
     annotations=ADDITIVE,
     meta={'anthropic/searchHint': 'iam user create add new account'},
 )
@@ -99,11 +114,13 @@ async def create_iam_user(
     first_name: str | None = None,
     last_name: str | None = None,
     is_active: bool = True,
-    groups: list[str] | None = None,
     region: str = '',
     **kwargs,
 ) -> dict[str, Any]:
     """Create a new IAM user.
+
+    Group assignment is handled separately via add_iam_member
+    (the user serializer has no groups field).
 
     Args:
         username: Username for the new user
@@ -112,7 +129,6 @@ async def create_iam_user(
         first_name: First name (optional)
         last_name: Last name (optional)
         is_active: Whether user is active (default: True)
-        groups: List of group IDs to assign to user (optional)
         region: Region (ap1, us1, eu1). Auto-detected if not provided
 
     Returns:
@@ -126,8 +142,6 @@ async def create_iam_user(
         user_data['first_name'] = first_name
     if last_name is not None:
         user_data['last_name'] = last_name
-    if groups is not None:
-        user_data['groups'] = groups
 
     result = await http_client.post(
         region=region,
@@ -143,7 +157,7 @@ async def create_iam_user(
 
 
 @mcp_tool_handler(
-    description='Update an existing IAM user profile. Can change email, first/last name, active/inactive status, or group memberships. Only the fields you provide will be updated (partial update).',
+    description='Update an existing IAM user profile. Can change email, first/last name, or active/inactive status. Only the fields you provide will be updated (partial update). Use add_iam_member/remove_iam_member to change group memberships.',
     annotations=IDEMPOTENT_WRITE,
     meta={'anthropic/searchHint': 'iam user update modify edit'},
 )
@@ -154,11 +168,13 @@ async def update_iam_user(
     first_name: str | None = None,
     last_name: str | None = None,
     is_active: bool | None = None,
-    groups: list[str] | None = None,
     region: str = '',
     **kwargs,
 ) -> dict[str, Any]:
     """Update an existing IAM user.
+
+    Group membership changes are handled separately via
+    add_iam_member/remove_iam_member (the user serializer has no groups field).
 
     Args:
         user_id: IAM user ID to update
@@ -167,7 +183,6 @@ async def update_iam_user(
         first_name: New first name (optional)
         last_name: New last name (optional)
         is_active: New active status (optional)
-        groups: New list of group IDs (optional)
         region: Region (ap1, us1, eu1). Auto-detected if not provided
 
     Returns:
@@ -184,8 +199,6 @@ async def update_iam_user(
         update_data['last_name'] = last_name
     if is_active is not None:
         update_data['is_active'] = is_active
-    if groups is not None:
-        update_data['groups'] = groups
 
     if not update_data:
         return error_response('No update data provided')
@@ -283,25 +296,25 @@ async def list_iam_groups(
 
 
 @mcp_tool_handler(
-    description='Create a new IAM permission group in the workspace. Requires a group name. Optionally set a description and assign permissions. Users can then be added to this group via create_iam_user or update_iam_user.',
+    description='Create a new IAM permission group in the workspace. Requires a group name (lowercase letters, digits, -/_ only). Optionally set a display name and description. Users can then be added to this group via add_iam_member.',
     annotations=ADDITIVE,
     meta={'anthropic/searchHint': 'iam group create add new'},
 )
 async def create_iam_group(
     name: str,
     workspace: str,
+    display_name: str | None = None,
     description: str | None = None,
-    permissions: list[str] | None = None,
     region: str = '',
     **kwargs,
 ) -> dict[str, Any]:
     """Create a new IAM group.
 
     Args:
-        name: Name for the new group
+        name: Name for the new group (lowercase letters, digits, -/_ only)
         workspace: Workspace name. Required parameter
+        display_name: Human-readable display name (optional)
         description: Description of the group (optional)
-        permissions: List of permission IDs to assign to group (optional)
         region: Region (ap1, us1, eu1). Auto-detected if not provided
 
     Returns:
@@ -311,10 +324,10 @@ async def create_iam_group(
 
     group_data: dict[str, Any] = {'name': name}
 
+    if display_name is not None:
+        group_data['display_name'] = display_name
     if description is not None:
         group_data['description'] = description
-    if permissions is not None:
-        group_data['permissions'] = permissions
 
     result = await http_client.post(
         region=region,
@@ -391,7 +404,7 @@ async def iam_groups_resource(region: str, workspace: str) -> dict[str, Any]:
 
 
 @mcp_tool_handler(
-    description='Get detailed information about a specific IAM group by its group ID. Returns group name, description, and member information. Related: list_iam_groups (all groups), update_iam_group, delete_iam_group.',
+    description='Get detailed information about a specific IAM group by its group ID. Returns group name, display name, description, member count (num_members), and member names. Related: list_iam_groups (all groups), update_iam_group, delete_iam_group.',
     annotations=READ_ONLY,
     meta={'anthropic/searchHint': 'iam group detail get'},
 )
@@ -411,6 +424,10 @@ async def get_iam_group(
     Returns:
         IAM group detail response
     """
+    err = _validate_uuid('group_id', group_id)
+    if err:
+        return err
+
     token = kwargs.get('token')
     result = await http_client.get(
         region=region,
@@ -418,39 +435,48 @@ async def get_iam_group(
         endpoint=f'/api/iam/groups/{group_id}/',
         token=token,
     )
-    return success_response(data=result, group_id=group_id, region=region, workspace=workspace)
+    return success_response(
+        data=result, group_id=group_id, region=region, workspace=workspace
+    )
 
 
 @mcp_tool_handler(
-    description='Update an existing IAM group. Can change the group name or description. Only the fields you provide will be updated (partial update). Related: get_iam_group, delete_iam_group.',
+    description='Update an existing IAM group. Can change the display name or description (the group name itself is immutable on the server). Only the fields you provide will be updated (partial update). Related: get_iam_group, delete_iam_group.',
     annotations=IDEMPOTENT_WRITE,
     meta={'anthropic/searchHint': 'iam group update modify edit'},
 )
 async def update_iam_group(
     group_id: str,
     workspace: str,
-    name: str | None = None,
+    display_name: str | None = None,
     description: str | None = None,
     region: str = '',
     **kwargs,
 ) -> dict[str, Any]:
     """Update an existing IAM group.
 
+    The group name is read-only on the server (GroupUpdateSerializer);
+    only display_name and description are exposed here.
+
     Args:
         group_id: Group ID to update
         workspace: Workspace name. Required parameter
-        name: New group name (optional)
+        display_name: New display name (optional)
         description: New group description (optional)
         region: Region (ap1, us1, eu1). Auto-detected if not provided
 
     Returns:
         IAM group update response
     """
+    err = _validate_uuid('group_id', group_id)
+    if err:
+        return err
+
     token = kwargs.get('token')
 
     update_data: dict[str, Any] = {}
-    if name is not None:
-        update_data['name'] = name
+    if display_name is not None:
+        update_data['display_name'] = display_name
     if description is not None:
         update_data['description'] = description
 
@@ -464,7 +490,9 @@ async def update_iam_group(
         token=token,
         data=update_data,
     )
-    return success_response(data=result, group_id=group_id, region=region, workspace=workspace)
+    return success_response(
+        data=result, group_id=group_id, region=region, workspace=workspace
+    )
 
 
 @mcp_tool_handler(
@@ -488,6 +516,10 @@ async def delete_iam_group(
     Returns:
         IAM group deletion response
     """
+    err = _validate_uuid('group_id', group_id)
+    if err:
+        return err
+
     token = kwargs.get('token')
     result = await http_client.delete(
         region=region,
@@ -495,7 +527,9 @@ async def delete_iam_group(
         endpoint=f'/api/iam/groups/{group_id}/',
         token=token,
     )
-    return success_response(data=result, group_id=group_id, region=region, workspace=workspace)
+    return success_response(
+        data=result, group_id=group_id, region=region, workspace=workspace
+    )
 
 
 # ===============================
@@ -549,7 +583,7 @@ async def list_iam_memberships(
 
 
 @mcp_tool_handler(
-    description='Add a user to an IAM group by creating a membership. Requires both group ID and user ID. Related: remove_iam_member, list_iam_memberships.',
+    description='Add a user to an IAM group by creating a membership. Requires both group ID and user ID. Optionally set the role (member, manager, or owner; default member). Related: remove_iam_member, list_iam_memberships.',
     annotations=ADDITIVE,
     meta={'anthropic/searchHint': 'iam member add group user membership'},
 )
@@ -557,6 +591,7 @@ async def add_iam_member(
     group_id: str,
     user_id: str,
     workspace: str,
+    role: str = 'member',
     region: str = '',
     **kwargs,
 ) -> dict[str, Any]:
@@ -566,18 +601,27 @@ async def add_iam_member(
         group_id: Group ID to add the user to
         user_id: User ID to add to the group
         workspace: Workspace name. Required parameter
+        role: Role in the group: member, manager, or owner (default: member)
         region: Region (ap1, us1, eu1). Auto-detected if not provided
 
     Returns:
         IAM membership creation response
     """
+    err = _validate_uuid('group_id', group_id) or _validate_uuid('user_id', user_id)
+    if err:
+        return err
+    if role not in VALID_MEMBERSHIP_ROLES:
+        return format_validation_error(
+            'role', role, f'Must be one of: {", ".join(sorted(VALID_MEMBERSHIP_ROLES))}'
+        )
+
     token = kwargs.get('token')
     result = await http_client.post(
         region=region,
         workspace=workspace,
         endpoint='/api/iam/memberships/',
         token=token,
-        data={'group': group_id, 'user': user_id},
+        data={'group': group_id, 'user': user_id, 'role': role},
     )
     return success_response(
         data=result,
@@ -609,6 +653,10 @@ async def remove_iam_member(
     Returns:
         IAM membership deletion response
     """
+    err = _validate_uuid('membership_id', membership_id)
+    if err:
+        return err
+
     token = kwargs.get('token')
     result = await http_client.delete(
         region=region,
@@ -625,29 +673,27 @@ async def remove_iam_member(
 
 
 # ===============================
-# USER INVITATION TOOLS
+# WORKSPACE INVITATION TOOLS
 # ===============================
 
 
 @mcp_tool_handler(
-    description='Send an email invitation to a user to join the workspace. Requires the user ID and the target email address. The user must already exist in IAM. Related: create_iam_user, get_iam_user.',
+    description='Send an email invitation to join the workspace. Requires only the target email address; the invitee does not need an existing IAM user record. Available on Auth0-enabled (cloud) deployments only. Related: list_iam_users, create_iam_user.',
     annotations=ADDITIVE,
-    meta={'anthropic/searchHint': 'iam user invite email send'},
+    meta={'anthropic/searchHint': 'workspace user invite email send'},
 )
-async def invite_iam_user(
-    user_id: str,
+async def invite_workspace_user(
     email: str,
     workspace: str,
     region: str = '',
     **kwargs,
 ) -> dict[str, Any]:
-    """Send an invitation email to an existing IAM user.
+    """Invite a user to the workspace by email.
 
-    The user must already have a record in the system.
-    Use create_iam_user first if the user does not exist yet.
+    Sends an Auth0 organization invitation and records a pending
+    InvitedUser entry. The invitee is identified by email only.
 
     Args:
-        user_id: IAM user ID to invite
         email: Email address to send the invitation to
         workspace: Workspace name. Required parameter
         region: Region (ap1, us1, eu1). Auto-detected if not provided
@@ -659,11 +705,13 @@ async def invite_iam_user(
     result = await http_client.post(
         region=region,
         workspace=workspace,
-        endpoint=f'/api/iam/users/{user_id}/invite/',
+        endpoint='/api/workspaces/users/invite/',
         token=token,
         data={'email': email},
     )
-    return success_response(data=result, user_id=user_id, region=region, workspace=workspace)
+    return success_response(
+        data=result, email=email, region=region, workspace=workspace
+    )
 
 
 # ===============================
@@ -672,7 +720,7 @@ async def invite_iam_user(
 
 
 @mcp_tool_handler(
-    description='List all IAM applications (service accounts / OAuth apps) in the workspace. Supports pagination. Related: create_iam_application, get_iam_application.',
+    description='List all IAM applications (machine service accounts for CI/CD, monitoring, automation, or external integrations) in the workspace. Supports pagination. Related: create_iam_application, get_iam_application.',
     annotations=READ_ONLY,
     meta={'anthropic/searchHint': 'iam applications list service accounts oauth'},
 )
@@ -713,14 +761,15 @@ async def list_iam_applications(
 
 
 @mcp_tool_handler(
-    description='Create a new IAM application (service account / OAuth app) in the workspace. Requires a name. Optionally set a description. Related: list_iam_applications, get_iam_application, provision_service_account.',
+    description='Create a new IAM application (machine service account) in the workspace. Requires a name. Optionally set a description and service type (ci_cd, monitoring, automation, or integration; default integration). Related: list_iam_applications, get_iam_application, assign_application_system_users.',
     annotations=ADDITIVE,
-    meta={'anthropic/searchHint': 'iam application create new service account oauth'},
+    meta={'anthropic/searchHint': 'iam application create new service account'},
 )
 async def create_iam_application(
     name: str,
     workspace: str,
     description: str | None = None,
+    service_type: str | None = None,
     region: str = '',
     **kwargs,
 ) -> dict[str, Any]:
@@ -730,16 +779,27 @@ async def create_iam_application(
         name: Name of the new application
         workspace: Workspace name. Required parameter
         description: Description of the application (optional)
+        service_type: ci_cd, monitoring, automation, or integration
+            (optional; server defaults to integration)
         region: Region (ap1, us1, eu1). Auto-detected if not provided
 
     Returns:
         IAM application creation response
     """
+    if service_type is not None and service_type not in VALID_SERVICE_TYPES:
+        return format_validation_error(
+            'service_type',
+            service_type,
+            f'Must be one of: {", ".join(sorted(VALID_SERVICE_TYPES))}',
+        )
+
     token = kwargs.get('token')
 
     app_data: dict[str, Any] = {'name': name}
     if description is not None:
         app_data['description'] = description
+    if service_type is not None:
+        app_data['service_type'] = service_type
 
     result = await http_client.post(
         region=region,
@@ -748,7 +808,9 @@ async def create_iam_application(
         token=token,
         data=app_data,
     )
-    return success_response(data=result, app_name=name, region=region, workspace=workspace)
+    return success_response(
+        data=result, app_name=name, region=region, workspace=workspace
+    )
 
 
 @mcp_tool_handler(
@@ -772,6 +834,10 @@ async def get_iam_application(
     Returns:
         IAM application detail response
     """
+    err = _validate_uuid('app_id', app_id)
+    if err:
+        return err
+
     token = kwargs.get('token')
     result = await http_client.get(
         region=region,
@@ -779,7 +845,9 @@ async def get_iam_application(
         endpoint=f'/api/iam/applications/{app_id}/',
         token=token,
     )
-    return success_response(data=result, app_id=app_id, region=region, workspace=workspace)
+    return success_response(
+        data=result, app_id=app_id, region=region, workspace=workspace
+    )
 
 
 @mcp_tool_handler(
@@ -807,6 +875,10 @@ async def update_iam_application(
     Returns:
         IAM application update response
     """
+    err = _validate_uuid('app_id', app_id)
+    if err:
+        return err
+
     token = kwargs.get('token')
 
     update_data: dict[str, Any] = {}
@@ -825,7 +897,9 @@ async def update_iam_application(
         token=token,
         data=update_data,
     )
-    return success_response(data=result, app_id=app_id, region=region, workspace=workspace)
+    return success_response(
+        data=result, app_id=app_id, region=region, workspace=workspace
+    )
 
 
 @mcp_tool_handler(
@@ -849,6 +923,10 @@ async def delete_iam_application(
     Returns:
         IAM application deletion response
     """
+    err = _validate_uuid('app_id', app_id)
+    if err:
+        return err
+
     token = kwargs.get('token')
     result = await http_client.delete(
         region=region,
@@ -856,35 +934,110 @@ async def delete_iam_application(
         endpoint=f'/api/iam/applications/{app_id}/',
         token=token,
     )
-    return success_response(data=result, app_id=app_id, region=region, workspace=workspace)
+    return success_response(
+        data=result, app_id=app_id, region=region, workspace=workspace
+    )
 
 
 @mcp_tool_handler(
-    description='Provision a service account for an IAM application. This creates a system-level account linked to the application for machine-to-machine authentication. Related: create_iam_application, get_iam_application.',
-    annotations=ADDITIVE,
-    meta={'anthropic/searchHint': 'iam application provision service account machine'},
+    description='Assign existing system users (OS-level accounts on servers) to an IAM application, binding them as the application service accounts. Requires the application ID and a list of system user IDs. Related: unassign_application_system_users, get_iam_application, list_system_users.',
+    annotations=IDEMPOTENT_WRITE,
+    meta={
+        'anthropic/searchHint': 'iam application assign system users service account bind'
+    },
 )
-async def provision_service_account(
+async def assign_application_system_users(
     app_id: str,
+    system_user_ids: list[str],
     workspace: str,
     region: str = '',
     **kwargs,
 ) -> dict[str, Any]:
-    """Provision a service account for an IAM application.
+    """Assign system users to an IAM application.
 
     Args:
-        app_id: Application ID to provision a service account for
+        app_id: Application ID to assign system users to
+        system_user_ids: List of system user IDs (UUIDs) to bind
         workspace: Workspace name. Required parameter
         region: Region (ap1, us1, eu1). Auto-detected if not provided
 
     Returns:
-        Service account provisioning response
+        Assigned system users response
     """
+    err = _validate_uuid('app_id', app_id)
+    if err:
+        return err
+    if not system_user_ids:
+        return format_validation_error(
+            'system_user_ids',
+            system_user_ids,
+            'Must contain at least one system user ID',
+        )
+    for su_id in system_user_ids:
+        err = _validate_uuid('system_user_ids', su_id)
+        if err:
+            return err
+
     token = kwargs.get('token')
     result = await http_client.post(
         region=region,
         workspace=workspace,
-        endpoint=f'/api/iam/applications/{app_id}/provision-account/',
+        endpoint=f'/api/iam/applications/{app_id}/system-users/',
         token=token,
+        data={'system_user_ids': system_user_ids},
     )
-    return success_response(data=result, app_id=app_id, region=region, workspace=workspace)
+    return success_response(
+        data=result, app_id=app_id, region=region, workspace=workspace
+    )
+
+
+@mcp_tool_handler(
+    description='Unassign system users from an IAM application, releasing them as application service accounts. Requires the application ID and a list of system user IDs. Related: assign_application_system_users, get_iam_application.',
+    annotations=IDEMPOTENT_WRITE,
+    meta={
+        'anthropic/searchHint': 'iam application unassign system users service account release'
+    },
+)
+async def unassign_application_system_users(
+    app_id: str,
+    system_user_ids: list[str],
+    workspace: str,
+    region: str = '',
+    **kwargs,
+) -> dict[str, Any]:
+    """Unassign system users from an IAM application.
+
+    Args:
+        app_id: Application ID to unassign system users from
+        system_user_ids: List of system user IDs (UUIDs) to release
+        workspace: Workspace name. Required parameter
+        region: Region (ap1, us1, eu1). Auto-detected if not provided
+
+    Returns:
+        Unassigned system users response
+    """
+    err = _validate_uuid('app_id', app_id)
+    if err:
+        return err
+    if not system_user_ids:
+        return format_validation_error(
+            'system_user_ids',
+            system_user_ids,
+            'Must contain at least one system user ID',
+        )
+    for su_id in system_user_ids:
+        err = _validate_uuid('system_user_ids', su_id)
+        if err:
+            return err
+
+    token = kwargs.get('token')
+    result = await http_client.post(
+        region=region,
+        workspace=workspace,
+        endpoint=f'/api/iam/applications/{app_id}/system-users/unassign/',
+        token=token,
+        data={'system_user_ids': system_user_ids},
+    )
+    return success_response(
+        data=result, app_id=app_id, region=region, workspace=workspace
+    )

--- a/tools/iam_tools.py
+++ b/tools/iam_tools.py
@@ -38,14 +38,12 @@ async def list_iam_users(
     """
     token = kwargs.get('token')
 
-    # Prepare query parameters
     params = {}
     if page is not None:
         params['page'] = page
     if page_size is not None:
         params['page_size'] = page_size
 
-    # Make async call to IAM users endpoint
     result = await http_client.get(
         region=region,
         workspace=workspace,
@@ -77,7 +75,6 @@ async def get_iam_user(
     """
     token = kwargs.get('token')
 
-    # Make async call to specific IAM user endpoint
     result = await http_client.get(
         region=region,
         workspace=workspace,
@@ -123,17 +120,15 @@ async def create_iam_user(
     """
     token = kwargs.get('token')
 
-    # Prepare user data
     user_data = {'username': username, 'email': email, 'is_active': is_active}
 
-    if first_name:
+    if first_name is not None:
         user_data['first_name'] = first_name
-    if last_name:
+    if last_name is not None:
         user_data['last_name'] = last_name
-    if groups:
+    if groups is not None:
         user_data['groups'] = groups
 
-    # Make async call to create IAM user
     result = await http_client.post(
         region=region,
         workspace=workspace,
@@ -180,7 +175,6 @@ async def update_iam_user(
     """
     token = kwargs.get('token')
 
-    # Prepare update data (only include provided fields)
     update_data: dict[str, Any] = {}
     if email is not None:
         update_data['email'] = email
@@ -196,7 +190,6 @@ async def update_iam_user(
     if not update_data:
         return error_response('No update data provided')
 
-    # Make async call to update IAM user
     result = await http_client.patch(
         region=region,
         workspace=workspace,
@@ -230,7 +223,6 @@ async def delete_iam_user(
     """
     token = kwargs.get('token')
 
-    # Make async call to delete IAM user
     result = await http_client.delete(
         region=region,
         workspace=workspace,
@@ -273,14 +265,12 @@ async def list_iam_groups(
     """
     token = kwargs.get('token')
 
-    # Prepare query parameters
     params = {}
     if page is not None:
         params['page'] = page
     if page_size is not None:
         params['page_size'] = page_size
 
-    # Make async call to IAM groups endpoint
     result = await http_client.get(
         region=region,
         workspace=workspace,
@@ -319,7 +309,6 @@ async def create_iam_group(
     """
     token = kwargs.get('token')
 
-    # Prepare group data
     group_data: dict[str, Any] = {'name': name}
 
     if description is not None:
@@ -327,7 +316,6 @@ async def create_iam_group(
     if permissions is not None:
         group_data['permissions'] = permissions
 
-    # Make async call to create IAM group
     result = await http_client.post(
         region=region,
         workspace=workspace,
@@ -460,7 +448,6 @@ async def update_iam_group(
     """
     token = kwargs.get('token')
 
-    # Prepare update data (only include provided fields)
     update_data: dict[str, Any] = {}
     if name is not None:
         update_data['name'] = name

--- a/tools/iam_tools.py
+++ b/tools/iam_tools.py
@@ -88,6 +88,10 @@ async def get_iam_user(
     Returns:
         IAM user details response
     """
+    err = _validate_uuid('user_id', user_id)
+    if err:
+        return err
+
     token = kwargs.get('token')
 
     result = await http_client.get(
@@ -188,6 +192,10 @@ async def update_iam_user(
     Returns:
         User update response
     """
+    err = _validate_uuid('user_id', user_id)
+    if err:
+        return err
+
     token = kwargs.get('token')
 
     update_data: dict[str, Any] = {}
@@ -234,6 +242,10 @@ async def delete_iam_user(
     Returns:
         User deletion response
     """
+    err = _validate_uuid('user_id', user_id)
+    if err:
+        return err
+
     token = kwargs.get('token')
 
     result = await http_client.delete(
@@ -562,6 +574,11 @@ async def list_iam_memberships(
     Returns:
         IAM memberships list response
     """
+    if group_id is not None:
+        err = _validate_uuid('group_id', group_id)
+        if err:
+            return err
+
     token = kwargs.get('token')
 
     params: dict[str, Any] = {}

--- a/tools/iam_tools.py
+++ b/tools/iam_tools.py
@@ -73,7 +73,7 @@ async def list_iam_users(
 
 
 @mcp_tool_handler(
-    description='Get detailed information about a specific IAM user by their user ID. Returns email, first/last name, active status, and assigned groups. Use this when you need full profile details for a single user.',
+    description='Get detailed information about a specific IAM user by their user ID. Returns email, first/last name, active status, and group count (num_groups). Use list_iam_memberships to see which groups the user belongs to. Use this when you need full profile details for a single user.',
     annotations=READ_ONLY,
     meta={'anthropic/searchHint': 'iam user detail profile'},
 )
@@ -81,6 +81,10 @@ async def get_iam_user(
     user_id: str, workspace: str, region: str = '', **kwargs
 ) -> dict[str, Any]:
     """Get detailed information about a specific IAM user.
+
+    Group memberships are not included in the user payload (the user
+    serializer has no groups field); use list_iam_memberships to look up
+    the groups a user belongs to.
 
     Args:
         user_id: IAM user ID

--- a/tools/iam_tools.py
+++ b/tools/iam_tools.py
@@ -40,9 +40,9 @@ async def list_iam_users(
 
     # Prepare query parameters
     params = {}
-    if page:
+    if page is not None:
         params['page'] = page
-    if page_size:
+    if page_size is not None:
         params['page_size'] = page_size
 
     # Make async call to IAM users endpoint
@@ -275,9 +275,9 @@ async def list_iam_groups(
 
     # Prepare query parameters
     params = {}
-    if page:
+    if page is not None:
         params['page'] = page
-    if page_size:
+    if page_size is not None:
         params['page_size'] = page_size
 
     # Make async call to IAM groups endpoint
@@ -322,9 +322,9 @@ async def create_iam_group(
     # Prepare group data
     group_data: dict[str, Any] = {'name': name}
 
-    if description:
+    if description is not None:
         group_data['description'] = description
-    if permissions:
+    if permissions is not None:
         group_data['permissions'] = permissions
 
     # Make async call to create IAM group
@@ -592,7 +592,13 @@ async def add_iam_member(
         token=token,
         data={'group': group_id, 'user': user_id},
     )
-    return success_response(data=result, group_id=group_id, user_id=user_id, region=region, workspace=workspace)
+    return success_response(
+        data=result,
+        group_id=group_id,
+        user_id=user_id,
+        region=region,
+        workspace=workspace,
+    )
 
 
 @mcp_tool_handler(
@@ -623,7 +629,12 @@ async def remove_iam_member(
         endpoint=f'/api/iam/memberships/{membership_id}/',
         token=token,
     )
-    return success_response(data=result, membership_id=membership_id, region=region, workspace=workspace)
+    return success_response(
+        data=result,
+        membership_id=membership_id,
+        region=region,
+        workspace=workspace,
+    )
 
 
 # ===============================
@@ -643,7 +654,10 @@ async def invite_iam_user(
     region: str = '',
     **kwargs,
 ) -> dict[str, Any]:
-    """Invite an IAM user by email.
+    """Send an invitation email to an existing IAM user.
+
+    The user must already have a record in the system.
+    Use create_iam_user first if the user does not exist yet.
 
     Args:
         user_id: IAM user ID to invite
@@ -885,6 +899,5 @@ async def provision_service_account(
         workspace=workspace,
         endpoint=f'/api/iam/applications/{app_id}/provision-account/',
         token=token,
-        data={},
     )
     return success_response(data=result, app_id=app_id, region=region, workspace=workspace)

--- a/tools/iam_tools.py
+++ b/tools/iam_tools.py
@@ -1,5 +1,6 @@
 """IAM (Identity and Access Management) tools for Alpacon MCP server."""
 
+import re
 from typing import Any
 
 from server import mcp
@@ -11,6 +12,7 @@ from utils.tool_annotations import ADDITIVE, DESTRUCTIVE, IDEMPOTENT_WRITE, READ
 
 VALID_MEMBERSHIP_ROLES = frozenset({'member', 'manager', 'owner'})
 VALID_SERVICE_TYPES = frozenset({'ci_cd', 'monitoring', 'automation', 'integration'})
+GROUP_NAME_PATTERN = re.compile(r'^[a-z0-9_-]+$')
 
 
 def _validate_uuid(field: str, value: str) -> dict[str, Any] | None:
@@ -332,6 +334,13 @@ async def create_iam_group(
     Returns:
         Group creation response
     """
+    if not GROUP_NAME_PATTERN.match(name):
+        return format_validation_error(
+            'name',
+            name,
+            'Must contain only lowercase letters, digits, hyphens, and underscores',
+        )
+
     token = kwargs.get('token')
 
     group_data: dict[str, Any] = {'name': name}

--- a/tools/iam_tools.py
+++ b/tools/iam_tools.py
@@ -395,3 +395,496 @@ async def iam_groups_resource(region: str, workspace: str) -> dict[str, Any]:
 
 
 # NOTE: IAM roles resource removed - endpoint not implemented in server
+
+
+# ===============================
+# EXTENDED GROUP MANAGEMENT TOOLS
+# ===============================
+
+
+@mcp_tool_handler(
+    description='Get detailed information about a specific IAM group by its group ID. Returns group name, description, and member information. Related: list_iam_groups (all groups), update_iam_group, delete_iam_group.',
+    annotations=READ_ONLY,
+    meta={'anthropic/searchHint': 'iam group detail get'},
+)
+async def get_iam_group(
+    group_id: str,
+    workspace: str,
+    region: str = '',
+    **kwargs,
+) -> dict[str, Any]:
+    """Get IAM group details.
+
+    Args:
+        group_id: Group ID
+        workspace: Workspace name. Required parameter
+        region: Region (ap1, us1, eu1). Auto-detected if not provided
+
+    Returns:
+        IAM group detail response
+    """
+    token = kwargs.get('token')
+    result = await http_client.get(
+        region=region,
+        workspace=workspace,
+        endpoint=f'/api/iam/groups/{group_id}/',
+        token=token,
+    )
+    return success_response(data=result, group_id=group_id, region=region, workspace=workspace)
+
+
+@mcp_tool_handler(
+    description='Update an existing IAM group. Can change the group name or description. Only the fields you provide will be updated (partial update). Related: get_iam_group, delete_iam_group.',
+    annotations=IDEMPOTENT_WRITE,
+    meta={'anthropic/searchHint': 'iam group update modify edit'},
+)
+async def update_iam_group(
+    group_id: str,
+    workspace: str,
+    name: str | None = None,
+    description: str | None = None,
+    region: str = '',
+    **kwargs,
+) -> dict[str, Any]:
+    """Update an existing IAM group.
+
+    Args:
+        group_id: Group ID to update
+        workspace: Workspace name. Required parameter
+        name: New group name (optional)
+        description: New group description (optional)
+        region: Region (ap1, us1, eu1). Auto-detected if not provided
+
+    Returns:
+        IAM group update response
+    """
+    token = kwargs.get('token')
+
+    # Prepare update data (only include provided fields)
+    update_data: dict[str, Any] = {}
+    if name is not None:
+        update_data['name'] = name
+    if description is not None:
+        update_data['description'] = description
+
+    if not update_data:
+        return error_response('No update data provided')
+
+    result = await http_client.patch(
+        region=region,
+        workspace=workspace,
+        endpoint=f'/api/iam/groups/{group_id}/',
+        token=token,
+        data=update_data,
+    )
+    return success_response(data=result, group_id=group_id, region=region, workspace=workspace)
+
+
+@mcp_tool_handler(
+    description='Permanently delete an IAM group from the workspace. This action cannot be undone. Users in the group will lose group-based permissions. Related: get_iam_group, list_iam_groups.',
+    annotations=DESTRUCTIVE,
+    meta={'anthropic/searchHint': 'iam group delete remove'},
+)
+async def delete_iam_group(
+    group_id: str,
+    workspace: str,
+    region: str = '',
+    **kwargs,
+) -> dict[str, Any]:
+    """Delete an IAM group.
+
+    Args:
+        group_id: Group ID to delete
+        workspace: Workspace name. Required parameter
+        region: Region (ap1, us1, eu1). Auto-detected if not provided
+
+    Returns:
+        IAM group deletion response
+    """
+    token = kwargs.get('token')
+    result = await http_client.delete(
+        region=region,
+        workspace=workspace,
+        endpoint=f'/api/iam/groups/{group_id}/',
+        token=token,
+    )
+    return success_response(data=result, group_id=group_id, region=region, workspace=workspace)
+
+
+# ===============================
+# MEMBERSHIP MANAGEMENT TOOLS
+# ===============================
+
+
+@mcp_tool_handler(
+    description='List IAM group memberships in the workspace. Optionally filter by group ID to see members of a specific group. Supports pagination. Related: add_iam_member, remove_iam_member.',
+    annotations=READ_ONLY,
+    meta={'anthropic/searchHint': 'iam memberships list group members'},
+)
+async def list_iam_memberships(
+    workspace: str,
+    group_id: str | None = None,
+    region: str = '',
+    page: int | None = None,
+    page_size: int | None = None,
+    **kwargs,
+) -> dict[str, Any]:
+    """List IAM group memberships.
+
+    Args:
+        workspace: Workspace name. Required parameter
+        group_id: Filter by group ID (optional)
+        region: Region (ap1, us1, eu1). Auto-detected if not provided
+        page: Page number for pagination (optional)
+        page_size: Number of memberships per page (optional)
+
+    Returns:
+        IAM memberships list response
+    """
+    token = kwargs.get('token')
+
+    params: dict[str, Any] = {}
+    if group_id is not None:
+        params['group'] = group_id
+    if page is not None:
+        params['page'] = page
+    if page_size is not None:
+        params['page_size'] = page_size
+
+    result = await http_client.get(
+        region=region,
+        workspace=workspace,
+        endpoint='/api/iam/memberships/',
+        token=token,
+        params=params,
+    )
+    return success_response(data=result, region=region, workspace=workspace)
+
+
+@mcp_tool_handler(
+    description='Add a user to an IAM group by creating a membership. Requires both group ID and user ID. Related: remove_iam_member, list_iam_memberships.',
+    annotations=ADDITIVE,
+    meta={'anthropic/searchHint': 'iam member add group user membership'},
+)
+async def add_iam_member(
+    group_id: str,
+    user_id: str,
+    workspace: str,
+    region: str = '',
+    **kwargs,
+) -> dict[str, Any]:
+    """Add a user to an IAM group.
+
+    Args:
+        group_id: Group ID to add the user to
+        user_id: User ID to add to the group
+        workspace: Workspace name. Required parameter
+        region: Region (ap1, us1, eu1). Auto-detected if not provided
+
+    Returns:
+        IAM membership creation response
+    """
+    token = kwargs.get('token')
+    result = await http_client.post(
+        region=region,
+        workspace=workspace,
+        endpoint='/api/iam/memberships/',
+        token=token,
+        data={'group': group_id, 'user': user_id},
+    )
+    return success_response(data=result, group_id=group_id, user_id=user_id, region=region, workspace=workspace)
+
+
+@mcp_tool_handler(
+    description='Remove a user from an IAM group by deleting a membership record. Requires the membership ID (not user or group ID). Use list_iam_memberships to find the membership ID. Related: add_iam_member, list_iam_memberships.',
+    annotations=DESTRUCTIVE,
+    meta={'anthropic/searchHint': 'iam member remove group user membership delete'},
+)
+async def remove_iam_member(
+    membership_id: str,
+    workspace: str,
+    region: str = '',
+    **kwargs,
+) -> dict[str, Any]:
+    """Remove a user from an IAM group.
+
+    Args:
+        membership_id: Membership ID to delete
+        workspace: Workspace name. Required parameter
+        region: Region (ap1, us1, eu1). Auto-detected if not provided
+
+    Returns:
+        IAM membership deletion response
+    """
+    token = kwargs.get('token')
+    result = await http_client.delete(
+        region=region,
+        workspace=workspace,
+        endpoint=f'/api/iam/memberships/{membership_id}/',
+        token=token,
+    )
+    return success_response(data=result, membership_id=membership_id, region=region, workspace=workspace)
+
+
+# ===============================
+# USER INVITATION TOOLS
+# ===============================
+
+
+@mcp_tool_handler(
+    description='Send an email invitation to a user to join the workspace. Requires the user ID and the target email address. The user must already exist in IAM. Related: create_iam_user, get_iam_user.',
+    annotations=ADDITIVE,
+    meta={'anthropic/searchHint': 'iam user invite email send'},
+)
+async def invite_iam_user(
+    user_id: str,
+    email: str,
+    workspace: str,
+    region: str = '',
+    **kwargs,
+) -> dict[str, Any]:
+    """Invite an IAM user by email.
+
+    Args:
+        user_id: IAM user ID to invite
+        email: Email address to send the invitation to
+        workspace: Workspace name. Required parameter
+        region: Region (ap1, us1, eu1). Auto-detected if not provided
+
+    Returns:
+        Invitation response
+    """
+    token = kwargs.get('token')
+    result = await http_client.post(
+        region=region,
+        workspace=workspace,
+        endpoint=f'/api/iam/users/{user_id}/invite/',
+        token=token,
+        data={'email': email},
+    )
+    return success_response(data=result, user_id=user_id, region=region, workspace=workspace)
+
+
+# ===============================
+# APPLICATION MANAGEMENT TOOLS
+# ===============================
+
+
+@mcp_tool_handler(
+    description='List all IAM applications (service accounts / OAuth apps) in the workspace. Supports pagination. Related: create_iam_application, get_iam_application.',
+    annotations=READ_ONLY,
+    meta={'anthropic/searchHint': 'iam applications list service accounts oauth'},
+)
+async def list_iam_applications(
+    workspace: str,
+    region: str = '',
+    page: int | None = None,
+    page_size: int | None = None,
+    **kwargs,
+) -> dict[str, Any]:
+    """List all IAM applications in the workspace.
+
+    Args:
+        workspace: Workspace name. Required parameter
+        region: Region (ap1, us1, eu1). Auto-detected if not provided
+        page: Page number for pagination (optional)
+        page_size: Number of applications per page (optional)
+
+    Returns:
+        IAM applications list response
+    """
+    token = kwargs.get('token')
+
+    params: dict[str, Any] = {}
+    if page is not None:
+        params['page'] = page
+    if page_size is not None:
+        params['page_size'] = page_size
+
+    result = await http_client.get(
+        region=region,
+        workspace=workspace,
+        endpoint='/api/iam/applications/',
+        token=token,
+        params=params,
+    )
+    return success_response(data=result, region=region, workspace=workspace)
+
+
+@mcp_tool_handler(
+    description='Create a new IAM application (service account / OAuth app) in the workspace. Requires a name. Optionally set a description. Related: list_iam_applications, get_iam_application, provision_service_account.',
+    annotations=ADDITIVE,
+    meta={'anthropic/searchHint': 'iam application create new service account oauth'},
+)
+async def create_iam_application(
+    name: str,
+    workspace: str,
+    description: str | None = None,
+    region: str = '',
+    **kwargs,
+) -> dict[str, Any]:
+    """Create a new IAM application.
+
+    Args:
+        name: Name of the new application
+        workspace: Workspace name. Required parameter
+        description: Description of the application (optional)
+        region: Region (ap1, us1, eu1). Auto-detected if not provided
+
+    Returns:
+        IAM application creation response
+    """
+    token = kwargs.get('token')
+
+    app_data: dict[str, Any] = {'name': name}
+    if description is not None:
+        app_data['description'] = description
+
+    result = await http_client.post(
+        region=region,
+        workspace=workspace,
+        endpoint='/api/iam/applications/',
+        token=token,
+        data=app_data,
+    )
+    return success_response(data=result, app_name=name, region=region, workspace=workspace)
+
+
+@mcp_tool_handler(
+    description='Get detailed information about a specific IAM application by its application ID. Returns name, description, and configuration details. Related: list_iam_applications, update_iam_application.',
+    annotations=READ_ONLY,
+    meta={'anthropic/searchHint': 'iam application detail get service account'},
+)
+async def get_iam_application(
+    app_id: str,
+    workspace: str,
+    region: str = '',
+    **kwargs,
+) -> dict[str, Any]:
+    """Get IAM application details.
+
+    Args:
+        app_id: Application ID
+        workspace: Workspace name. Required parameter
+        region: Region (ap1, us1, eu1). Auto-detected if not provided
+
+    Returns:
+        IAM application detail response
+    """
+    token = kwargs.get('token')
+    result = await http_client.get(
+        region=region,
+        workspace=workspace,
+        endpoint=f'/api/iam/applications/{app_id}/',
+        token=token,
+    )
+    return success_response(data=result, app_id=app_id, region=region, workspace=workspace)
+
+
+@mcp_tool_handler(
+    description='Update an existing IAM application. Can change the application name or description. Only provided fields will be updated (partial update). Related: get_iam_application, delete_iam_application.',
+    annotations=IDEMPOTENT_WRITE,
+    meta={'anthropic/searchHint': 'iam application update modify edit'},
+)
+async def update_iam_application(
+    app_id: str,
+    workspace: str,
+    name: str | None = None,
+    description: str | None = None,
+    region: str = '',
+    **kwargs,
+) -> dict[str, Any]:
+    """Update an existing IAM application.
+
+    Args:
+        app_id: Application ID to update
+        workspace: Workspace name. Required parameter
+        name: New application name (optional)
+        description: New application description (optional)
+        region: Region (ap1, us1, eu1). Auto-detected if not provided
+
+    Returns:
+        IAM application update response
+    """
+    token = kwargs.get('token')
+
+    update_data: dict[str, Any] = {}
+    if name is not None:
+        update_data['name'] = name
+    if description is not None:
+        update_data['description'] = description
+
+    if not update_data:
+        return error_response('No update data provided')
+
+    result = await http_client.patch(
+        region=region,
+        workspace=workspace,
+        endpoint=f'/api/iam/applications/{app_id}/',
+        token=token,
+        data=update_data,
+    )
+    return success_response(data=result, app_id=app_id, region=region, workspace=workspace)
+
+
+@mcp_tool_handler(
+    description='Permanently delete an IAM application from the workspace. This action cannot be undone. Related: get_iam_application, list_iam_applications.',
+    annotations=DESTRUCTIVE,
+    meta={'anthropic/searchHint': 'iam application delete remove'},
+)
+async def delete_iam_application(
+    app_id: str,
+    workspace: str,
+    region: str = '',
+    **kwargs,
+) -> dict[str, Any]:
+    """Delete an IAM application.
+
+    Args:
+        app_id: Application ID to delete
+        workspace: Workspace name. Required parameter
+        region: Region (ap1, us1, eu1). Auto-detected if not provided
+
+    Returns:
+        IAM application deletion response
+    """
+    token = kwargs.get('token')
+    result = await http_client.delete(
+        region=region,
+        workspace=workspace,
+        endpoint=f'/api/iam/applications/{app_id}/',
+        token=token,
+    )
+    return success_response(data=result, app_id=app_id, region=region, workspace=workspace)
+
+
+@mcp_tool_handler(
+    description='Provision a service account for an IAM application. This creates a system-level account linked to the application for machine-to-machine authentication. Related: create_iam_application, get_iam_application.',
+    annotations=ADDITIVE,
+    meta={'anthropic/searchHint': 'iam application provision service account machine'},
+)
+async def provision_service_account(
+    app_id: str,
+    workspace: str,
+    region: str = '',
+    **kwargs,
+) -> dict[str, Any]:
+    """Provision a service account for an IAM application.
+
+    Args:
+        app_id: Application ID to provision a service account for
+        workspace: Workspace name. Required parameter
+        region: Region (ap1, us1, eu1). Auto-detected if not provided
+
+    Returns:
+        Service account provisioning response
+    """
+    token = kwargs.get('token')
+    result = await http_client.post(
+        region=region,
+        workspace=workspace,
+        endpoint=f'/api/iam/applications/{app_id}/provision-account/',
+        token=token,
+        data={},
+    )
+    return success_response(data=result, app_id=app_id, region=region, workspace=workspace)


### PR DESCRIPTION
## Summary

Closes #78

Completes the IAM tool set in `tools/iam_tools.py`, verified against the Alpacon server source (`iam` app) and hardened through repeated clean review loops.

### New tools

**Group management**
- `get_iam_group`, `update_iam_group` (display name/description; group name is immutable), `delete_iam_group`

**Membership management**
- `list_iam_memberships` (optional group filter)
- `add_iam_member` (roles: `member`, `manager`, `owner`)
- `remove_iam_member`

**Application management (machine service accounts)**
- `list_iam_applications`, `create_iam_application` (service types: `ci_cd`, `monitoring`, `automation`, `integration`), `get_iam_application`, `update_iam_application`, `delete_iam_application`
- `assign_application_system_users` / `unassign_application_system_users`

**User management**
- `invite_workspace_user` (Auth0-enabled deployments only)

### Server-spec alignment fixes

- Removed writable `groups` field from `create_iam_user`/`update_iam_user` and `permissions` from `create_iam_group`—the server serializers expose neither; group membership is managed exclusively through the memberships API
- Membership payload (`{group, user, role}`), application payloads, and the `system_user_ids` assign/unassign contract match the server serializers exactly
- Removed role/permission tools (`list_iam_roles`, `assign_iam_user_role`, `list_iam_permissions`, `get_iam_user_permissions`)—those endpoints do not exist on the server
- User invitation deviates from the issue #78 proposal (`/api/iam/users/{id}/invite/`, `invite_iam_user`): the server implements invitation only as a workspace-level Auth0 action at `/api/workspaces/users/invite/` taking an email (no existing user record required), so the tool is `invite_workspace_user`

### Validation

- Local UUID validation for all IAM resource IDs (user, group, membership, application, system user) before any API call
- Enum validation for membership roles and application service types
- Empty `system_user_ids` rejected early (server enforces `min_length=1`)

### Docs

- CLAUDE.md IAM section rewritten to match the final tool set

## Test plan

- [x] `pytest tests/test_iam_tools.py -q` → 39 passed
- [x] `pytest tests/ -q` → 664 passed
- [x] Two clean-review-loop rounds against the server source ended with `NO ISSUES FOUND`
