### PR TITLE
feat(command): surface exec-sudo denial guidance to the agent

### DIFF
--- a/tests/test_command_tools.py
+++ b/tests/test_command_tools.py
@@ -6,10 +6,41 @@ import pytest
 
 from tools.command_tools import (
     _submit_command,
+    _sudo_denial_hint,
     execute_command,
     execute_command_multi_server,
     list_commands,
 )
+
+
+class TestSudoDenialHint:
+    """The exec-sudo denial code -> agent guidance mapping."""
+
+    def test_presence_required(self):
+        out = {'result': 'sudo: Permission denied (SUDO_PRESENCE_REQUIRED)\n'}
+        hint = _sudo_denial_hint(out)
+        assert hint is not None
+        assert 'step-up' in hint
+
+    def test_approval_required(self):
+        out = {'result': 'sudo: Permission denied (SUDO_APPROVAL_REQUIRED)\n'}
+        hint = _sudo_denial_hint(out)
+        assert hint is not None
+        assert 'approv' in hint
+
+    def test_risk_denied_no_score_disclosed(self):
+        out = {'result': 'sudo: Permission denied (SUDO_RISK_DENIED)\n'}
+        hint = _sudo_denial_hint(out)
+        assert hint is not None
+        assert 'risk' in hint
+        # Disclosure: never echo a score / reasoning, only the category.
+        assert 'score' not in hint
+
+    def test_no_denial(self):
+        assert _sudo_denial_hint({'result': 'uid=0(root)\n'}) is None
+        assert _sudo_denial_hint({'result': ''}) is None
+        assert _sudo_denial_hint({'result': None}) is None
+        assert _sudo_denial_hint({}) is None
 
 
 @pytest.fixture

--- a/tests/test_command_tools.py
+++ b/tests/test_command_tools.py
@@ -382,6 +382,66 @@ class TestExecuteCommand:
         assert result['status'] == 'error'
         assert 'No token found' in result['message']
 
+    @pytest.mark.asyncio
+    async def test_surfaces_sudo_hint_on_denial(
+        self, mock_http_client, mock_token_manager
+    ):
+        # A finished command whose output carries a parenthesized denial code
+        # must get a category-level sudo_hint attached to the response.
+        with (
+            patch('tools.command_tools._submit_command') as mock_submit,
+            patch('tools.command_tools._get_command_result') as mock_poll,
+        ):
+            mock_submit.return_value = {'id': 'cmd-789'}
+            mock_poll.return_value = {
+                'id': 'cmd-789',
+                'status': 'completed',
+                'exit_code': 1,
+                'result': 'sudo: Permission denied (SUDO_PRESENCE_REQUIRED)\n',
+                'finished_at': '2024-01-01T00:00:01Z',
+            }
+
+            result = await execute_command(
+                server_id='550e8400-e29b-41d4-a716-446655440001',
+                command='sudo systemctl restart nginx',
+                workspace='testworkspace',
+                timeout=10,
+            )
+
+            assert result['status'] == 'success'
+            assert 'sudo_hint' in result
+            assert 'step-up' in result['sudo_hint']
+            # Disclosure guard: never echo a score/reasoning, only the category.
+            assert 'score' not in result['sudo_hint']
+
+    @pytest.mark.asyncio
+    async def test_no_sudo_hint_when_no_denial(
+        self, mock_http_client, mock_token_manager
+    ):
+        # A clean command must not carry a sudo_hint field.
+        with (
+            patch('tools.command_tools._submit_command') as mock_submit,
+            patch('tools.command_tools._get_command_result') as mock_poll,
+        ):
+            mock_submit.return_value = {'id': 'cmd-790'}
+            mock_poll.return_value = {
+                'id': 'cmd-790',
+                'status': 'completed',
+                'exit_code': 0,
+                'result': 'uid=0(root)\n',
+                'finished_at': '2024-01-01T00:00:01Z',
+            }
+
+            result = await execute_command(
+                server_id='550e8400-e29b-41d4-a716-446655440001',
+                command='id',
+                workspace='testworkspace',
+                timeout=10,
+            )
+
+            assert result['status'] == 'success'
+            assert 'sudo_hint' not in result
+
 
 class TestSubmitCommandWithSession:
     """Test _submit_command forwards work_session to API payload."""

--- a/tests/test_command_tools.py
+++ b/tests/test_command_tools.py
@@ -42,6 +42,10 @@ class TestSudoDenialHint:
         assert _sudo_denial_hint({'result': None}) is None
         assert _sudo_denial_hint({}) is None
 
+    def test_bare_code_is_not_a_false_positive(self):
+        # A command that merely prints the code (no "(CODE)" token) is not a hit.
+        assert _sudo_denial_hint({'result': 'echo SUDO_RISK_DENIED\n'}) is None
+
 
 @pytest.fixture
 def mock_http_client():

--- a/tests/test_command_tools.py
+++ b/tests/test_command_tools.py
@@ -17,19 +17,27 @@ class TestSudoDenialHint:
     """The exec-sudo denial code -> agent guidance mapping."""
 
     def test_presence_required(self):
-        out = {'result': 'sudo: Permission denied (SUDO_PRESENCE_REQUIRED)\n'}
+        out = {
+            'result': 'Alpacon denied this sudo command '
+            '(SUDO_PRESENCE_REQUIRED).\n'
+        }
         hint = _sudo_denial_hint(out)
         assert hint is not None
         assert 'step-up' in hint
 
     def test_approval_required(self):
-        out = {'result': 'sudo: Permission denied (SUDO_APPROVAL_REQUIRED)\n'}
+        out = {
+            'result': 'Alpacon denied this sudo command '
+            '(SUDO_APPROVAL_REQUIRED).\n'
+        }
         hint = _sudo_denial_hint(out)
         assert hint is not None
         assert 'approv' in hint
 
     def test_risk_denied_no_score_disclosed(self):
-        out = {'result': 'sudo: Permission denied (SUDO_RISK_DENIED)\n'}
+        out = {
+            'result': 'Alpacon denied this sudo command (SUDO_RISK_DENIED).\n'
+        }
         hint = _sudo_denial_hint(out)
         assert hint is not None
         assert 'risk' in hint
@@ -43,8 +51,14 @@ class TestSudoDenialHint:
         assert _sudo_denial_hint({}) is None
 
     def test_bare_code_is_not_a_false_positive(self):
-        # A command that merely prints the code (no "(CODE)" token) is not a hit.
+        # A command that merely prints the code (no denial line) is not a hit.
         assert _sudo_denial_hint({'result': 'echo SUDO_RISK_DENIED\n'}) is None
+
+    def test_forged_parenthesized_token_is_not_a_false_positive(self):
+        # A command whose own output prints the parenthesized token, without the
+        # plugin's denial line, must not forge a hint (the command succeeded).
+        forged = {'result': 'echo "(SUDO_RISK_DENIED)"\n(SUDO_RISK_DENIED)\n'}
+        assert _sudo_denial_hint(forged) is None
 
 
 @pytest.fixture
@@ -397,7 +411,8 @@ class TestExecuteCommand:
                 'id': 'cmd-789',
                 'status': 'completed',
                 'exit_code': 1,
-                'result': 'sudo: Permission denied (SUDO_PRESENCE_REQUIRED)\n',
+                'result': 'Alpacon denied this sudo command '
+                '(SUDO_PRESENCE_REQUIRED).\n',
                 'finished_at': '2024-01-01T00:00:01Z',
             }
 

--- a/tools/command_tools.py
+++ b/tools/command_tools.py
@@ -16,8 +16,10 @@ _SUDO_DENIAL_HINTS: tuple[tuple[str, str], ...] = (
     (
         'SUDO_NO_WORKSESSION_POLICY',
         'sudo was denied: this command is not covered by an MFA-bypass policy '
-        'in the Work Session. Add it (work_session update with the sudo command) '
-        'and re-run.',
+        'in the Work Session. There is no MCP tool to add one—a human must add '
+        'the command to the Work Session sudo policy (via the Alpacon web '
+        "console or the CLI's 'work-session update --sudo'). Re-run once it is "
+        'added.',
     ),
     (
         'SUDO_PRESENCE_REQUIRED',

--- a/tools/command_tools.py
+++ b/tools/command_tools.py
@@ -8,6 +8,48 @@ from utils.decorators import mcp_tool_handler
 from utils.http_client import http_client
 from utils.tool_annotations import ADDITIVE, READ_ONLY
 
+# Non-interactive sudo denial codes, as they reach the command output via
+# alpacon_approval.c's [A-Z0-9_] sanitizer (UPPERCASE). Kept in sync with
+# alpacon-server utils/error_codes.py. Surfaced to the agent as category-level
+# guidance only—the server never sends the risk score or reasoning to a client.
+_SUDO_DENIAL_HINTS: tuple[tuple[str, str], ...] = (
+    (
+        'SUDO_NO_WORKSESSION_POLICY',
+        'sudo was denied: this command is not covered by an MFA-bypass policy '
+        'in the Work Session. Add it (work_session update with the sudo command) '
+        'and re-run.',
+    ),
+    (
+        'SUDO_PRESENCE_REQUIRED',
+        'sudo needs a recent human MFA: a human must complete a step-up, then '
+        're-run. An agent cannot satisfy this.',
+    ),
+    (
+        'SUDO_APPROVAL_REQUIRED',
+        'sudo needs human approval: an approval request was created. Re-run '
+        'after a reviewer approves it.',
+    ),
+    (
+        'SUDO_RISK_DENIED',
+        'sudo was denied by runtime risk assessment; this command is not '
+        'permitted in this Work Session.',
+    ),
+)
+
+
+def _sudo_denial_hint(result: dict[str, Any]) -> str | None:
+    """Return category-level guidance when a non-interactive sudo was denied in
+    the command output, so an agent can act (have a human step up / request
+    approval / stop) without parsing free text. None when no denial is present.
+    """
+    output = result.get('result') or ''
+    if not isinstance(output, str):
+        return None
+    for code, hint in _SUDO_DENIAL_HINTS:
+        if code in output:
+            return hint
+    return None
+
 
 async def _submit_command(
     server_id: str,
@@ -217,7 +259,7 @@ async def execute_command(
             status = result.get('status', '')
 
             if result.get('finished_at') is not None:
-                return success_response(
+                response = success_response(
                     data=result,
                     command_id=command_id,
                     server_id=server_id,
@@ -226,6 +268,10 @@ async def execute_command(
                     region=region,
                     workspace=workspace,
                 )
+                hint = _sudo_denial_hint(result)
+                if hint:
+                    response['sudo_hint'] = hint
+                return response
 
             if status in ('stuck', 'error'):
                 return error_response(

--- a/tools/command_tools.py
+++ b/tools/command_tools.py
@@ -46,7 +46,10 @@ def _sudo_denial_hint(result: dict[str, Any]) -> str | None:
     if not isinstance(output, str):
         return None
     for code, hint in _SUDO_DENIAL_HINTS:
-        if code in output:
+        # Match the parenthesized denial token '(CODE)'—the form
+        # alpacon_approval.c emits—not the bare code, so a command that merely
+        # prints the code string in its own output is not a false positive.
+        if f'({code})' in output:
             return hint
     return None
 

--- a/tools/command_tools.py
+++ b/tools/command_tools.py
@@ -39,6 +39,13 @@ _SUDO_DENIAL_HINTS: tuple[tuple[str, str], ...] = (
 )
 
 
+# The exact terminal-facing denial line alpacon_approval.c emits via
+# g_plugin_printf ("Alpacon denied this sudo command (CODE)."). The other
+# "Permission denied (CODE)" form is assigned to *errstr, which only reaches the
+# audit log—not the invoking terminal—so it must not be matched here.
+_SUDO_DENIAL_LINE_PREFIX = 'Alpacon denied this sudo command'
+
+
 def _sudo_denial_hint(result: dict[str, Any]) -> str | None:
     """Return category-level guidance when a non-interactive sudo was denied in
     the command output, so an agent can act (have a human step up / request
@@ -48,10 +55,11 @@ def _sudo_denial_hint(result: dict[str, Any]) -> str | None:
     if not isinstance(output, str):
         return None
     for code, hint in _SUDO_DENIAL_HINTS:
-        # Match the parenthesized denial token '(CODE)'—the form
-        # alpacon_approval.c emits—not the bare code, so a command that merely
-        # prints the code string in its own output is not a false positive.
-        if f'({code})' in output:
+        # Anchor on the plugin's full denial line, not a bare '(CODE)' token:
+        # otherwise a command whose own output prints '(SUDO_RISK_DENIED)' could
+        # forge a hint on a command that actually succeeded and mislead the
+        # agent into a wrong action.
+        if f'{_SUDO_DENIAL_LINE_PREFIX} ({code})' in output:
             return hint
     return None
 


### PR DESCRIPTION
## What

When an agent runs `execute_command` and the command's `sudo` is denied on the host, the denial code reaches the MCP server in the command output (alpacon_approval.c prints `Permission denied (<CODE>)`). The agent could read the raw text, but a structured `sudo_hint` makes it reliable. This adds category-level guidance for the codes the server's exec-sudo risk gate (PR-X, `alpacon-server`) emits:

| Code | `sudo_hint` |
|---|---|
| `SUDO_PRESENCE_REQUIRED` | a human must complete a step-up, then re-run (an agent cannot satisfy this) |
| `SUDO_APPROVAL_REQUIRED` | an approval request was created; re-run after a reviewer approves it |
| `SUDO_RISK_DENIED` | denied by runtime risk assessment; not permitted in this Work Session |
| `SUDO_NO_WORKSESSION_POLICY` | not covered by an MFA-bypass policy; add it and re-run |

The hint is added to the `execute_command` response only when a denial code is present in the output.

## Security / disclosure

Hints stay at the **denial category** level (what to do). The server never sends the risk **score**, factors, or reasoning to a client — those go to the audit log server-side. A test asserts the risk-denied hint never echoes a `score`.

## Tests

`TestSudoDenialHint` (4 cases) + the existing 23 command tests pass; `mypy --ignore-missing-imports --no-strict-optional` clean. (Repo uses single quotes and runs neither black nor flake8 in CI — only mypy + pytest.)

## Dependencies

Pairs with **PR-X** (`alpacon-server`) which emits these codes, and the sibling `alpacon-cli` hint PR. Pure client-side string-match addition; merges independently, produces hints end-to-end once PR-X is in `EXEC_SUDO_MODE=enforce`.