### PR TITLE
feat: complete security ACL tools with update/delete and bulk operations

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -306,9 +306,14 @@ All validators are defined in `utils/error_handler.py` and return user-friendly 
 - `update_command_acl`: Update an existing command ACL rule
 - `delete_command_acl`: Delete a command ACL rule
 - `list_server_acls`: List server ACL rules
-- `create_server_acl`: Create a server ACL rule (control server access)
+- `create_server_acl`: Create a server ACL rule granting a token access to a server
+- `update_server_acl`: Update an existing server ACL rule
+- `delete_server_acl`: Delete a server ACL rule
+- `bulk_server_acl`: Bulk add or remove server ACL entries for multiple servers
 - `list_file_acls`: List file ACL rules
-- `create_file_acl`: Create a file ACL rule (control file access)
+- `create_file_acl`: Create a file ACL rule (control file upload/download access)
+- `update_file_acl`: Update an existing file ACL rule
+- `delete_file_acl`: Delete a file ACL rule
 
 ### 📋 Events & logging
 - `list_events`: List server events

--- a/tests/test_security_tools.py
+++ b/tests/test_security_tools.py
@@ -1,0 +1,356 @@
+"""Unit tests for security ACL tools."""
+
+from unittest.mock import AsyncMock, patch
+
+import pytest
+
+from tools.security_tools import (
+    bulk_server_acl,
+    delete_file_acl,
+    delete_server_acl,
+    update_file_acl,
+    update_server_acl,
+)
+
+
+@pytest.fixture
+def mock_http_client():
+    """Mock HTTP client for testing."""
+    with patch('tools.security_tools.http_client') as mock_client:
+        mock_client.get = AsyncMock()
+        mock_client.post = AsyncMock()
+        mock_client.patch = AsyncMock()
+        mock_client.delete = AsyncMock()
+        yield mock_client
+
+
+@pytest.fixture
+def mock_token_manager():
+    """Mock token manager for testing."""
+    with patch('utils.common.token_manager') as mock_manager:
+        mock_manager.get_token.return_value = 'test-token'
+        yield mock_manager
+
+
+class TestUpdateServerAcl:
+    """Test update_server_acl tool."""
+
+    @pytest.mark.asyncio
+    async def test_update_server_acl_success(self, mock_http_client, mock_token_manager):
+        """Test successful server ACL rule update."""
+        mock_http_client.patch.return_value = {
+            'id': 'acl-1',
+            'effect': 'deny',
+            'description': 'Updated rule',
+        }
+
+        result = await update_server_acl(
+            acl_id='acl-1',
+            workspace='testworkspace',
+            effect='deny',
+            description='Updated rule',
+            region='ap1',
+        )
+
+        assert result['status'] == 'success'
+        assert result['acl_id'] == 'acl-1'
+        mock_http_client.patch.assert_called_once_with(
+            region='ap1',
+            workspace='testworkspace',
+            endpoint='/api/security/server-acl/acl-1/',
+            token='test-token',
+            data={'effect': 'deny', 'description': 'Updated rule'},
+        )
+
+    @pytest.mark.asyncio
+    async def test_update_server_acl_users_and_groups(
+        self, mock_http_client, mock_token_manager
+    ):
+        """Test server ACL update with users and groups."""
+        mock_http_client.patch.return_value = {'id': 'acl-1', 'effect': 'allow'}
+
+        result = await update_server_acl(
+            acl_id='acl-1',
+            workspace='testworkspace',
+            users=['user-1', 'user-2'],
+            groups=['group-1'],
+            priority=10,
+            region='ap1',
+        )
+
+        assert result['status'] == 'success'
+        mock_http_client.patch.assert_called_once_with(
+            region='ap1',
+            workspace='testworkspace',
+            endpoint='/api/security/server-acl/acl-1/',
+            token='test-token',
+            data={'users': ['user-1', 'user-2'], 'groups': ['group-1'], 'priority': 10},
+        )
+
+    @pytest.mark.asyncio
+    async def test_update_server_acl_no_data_returns_error(
+        self, mock_http_client, mock_token_manager
+    ):
+        """Test that updating with no fields returns an error."""
+        result = await update_server_acl(
+            acl_id='acl-1',
+            workspace='testworkspace',
+            region='ap1',
+        )
+
+        assert result['status'] == 'error'
+        mock_http_client.patch.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_update_server_acl_servers_field(
+        self, mock_http_client, mock_token_manager
+    ):
+        """Test server ACL update with servers field."""
+        mock_http_client.patch.return_value = {'id': 'acl-2', 'effect': 'allow'}
+
+        result = await update_server_acl(
+            acl_id='acl-2',
+            workspace='testworkspace',
+            servers=['server-uuid-1'],
+            region='ap1',
+        )
+
+        assert result['status'] == 'success'
+        mock_http_client.patch.assert_called_once_with(
+            region='ap1',
+            workspace='testworkspace',
+            endpoint='/api/security/server-acl/acl-2/',
+            token='test-token',
+            data={'servers': ['server-uuid-1']},
+        )
+
+
+class TestDeleteServerAcl:
+    """Test delete_server_acl tool."""
+
+    @pytest.mark.asyncio
+    async def test_delete_server_acl_success(
+        self, mock_http_client, mock_token_manager
+    ):
+        """Test successful server ACL rule deletion."""
+        mock_http_client.delete.return_value = {}
+
+        result = await delete_server_acl(
+            acl_id='acl-1',
+            workspace='testworkspace',
+            region='ap1',
+        )
+
+        assert result['status'] == 'success'
+        assert result['acl_id'] == 'acl-1'
+        mock_http_client.delete.assert_called_once_with(
+            region='ap1',
+            workspace='testworkspace',
+            endpoint='/api/security/server-acl/acl-1/',
+            token='test-token',
+        )
+
+    @pytest.mark.asyncio
+    async def test_delete_server_acl_default_region(
+        self, mock_http_client, mock_token_manager
+    ):
+        """Test server ACL deletion with default region (auto-resolved to ap1)."""
+        mock_http_client.delete.return_value = {}
+
+        result = await delete_server_acl(
+            acl_id='acl-99',
+            workspace='testworkspace',
+        )
+
+        assert result['status'] == 'success'
+        assert result['acl_id'] == 'acl-99'
+        mock_http_client.delete.assert_called_once_with(
+            region='ap1',
+            workspace='testworkspace',
+            endpoint='/api/security/server-acl/acl-99/',
+            token='test-token',
+        )
+
+
+class TestBulkServerAcl:
+    """Test bulk_server_acl tool."""
+
+    @pytest.mark.asyncio
+    async def test_bulk_server_acl_add_success(
+        self, mock_http_client, mock_token_manager
+    ):
+        """Test successful bulk add of server ACL entries."""
+        acl_entries = [
+            {'effect': 'allow', 'users': ['user-1'], 'servers': ['server-1']},
+            {'effect': 'allow', 'users': ['user-2'], 'servers': ['server-2']},
+        ]
+        mock_http_client.post.return_value = {'created': 2}
+
+        result = await bulk_server_acl(
+            workspace='testworkspace',
+            action='add',
+            acl_list=acl_entries,
+            region='ap1',
+        )
+
+        assert result['status'] == 'success'
+        assert result['action'] == 'add'
+        mock_http_client.post.assert_called_once_with(
+            region='ap1',
+            workspace='testworkspace',
+            endpoint='/api/security/server-acl/bulk/',
+            token='test-token',
+            data={'action': 'add', 'acls': acl_entries},
+        )
+
+    @pytest.mark.asyncio
+    async def test_bulk_server_acl_remove_success(
+        self, mock_http_client, mock_token_manager
+    ):
+        """Test successful bulk remove of server ACL entries."""
+        acl_entries = [{'id': 'acl-1'}, {'id': 'acl-2'}]
+        mock_http_client.post.return_value = {'deleted': 2}
+
+        result = await bulk_server_acl(
+            workspace='testworkspace',
+            action='remove',
+            acl_list=acl_entries,
+            region='ap1',
+        )
+
+        assert result['status'] == 'success'
+        assert result['action'] == 'remove'
+        mock_http_client.post.assert_called_once_with(
+            region='ap1',
+            workspace='testworkspace',
+            endpoint='/api/security/server-acl/bulk/',
+            token='test-token',
+            data={'action': 'remove', 'acls': acl_entries},
+        )
+
+
+class TestUpdateFileAcl:
+    """Test update_file_acl tool."""
+
+    @pytest.mark.asyncio
+    async def test_update_file_acl_success(self, mock_http_client, mock_token_manager):
+        """Test successful file ACL rule update."""
+        mock_http_client.patch.return_value = {
+            'id': 'facl-1',
+            'effect': 'deny',
+            'file_pattern': '/etc/passwd',
+        }
+
+        result = await update_file_acl(
+            acl_id='facl-1',
+            workspace='testworkspace',
+            effect='deny',
+            file_pattern='/etc/passwd',
+            region='ap1',
+        )
+
+        assert result['status'] == 'success'
+        assert result['acl_id'] == 'facl-1'
+        mock_http_client.patch.assert_called_once_with(
+            region='ap1',
+            workspace='testworkspace',
+            endpoint='/api/security/file-acl/facl-1/',
+            token='test-token',
+            data={'effect': 'deny', 'file_pattern': '/etc/passwd'},
+        )
+
+    @pytest.mark.asyncio
+    async def test_update_file_acl_with_all_fields(
+        self, mock_http_client, mock_token_manager
+    ):
+        """Test file ACL update with all optional fields."""
+        mock_http_client.patch.return_value = {'id': 'facl-1'}
+
+        result = await update_file_acl(
+            acl_id='facl-1',
+            workspace='testworkspace',
+            effect='allow',
+            file_pattern='/var/log/*',
+            users=['user-1'],
+            groups=['group-1'],
+            servers=['server-1'],
+            description='Allow log access',
+            priority=5,
+            region='ap1',
+        )
+
+        assert result['status'] == 'success'
+        mock_http_client.patch.assert_called_once_with(
+            region='ap1',
+            workspace='testworkspace',
+            endpoint='/api/security/file-acl/facl-1/',
+            token='test-token',
+            data={
+                'effect': 'allow',
+                'file_pattern': '/var/log/*',
+                'users': ['user-1'],
+                'groups': ['group-1'],
+                'servers': ['server-1'],
+                'description': 'Allow log access',
+                'priority': 5,
+            },
+        )
+
+    @pytest.mark.asyncio
+    async def test_update_file_acl_no_data_returns_error(
+        self, mock_http_client, mock_token_manager
+    ):
+        """Test that updating with no fields returns an error."""
+        result = await update_file_acl(
+            acl_id='facl-1',
+            workspace='testworkspace',
+            region='ap1',
+        )
+
+        assert result['status'] == 'error'
+        mock_http_client.patch.assert_not_called()
+
+
+class TestDeleteFileAcl:
+    """Test delete_file_acl tool."""
+
+    @pytest.mark.asyncio
+    async def test_delete_file_acl_success(self, mock_http_client, mock_token_manager):
+        """Test successful file ACL rule deletion."""
+        mock_http_client.delete.return_value = {}
+
+        result = await delete_file_acl(
+            acl_id='facl-1',
+            workspace='testworkspace',
+            region='ap1',
+        )
+
+        assert result['status'] == 'success'
+        assert result['acl_id'] == 'facl-1'
+        mock_http_client.delete.assert_called_once_with(
+            region='ap1',
+            workspace='testworkspace',
+            endpoint='/api/security/file-acl/facl-1/',
+            token='test-token',
+        )
+
+    @pytest.mark.asyncio
+    async def test_delete_file_acl_default_region(
+        self, mock_http_client, mock_token_manager
+    ):
+        """Test file ACL deletion with default region (auto-resolved to ap1)."""
+        mock_http_client.delete.return_value = {}
+
+        result = await delete_file_acl(
+            acl_id='facl-42',
+            workspace='testworkspace',
+        )
+
+        assert result['status'] == 'success'
+        assert result['acl_id'] == 'facl-42'
+        mock_http_client.delete.assert_called_once_with(
+            region='ap1',
+            workspace='testworkspace',
+            endpoint='/api/security/file-acl/facl-42/',
+            token='test-token',
+        )

--- a/tests/test_security_tools.py
+++ b/tests/test_security_tools.py
@@ -20,6 +20,9 @@ from tools.security_tools import (
     update_server_acl,
 )
 
+SERVER_UUID = '7e3984de-49ab-4cc6-bcdf-21fbd35858b8'
+SERVER_UUID_2 = 'a1b2c3d4-e5f6-7890-abcd-ef1234567890'
+
 
 @pytest.fixture
 def mock_http_client():
@@ -36,10 +39,6 @@ def mock_token_manager():
     with patch('utils.common.token_manager') as mock_manager:
         mock_manager.get_token.return_value = 'test-token'
         yield mock_manager
-
-
-SERVER_UUID = '7e3984de-49ab-4cc6-bcdf-21fbd35858b8'
-SERVER_UUID_2 = 'a1b2c3d4-e5f6-7890-abcd-ef1234567890'
 
 
 class TestListCommandAcls:

--- a/tests/test_security_tools.py
+++ b/tests/test_security_tools.py
@@ -6,8 +6,16 @@ import pytest
 
 from tools.security_tools import (
     bulk_server_acl,
+    create_command_acl,
+    create_file_acl,
+    create_server_acl,
+    delete_command_acl,
     delete_file_acl,
     delete_server_acl,
+    list_command_acls,
+    list_file_acls,
+    list_server_acls,
+    update_command_acl,
     update_file_acl,
     update_server_acl,
 )
@@ -15,7 +23,6 @@ from tools.security_tools import (
 
 @pytest.fixture
 def mock_http_client():
-    """Mock HTTP client for testing."""
     with patch('tools.security_tools.http_client') as mock_client:
         mock_client.get = AsyncMock()
         mock_client.post = AsyncMock()
@@ -26,29 +33,429 @@ def mock_http_client():
 
 @pytest.fixture
 def mock_token_manager():
-    """Mock token manager for testing."""
     with patch('utils.common.token_manager') as mock_manager:
         mock_manager.get_token.return_value = 'test-token'
         yield mock_manager
 
 
-class TestUpdateServerAcl:
-    """Test update_server_acl tool."""
+SERVER_UUID = '7e3984de-49ab-4cc6-bcdf-21fbd35858b8'
+SERVER_UUID_2 = 'a1b2c3d4-e5f6-7890-abcd-ef1234567890'
+
+
+# ===============================
+# CommandACL tests
+# ===============================
+
+
+class TestListCommandAcls:
+    @pytest.mark.asyncio
+    async def test_list_no_filter(self, mock_http_client, mock_token_manager):
+        mock_http_client.get.return_value = {'results': [], 'count': 0}
+
+        result = await list_command_acls(workspace='testworkspace', region='ap1')
+
+        assert result['status'] == 'success'
+        mock_http_client.get.assert_called_once_with(
+            region='ap1',
+            workspace='testworkspace',
+            endpoint='/api/security/command-acl/',
+            token='test-token',
+            params={},
+        )
 
     @pytest.mark.asyncio
-    async def test_update_server_acl_success(self, mock_http_client, mock_token_manager):
-        """Test successful server ACL rule update."""
-        mock_http_client.patch.return_value = {
+    async def test_list_filter_by_api_token(self, mock_http_client, mock_token_manager):
+        mock_http_client.get.return_value = {'results': []}
+
+        result = await list_command_acls(
+            workspace='testworkspace',
+            api_token_id='token-uuid',
+            region='ap1',
+        )
+
+        assert result['status'] == 'success'
+        mock_http_client.get.assert_called_once_with(
+            region='ap1',
+            workspace='testworkspace',
+            endpoint='/api/security/command-acl/',
+            token='test-token',
+            params={'api_token': 'token-uuid'},
+        )
+
+    @pytest.mark.asyncio
+    async def test_list_filter_by_service_token(
+        self, mock_http_client, mock_token_manager
+    ):
+        mock_http_client.get.return_value = {'results': []}
+
+        result = await list_command_acls(
+            workspace='testworkspace',
+            service_token_id='svc-uuid',
+            page=2,
+            page_size=10,
+            region='ap1',
+        )
+
+        assert result['status'] == 'success'
+        mock_http_client.get.assert_called_once_with(
+            region='ap1',
+            workspace='testworkspace',
+            endpoint='/api/security/command-acl/',
+            token='test-token',
+            params={'service_token': 'svc-uuid', 'page': 2, 'page_size': 10},
+        )
+
+    @pytest.mark.asyncio
+    async def test_list_both_tokens_returns_error(
+        self, mock_http_client, mock_token_manager
+    ):
+        result = await list_command_acls(
+            workspace='testworkspace',
+            api_token_id='token-uuid',
+            service_token_id='svc-uuid',
+            region='ap1',
+        )
+
+        assert result['status'] == 'error'
+        mock_http_client.get.assert_not_called()
+
+
+class TestCreateCommandAcl:
+    @pytest.mark.asyncio
+    async def test_create_with_api_token(self, mock_http_client, mock_token_manager):
+        mock_http_client.post.return_value = {
             'id': 'acl-1',
-            'effect': 'deny',
-            'description': 'Updated rule',
+            'token': 'token-uuid',
+            'command': 'docker *',
+            'username': '',
+            'groupname': '',
         }
+
+        result = await create_command_acl(
+            workspace='testworkspace',
+            command='docker *',
+            api_token_id='token-uuid',
+            region='ap1',
+        )
+
+        assert result['status'] == 'success'
+        mock_http_client.post.assert_called_once_with(
+            region='ap1',
+            workspace='testworkspace',
+            endpoint='/api/security/command-acl/',
+            token='test-token',
+            data={
+                'command': 'docker *',
+                'username': '',
+                'groupname': '',
+                'token': 'token-uuid',
+            },
+        )
+
+    @pytest.mark.asyncio
+    async def test_create_with_service_token(
+        self, mock_http_client, mock_token_manager
+    ):
+        mock_http_client.post.return_value = {
+            'id': 'acl-2',
+            'service_token': 'svc-uuid',
+        }
+
+        result = await create_command_acl(
+            workspace='testworkspace',
+            command='ls -la',
+            service_token_id='svc-uuid',
+            username='deploy',
+            groupname='docker',
+            region='ap1',
+        )
+
+        assert result['status'] == 'success'
+        mock_http_client.post.assert_called_once_with(
+            region='ap1',
+            workspace='testworkspace',
+            endpoint='/api/security/command-acl/',
+            token='test-token',
+            data={
+                'command': 'ls -la',
+                'username': 'deploy',
+                'groupname': 'docker',
+                'service_token': 'svc-uuid',
+            },
+        )
+
+    @pytest.mark.asyncio
+    async def test_create_missing_token_returns_error(
+        self, mock_http_client, mock_token_manager
+    ):
+        result = await create_command_acl(
+            workspace='testworkspace',
+            command='docker *',
+            region='ap1',
+        )
+
+        assert result['status'] == 'error'
+        mock_http_client.post.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_create_both_tokens_returns_error(
+        self, mock_http_client, mock_token_manager
+    ):
+        result = await create_command_acl(
+            workspace='testworkspace',
+            command='docker *',
+            api_token_id='token-uuid',
+            service_token_id='svc-uuid',
+            region='ap1',
+        )
+
+        assert result['status'] == 'error'
+        mock_http_client.post.assert_not_called()
+
+
+class TestUpdateCommandAcl:
+    @pytest.mark.asyncio
+    async def test_update_command(self, mock_http_client, mock_token_manager):
+        mock_http_client.patch.return_value = {'id': 'acl-1', 'command': 'ls *'}
+
+        result = await update_command_acl(
+            acl_id='acl-1',
+            workspace='testworkspace',
+            command='ls *',
+            region='ap1',
+        )
+
+        assert result['status'] == 'success'
+        assert result['acl_id'] == 'acl-1'
+        mock_http_client.patch.assert_called_once_with(
+            region='ap1',
+            workspace='testworkspace',
+            endpoint='/api/security/command-acl/acl-1/',
+            token='test-token',
+            data={'command': 'ls *'},
+        )
+
+    @pytest.mark.asyncio
+    async def test_update_username_and_groupname(
+        self, mock_http_client, mock_token_manager
+    ):
+        mock_http_client.patch.return_value = {'id': 'acl-1'}
+
+        result = await update_command_acl(
+            acl_id='acl-1',
+            workspace='testworkspace',
+            username='root',
+            groupname='docker',
+            region='ap1',
+        )
+
+        assert result['status'] == 'success'
+        mock_http_client.patch.assert_called_once_with(
+            region='ap1',
+            workspace='testworkspace',
+            endpoint='/api/security/command-acl/acl-1/',
+            token='test-token',
+            data={'username': 'root', 'groupname': 'docker'},
+        )
+
+    @pytest.mark.asyncio
+    async def test_update_no_data_returns_error(
+        self, mock_http_client, mock_token_manager
+    ):
+        result = await update_command_acl(
+            acl_id='acl-1',
+            workspace='testworkspace',
+            region='ap1',
+        )
+
+        assert result['status'] == 'error'
+        mock_http_client.patch.assert_not_called()
+
+
+class TestDeleteCommandAcl:
+    @pytest.mark.asyncio
+    async def test_delete_success(self, mock_http_client, mock_token_manager):
+        mock_http_client.delete.return_value = {}
+
+        result = await delete_command_acl(
+            acl_id='acl-1',
+            workspace='testworkspace',
+            region='ap1',
+        )
+
+        assert result['status'] == 'success'
+        assert result['acl_id'] == 'acl-1'
+        mock_http_client.delete.assert_called_once_with(
+            region='ap1',
+            workspace='testworkspace',
+            endpoint='/api/security/command-acl/acl-1/',
+            token='test-token',
+        )
+
+
+# ===============================
+# ServerACL tests
+# ===============================
+
+
+class TestListServerAcls:
+    @pytest.mark.asyncio
+    async def test_list_no_filter(self, mock_http_client, mock_token_manager):
+        mock_http_client.get.return_value = {'results': [], 'count': 0}
+
+        result = await list_server_acls(workspace='testworkspace', region='ap1')
+
+        assert result['status'] == 'success'
+        mock_http_client.get.assert_called_once_with(
+            region='ap1',
+            workspace='testworkspace',
+            endpoint='/api/security/server-acl/',
+            token='test-token',
+            params={},
+        )
+
+    @pytest.mark.asyncio
+    async def test_list_filter_by_api_token(self, mock_http_client, mock_token_manager):
+        mock_http_client.get.return_value = {'results': []}
+
+        result = await list_server_acls(
+            workspace='testworkspace',
+            api_token_id='token-uuid',
+            region='ap1',
+        )
+
+        assert result['status'] == 'success'
+        mock_http_client.get.assert_called_once_with(
+            region='ap1',
+            workspace='testworkspace',
+            endpoint='/api/security/server-acl/',
+            token='test-token',
+            params={'api_token': 'token-uuid'},
+        )
+
+    @pytest.mark.asyncio
+    async def test_list_filter_by_service_token(
+        self, mock_http_client, mock_token_manager
+    ):
+        mock_http_client.get.return_value = {'results': []}
+
+        result = await list_server_acls(
+            workspace='testworkspace',
+            service_token_id='svc-uuid',
+            page=2,
+            page_size=10,
+            region='ap1',
+        )
+
+        assert result['status'] == 'success'
+        mock_http_client.get.assert_called_once_with(
+            region='ap1',
+            workspace='testworkspace',
+            endpoint='/api/security/server-acl/',
+            token='test-token',
+            params={'service_token': 'svc-uuid', 'page': 2, 'page_size': 10},
+        )
+
+    @pytest.mark.asyncio
+    async def test_list_both_tokens_returns_error(
+        self, mock_http_client, mock_token_manager
+    ):
+        result = await list_server_acls(
+            workspace='testworkspace',
+            api_token_id='token-uuid',
+            service_token_id='svc-uuid',
+            region='ap1',
+        )
+
+        assert result['status'] == 'error'
+        mock_http_client.get.assert_not_called()
+
+
+class TestCreateServerAcl:
+    @pytest.mark.asyncio
+    async def test_create_with_api_token(self, mock_http_client, mock_token_manager):
+        mock_http_client.post.return_value = {
+            'id': 'acl-1',
+            'token': 'token-uuid',
+            'server': SERVER_UUID,
+        }
+
+        result = await create_server_acl(
+            workspace='testworkspace',
+            server_id=SERVER_UUID,
+            api_token_id='token-uuid',
+            region='ap1',
+        )
+
+        assert result['status'] == 'success'
+        mock_http_client.post.assert_called_once_with(
+            region='ap1',
+            workspace='testworkspace',
+            endpoint='/api/security/server-acl/',
+            token='test-token',
+            data={'server': SERVER_UUID, 'token': 'token-uuid'},
+        )
+
+    @pytest.mark.asyncio
+    async def test_create_with_service_token(
+        self, mock_http_client, mock_token_manager
+    ):
+        mock_http_client.post.return_value = {'id': 'acl-2'}
+
+        result = await create_server_acl(
+            workspace='testworkspace',
+            server_id=SERVER_UUID,
+            service_token_id='svc-uuid',
+            region='ap1',
+        )
+
+        assert result['status'] == 'success'
+        mock_http_client.post.assert_called_once_with(
+            region='ap1',
+            workspace='testworkspace',
+            endpoint='/api/security/server-acl/',
+            token='test-token',
+            data={'server': SERVER_UUID, 'service_token': 'svc-uuid'},
+        )
+
+    @pytest.mark.asyncio
+    async def test_create_missing_token_returns_error(
+        self, mock_http_client, mock_token_manager
+    ):
+        result = await create_server_acl(
+            workspace='testworkspace',
+            server_id=SERVER_UUID,
+            region='ap1',
+        )
+
+        assert result['status'] == 'error'
+        mock_http_client.post.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_create_both_tokens_returns_error(
+        self, mock_http_client, mock_token_manager
+    ):
+        result = await create_server_acl(
+            workspace='testworkspace',
+            server_id=SERVER_UUID,
+            api_token_id='token-uuid',
+            service_token_id='svc-uuid',
+            region='ap1',
+        )
+
+        assert result['status'] == 'error'
+        mock_http_client.post.assert_not_called()
+
+
+class TestUpdateServerAcl:
+    @pytest.mark.asyncio
+    async def test_update_server(self, mock_http_client, mock_token_manager):
+        mock_http_client.patch.return_value = {'id': 'acl-1', 'server': SERVER_UUID_2}
 
         result = await update_server_acl(
             acl_id='acl-1',
             workspace='testworkspace',
-            effect='deny',
-            description='Updated rule',
+            server_id=SERVER_UUID_2,
             region='ap1',
         )
 
@@ -59,22 +466,19 @@ class TestUpdateServerAcl:
             workspace='testworkspace',
             endpoint='/api/security/server-acl/acl-1/',
             token='test-token',
-            data={'effect': 'deny', 'description': 'Updated rule'},
+            data={'server': SERVER_UUID_2},
         )
 
     @pytest.mark.asyncio
-    async def test_update_server_acl_users_and_groups(
+    async def test_update_rebind_to_api_token(
         self, mock_http_client, mock_token_manager
     ):
-        """Test server ACL update with users and groups."""
-        mock_http_client.patch.return_value = {'id': 'acl-1', 'effect': 'allow'}
+        mock_http_client.patch.return_value = {'id': 'acl-1'}
 
         result = await update_server_acl(
             acl_id='acl-1',
             workspace='testworkspace',
-            users=['user-1', 'user-2'],
-            groups=['group-1'],
-            priority=10,
+            api_token_id='new-token-uuid',
             region='ap1',
         )
 
@@ -84,14 +488,62 @@ class TestUpdateServerAcl:
             workspace='testworkspace',
             endpoint='/api/security/server-acl/acl-1/',
             token='test-token',
-            data={'users': ['user-1', 'user-2'], 'groups': ['group-1'], 'priority': 10},
+            data={'token': 'new-token-uuid', 'service_token': None},
         )
 
     @pytest.mark.asyncio
-    async def test_update_server_acl_no_data_returns_error(
+    async def test_update_rebind_to_service_token(
         self, mock_http_client, mock_token_manager
     ):
-        """Test that updating with no fields returns an error."""
+        mock_http_client.patch.return_value = {'id': 'acl-1'}
+
+        result = await update_server_acl(
+            acl_id='acl-1',
+            workspace='testworkspace',
+            service_token_id='svc-uuid',
+            region='ap1',
+        )
+
+        assert result['status'] == 'success'
+        mock_http_client.patch.assert_called_once_with(
+            region='ap1',
+            workspace='testworkspace',
+            endpoint='/api/security/server-acl/acl-1/',
+            token='test-token',
+            data={'service_token': 'svc-uuid', 'token': None},
+        )
+
+    @pytest.mark.asyncio
+    async def test_update_server_and_token_combined(
+        self, mock_http_client, mock_token_manager
+    ):
+        mock_http_client.patch.return_value = {'id': 'acl-1'}
+
+        result = await update_server_acl(
+            acl_id='acl-1',
+            workspace='testworkspace',
+            server_id=SERVER_UUID_2,
+            api_token_id='new-token-uuid',
+            region='ap1',
+        )
+
+        assert result['status'] == 'success'
+        mock_http_client.patch.assert_called_once_with(
+            region='ap1',
+            workspace='testworkspace',
+            endpoint='/api/security/server-acl/acl-1/',
+            token='test-token',
+            data={
+                'server': SERVER_UUID_2,
+                'token': 'new-token-uuid',
+                'service_token': None,
+            },
+        )
+
+    @pytest.mark.asyncio
+    async def test_update_no_data_returns_error(
+        self, mock_http_client, mock_token_manager
+    ):
         result = await update_server_acl(
             acl_id='acl-1',
             workspace='testworkspace',
@@ -102,37 +554,24 @@ class TestUpdateServerAcl:
         mock_http_client.patch.assert_not_called()
 
     @pytest.mark.asyncio
-    async def test_update_server_acl_servers_field(
+    async def test_update_both_tokens_returns_error(
         self, mock_http_client, mock_token_manager
     ):
-        """Test server ACL update with servers field."""
-        mock_http_client.patch.return_value = {'id': 'acl-2', 'effect': 'allow'}
-
         result = await update_server_acl(
-            acl_id='acl-2',
+            acl_id='acl-1',
             workspace='testworkspace',
-            servers=['server-uuid-1'],
+            api_token_id='token-uuid',
+            service_token_id='svc-uuid',
             region='ap1',
         )
 
-        assert result['status'] == 'success'
-        mock_http_client.patch.assert_called_once_with(
-            region='ap1',
-            workspace='testworkspace',
-            endpoint='/api/security/server-acl/acl-2/',
-            token='test-token',
-            data={'servers': ['server-uuid-1']},
-        )
+        assert result['status'] == 'error'
+        mock_http_client.patch.assert_not_called()
 
 
 class TestDeleteServerAcl:
-    """Test delete_server_acl tool."""
-
     @pytest.mark.asyncio
-    async def test_delete_server_acl_success(
-        self, mock_http_client, mock_token_manager
-    ):
-        """Test successful server ACL rule deletion."""
+    async def test_delete_success(self, mock_http_client, mock_token_manager):
         mock_http_client.delete.return_value = {}
 
         result = await delete_server_acl(
@@ -150,93 +589,369 @@ class TestDeleteServerAcl:
             token='test-token',
         )
 
-    @pytest.mark.asyncio
-    async def test_delete_server_acl_default_region(
-        self, mock_http_client, mock_token_manager
-    ):
-        """Test server ACL deletion with default region (auto-resolved to ap1)."""
-        mock_http_client.delete.return_value = {}
-
-        result = await delete_server_acl(
-            acl_id='acl-99',
-            workspace='testworkspace',
-        )
-
-        assert result['status'] == 'success'
-        assert result['acl_id'] == 'acl-99'
-        mock_http_client.delete.assert_called_once_with(
-            region='ap1',
-            workspace='testworkspace',
-            endpoint='/api/security/server-acl/acl-99/',
-            token='test-token',
-        )
-
 
 class TestBulkServerAcl:
-    """Test bulk_server_acl tool."""
-
     @pytest.mark.asyncio
-    async def test_bulk_server_acl_add_success(
+    async def test_bulk_add_uses_correct_endpoint(
         self, mock_http_client, mock_token_manager
     ):
-        """Test successful bulk add of server ACL entries."""
-        acl_entries = [
-            {'effect': 'allow', 'users': ['user-1'], 'servers': ['server-1']},
-            {'effect': 'allow', 'users': ['user-2'], 'servers': ['server-2']},
-        ]
-        mock_http_client.post.return_value = {'created': 2}
+        mock_http_client.post.return_value = [{'id': 'acl-1'}, {'id': 'acl-2'}]
 
         result = await bulk_server_acl(
             workspace='testworkspace',
             action='add',
-            acl_list=acl_entries,
+            server_ids=[SERVER_UUID, SERVER_UUID_2],
+            api_token_id='token-uuid',
             region='ap1',
         )
 
         assert result['status'] == 'success'
-        assert result['action'] == 'add'
         mock_http_client.post.assert_called_once_with(
             region='ap1',
             workspace='testworkspace',
             endpoint='/api/security/server-acl/bulk/',
             token='test-token',
-            data={'action': 'add', 'acls': acl_entries},
+            data={'servers': [SERVER_UUID, SERVER_UUID_2], 'token': 'token-uuid'},
         )
 
     @pytest.mark.asyncio
-    async def test_bulk_server_acl_remove_success(
+    async def test_bulk_remove_uses_delete_endpoint(
         self, mock_http_client, mock_token_manager
     ):
-        """Test successful bulk remove of server ACL entries."""
-        acl_entries = [{'id': 'acl-1'}, {'id': 'acl-2'}]
         mock_http_client.post.return_value = {'deleted': 2}
 
         result = await bulk_server_acl(
             workspace='testworkspace',
             action='remove',
-            acl_list=acl_entries,
+            server_ids=[SERVER_UUID, SERVER_UUID_2],
+            api_token_id='token-uuid',
             region='ap1',
         )
 
         assert result['status'] == 'success'
-        assert result['action'] == 'remove'
+        mock_http_client.post.assert_called_once_with(
+            region='ap1',
+            workspace='testworkspace',
+            endpoint='/api/security/server-acl/bulk/delete/',
+            token='test-token',
+            data={'servers': [SERVER_UUID, SERVER_UUID_2], 'token': 'token-uuid'},
+        )
+
+    @pytest.mark.asyncio
+    async def test_bulk_with_service_token(self, mock_http_client, mock_token_manager):
+        mock_http_client.post.return_value = [{'id': 'acl-1'}]
+
+        result = await bulk_server_acl(
+            workspace='testworkspace',
+            action='add',
+            server_ids=[SERVER_UUID],
+            service_token_id='svc-uuid',
+            region='ap1',
+        )
+
+        assert result['status'] == 'success'
         mock_http_client.post.assert_called_once_with(
             region='ap1',
             workspace='testworkspace',
             endpoint='/api/security/server-acl/bulk/',
             token='test-token',
-            data={'action': 'remove', 'acls': acl_entries},
+            data={'servers': [SERVER_UUID], 'service_token': 'svc-uuid'},
         )
 
     @pytest.mark.asyncio
-    async def test_bulk_server_acl_invalid_action_returns_error(
+    async def test_bulk_invalid_action_returns_error(
         self, mock_http_client, mock_token_manager
     ):
-        """Test that an invalid action returns an error without calling the API."""
         result = await bulk_server_acl(
             workspace='testworkspace',
             action='delete',
-            acl_list=[{'id': 'acl-1'}],
+            server_ids=[SERVER_UUID],
+            api_token_id='token-uuid',
+            region='ap1',
+        )
+
+        assert result['status'] == 'error'
+        mock_http_client.post.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_bulk_missing_token_returns_error(
+        self, mock_http_client, mock_token_manager
+    ):
+        result = await bulk_server_acl(
+            workspace='testworkspace',
+            action='add',
+            server_ids=[SERVER_UUID],
+            region='ap1',
+        )
+
+        assert result['status'] == 'error'
+        mock_http_client.post.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_bulk_both_tokens_returns_error(
+        self, mock_http_client, mock_token_manager
+    ):
+        result = await bulk_server_acl(
+            workspace='testworkspace',
+            action='add',
+            server_ids=[SERVER_UUID],
+            api_token_id='token-uuid',
+            service_token_id='svc-uuid',
+            region='ap1',
+        )
+
+        assert result['status'] == 'error'
+        mock_http_client.post.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_bulk_empty_server_ids_returns_error(
+        self, mock_http_client, mock_token_manager
+    ):
+        result = await bulk_server_acl(
+            workspace='testworkspace',
+            action='add',
+            server_ids=[],
+            api_token_id='token-uuid',
+            region='ap1',
+        )
+
+        assert result['status'] == 'error'
+        mock_http_client.post.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_bulk_over_100_server_ids_returns_error(
+        self, mock_http_client, mock_token_manager
+    ):
+        server_ids = [f'00000000-0000-4000-8000-{i:012d}' for i in range(101)]
+
+        result = await bulk_server_acl(
+            workspace='testworkspace',
+            action='add',
+            server_ids=server_ids,
+            api_token_id='token-uuid',
+            region='ap1',
+        )
+
+        assert result['status'] == 'error'
+        mock_http_client.post.assert_not_called()
+
+
+# ===============================
+# FileACL tests
+# ===============================
+
+
+class TestListFileAcls:
+    @pytest.mark.asyncio
+    async def test_list_no_filter(self, mock_http_client, mock_token_manager):
+        mock_http_client.get.return_value = {'results': [], 'count': 0}
+
+        result = await list_file_acls(workspace='testworkspace', region='ap1')
+
+        assert result['status'] == 'success'
+        mock_http_client.get.assert_called_once_with(
+            region='ap1',
+            workspace='testworkspace',
+            endpoint='/api/security/file-acl/',
+            token='test-token',
+            params={},
+        )
+
+    @pytest.mark.asyncio
+    async def test_list_filter_by_api_token(self, mock_http_client, mock_token_manager):
+        mock_http_client.get.return_value = {'results': []}
+
+        result = await list_file_acls(
+            workspace='testworkspace',
+            api_token_id='token-uuid',
+            page=1,
+            page_size=20,
+            region='ap1',
+        )
+
+        assert result['status'] == 'success'
+        mock_http_client.get.assert_called_once_with(
+            region='ap1',
+            workspace='testworkspace',
+            endpoint='/api/security/file-acl/',
+            token='test-token',
+            params={'api_token': 'token-uuid', 'page': 1, 'page_size': 20},
+        )
+
+    @pytest.mark.asyncio
+    async def test_list_filter_by_service_token(
+        self, mock_http_client, mock_token_manager
+    ):
+        mock_http_client.get.return_value = {'results': []}
+
+        result = await list_file_acls(
+            workspace='testworkspace',
+            service_token_id='svc-uuid',
+            page=2,
+            page_size=10,
+            region='ap1',
+        )
+
+        assert result['status'] == 'success'
+        mock_http_client.get.assert_called_once_with(
+            region='ap1',
+            workspace='testworkspace',
+            endpoint='/api/security/file-acl/',
+            token='test-token',
+            params={'service_token': 'svc-uuid', 'page': 2, 'page_size': 10},
+        )
+
+    @pytest.mark.asyncio
+    async def test_list_both_tokens_returns_error(
+        self, mock_http_client, mock_token_manager
+    ):
+        result = await list_file_acls(
+            workspace='testworkspace',
+            api_token_id='token-uuid',
+            service_token_id='svc-uuid',
+            region='ap1',
+        )
+
+        assert result['status'] == 'error'
+        mock_http_client.get.assert_not_called()
+
+
+class TestCreateFileAcl:
+    @pytest.mark.asyncio
+    async def test_create_upload_rule(self, mock_http_client, mock_token_manager):
+        mock_http_client.post.return_value = {
+            'id': 'acl-1',
+            'token': 'token-uuid',
+            'path': '/var/log/*',
+            'action': 'upload',
+            'username': '',
+            'groupname': '',
+        }
+
+        result = await create_file_acl(
+            workspace='testworkspace',
+            path='/var/log/*',
+            action='upload',
+            api_token_id='token-uuid',
+            region='ap1',
+        )
+
+        assert result['status'] == 'success'
+        mock_http_client.post.assert_called_once_with(
+            region='ap1',
+            workspace='testworkspace',
+            endpoint='/api/security/file-acl/',
+            token='test-token',
+            data={
+                'path': '/var/log/*',
+                'action': 'upload',
+                'username': '',
+                'groupname': '',
+                'token': 'token-uuid',
+            },
+        )
+
+    @pytest.mark.asyncio
+    async def test_create_wildcard_action(self, mock_http_client, mock_token_manager):
+        mock_http_client.post.return_value = {'id': 'acl-2'}
+
+        result = await create_file_acl(
+            workspace='testworkspace',
+            path='/home/deploy/*',
+            action='*',
+            api_token_id='token-uuid',
+            username='deploy',
+            groupname='*',
+            region='ap1',
+        )
+
+        assert result['status'] == 'success'
+        mock_http_client.post.assert_called_once_with(
+            region='ap1',
+            workspace='testworkspace',
+            endpoint='/api/security/file-acl/',
+            token='test-token',
+            data={
+                'path': '/home/deploy/*',
+                'action': '*',
+                'username': 'deploy',
+                'groupname': '*',
+                'token': 'token-uuid',
+            },
+        )
+
+    @pytest.mark.asyncio
+    async def test_create_with_service_token(
+        self, mock_http_client, mock_token_manager
+    ):
+        mock_http_client.post.return_value = {
+            'id': 'acl-3',
+            'service_token': 'svc-uuid',
+        }
+
+        result = await create_file_acl(
+            workspace='testworkspace',
+            path='/var/log/*',
+            action='download',
+            service_token_id='svc-uuid',
+            username='deploy',
+            region='ap1',
+        )
+
+        assert result['status'] == 'success'
+        mock_http_client.post.assert_called_once_with(
+            region='ap1',
+            workspace='testworkspace',
+            endpoint='/api/security/file-acl/',
+            token='test-token',
+            data={
+                'path': '/var/log/*',
+                'action': 'download',
+                'username': 'deploy',
+                'groupname': '',
+                'service_token': 'svc-uuid',
+            },
+        )
+
+    @pytest.mark.asyncio
+    async def test_create_invalid_action_returns_error(
+        self, mock_http_client, mock_token_manager
+    ):
+        result = await create_file_acl(
+            workspace='testworkspace',
+            path='/var/log/*',
+            action='delete',
+            api_token_id='token-uuid',
+            region='ap1',
+        )
+
+        assert result['status'] == 'error'
+        mock_http_client.post.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_create_missing_token_returns_error(
+        self, mock_http_client, mock_token_manager
+    ):
+        result = await create_file_acl(
+            workspace='testworkspace',
+            path='/var/log/*',
+            action='upload',
+            region='ap1',
+        )
+
+        assert result['status'] == 'error'
+        mock_http_client.post.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_create_both_tokens_returns_error(
+        self, mock_http_client, mock_token_manager
+    ):
+        result = await create_file_acl(
+            workspace='testworkspace',
+            path='/var/log/*',
+            action='upload',
+            api_token_id='token-uuid',
+            service_token_id='svc-uuid',
             region='ap1',
         )
 
@@ -245,52 +960,38 @@ class TestBulkServerAcl:
 
 
 class TestUpdateFileAcl:
-    """Test update_file_acl tool."""
-
     @pytest.mark.asyncio
-    async def test_update_file_acl_success(self, mock_http_client, mock_token_manager):
-        """Test successful file ACL rule update."""
-        mock_http_client.patch.return_value = {
-            'id': 'facl-1',
-            'effect': 'deny',
-            'file_pattern': '/etc/passwd',
-        }
+    async def test_update_path(self, mock_http_client, mock_token_manager):
+        mock_http_client.patch.return_value = {'id': 'acl-1', 'path': '/new/path/*'}
 
         result = await update_file_acl(
-            acl_id='facl-1',
+            acl_id='acl-1',
             workspace='testworkspace',
-            effect='deny',
-            file_pattern='/etc/passwd',
+            path='/new/path/*',
             region='ap1',
         )
 
         assert result['status'] == 'success'
-        assert result['acl_id'] == 'facl-1'
+        assert result['acl_id'] == 'acl-1'
         mock_http_client.patch.assert_called_once_with(
             region='ap1',
             workspace='testworkspace',
-            endpoint='/api/security/file-acl/facl-1/',
+            endpoint='/api/security/file-acl/acl-1/',
             token='test-token',
-            data={'effect': 'deny', 'file_pattern': '/etc/passwd'},
+            data={'path': '/new/path/*'},
         )
 
     @pytest.mark.asyncio
-    async def test_update_file_acl_with_all_fields(
+    async def test_update_action_and_username(
         self, mock_http_client, mock_token_manager
     ):
-        """Test file ACL update with all optional fields."""
-        mock_http_client.patch.return_value = {'id': 'facl-1'}
+        mock_http_client.patch.return_value = {'id': 'acl-1'}
 
         result = await update_file_acl(
-            acl_id='facl-1',
+            acl_id='acl-1',
             workspace='testworkspace',
-            effect='allow',
-            file_pattern='/var/log/*',
-            users=['user-1'],
-            groups=['group-1'],
-            servers=['server-1'],
-            description='Allow log access',
-            priority=5,
+            action='download',
+            username='root',
             region='ap1',
         )
 
@@ -298,26 +999,31 @@ class TestUpdateFileAcl:
         mock_http_client.patch.assert_called_once_with(
             region='ap1',
             workspace='testworkspace',
-            endpoint='/api/security/file-acl/facl-1/',
+            endpoint='/api/security/file-acl/acl-1/',
             token='test-token',
-            data={
-                'effect': 'allow',
-                'file_pattern': '/var/log/*',
-                'users': ['user-1'],
-                'groups': ['group-1'],
-                'servers': ['server-1'],
-                'description': 'Allow log access',
-                'priority': 5,
-            },
+            data={'action': 'download', 'username': 'root'},
         )
 
     @pytest.mark.asyncio
-    async def test_update_file_acl_no_data_returns_error(
+    async def test_update_invalid_action_returns_error(
         self, mock_http_client, mock_token_manager
     ):
-        """Test that updating with no fields returns an error."""
         result = await update_file_acl(
-            acl_id='facl-1',
+            acl_id='acl-1',
+            workspace='testworkspace',
+            action='write',
+            region='ap1',
+        )
+
+        assert result['status'] == 'error'
+        mock_http_client.patch.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_update_no_data_returns_error(
+        self, mock_http_client, mock_token_manager
+    ):
+        result = await update_file_acl(
+            acl_id='acl-1',
             workspace='testworkspace',
             region='ap1',
         )
@@ -327,45 +1033,21 @@ class TestUpdateFileAcl:
 
 
 class TestDeleteFileAcl:
-    """Test delete_file_acl tool."""
-
     @pytest.mark.asyncio
-    async def test_delete_file_acl_success(self, mock_http_client, mock_token_manager):
-        """Test successful file ACL rule deletion."""
+    async def test_delete_success(self, mock_http_client, mock_token_manager):
         mock_http_client.delete.return_value = {}
 
         result = await delete_file_acl(
-            acl_id='facl-1',
+            acl_id='acl-1',
             workspace='testworkspace',
             region='ap1',
         )
 
         assert result['status'] == 'success'
-        assert result['acl_id'] == 'facl-1'
+        assert result['acl_id'] == 'acl-1'
         mock_http_client.delete.assert_called_once_with(
             region='ap1',
             workspace='testworkspace',
-            endpoint='/api/security/file-acl/facl-1/',
-            token='test-token',
-        )
-
-    @pytest.mark.asyncio
-    async def test_delete_file_acl_default_region(
-        self, mock_http_client, mock_token_manager
-    ):
-        """Test file ACL deletion with default region (auto-resolved to ap1)."""
-        mock_http_client.delete.return_value = {}
-
-        result = await delete_file_acl(
-            acl_id='facl-42',
-            workspace='testworkspace',
-        )
-
-        assert result['status'] == 'success'
-        assert result['acl_id'] == 'facl-42'
-        mock_http_client.delete.assert_called_once_with(
-            region='ap1',
-            workspace='testworkspace',
-            endpoint='/api/security/file-acl/facl-42/',
+            endpoint='/api/security/file-acl/acl-1/',
             token='test-token',
         )

--- a/tests/test_security_tools.py
+++ b/tests/test_security_tools.py
@@ -228,6 +228,21 @@ class TestBulkServerAcl:
             data={'action': 'remove', 'acls': acl_entries},
         )
 
+    @pytest.mark.asyncio
+    async def test_bulk_server_acl_invalid_action_returns_error(
+        self, mock_http_client, mock_token_manager
+    ):
+        """Test that an invalid action returns an error without calling the API."""
+        result = await bulk_server_acl(
+            workspace='testworkspace',
+            action='delete',
+            acl_list=[{'id': 'acl-1'}],
+            region='ap1',
+        )
+
+        assert result['status'] == 'error'
+        mock_http_client.post.assert_not_called()
+
 
 class TestUpdateFileAcl:
     """Test update_file_acl tool."""

--- a/tests/test_security_tools.py
+++ b/tests/test_security_tools.py
@@ -42,11 +42,6 @@ SERVER_UUID = '7e3984de-49ab-4cc6-bcdf-21fbd35858b8'
 SERVER_UUID_2 = 'a1b2c3d4-e5f6-7890-abcd-ef1234567890'
 
 
-# ===============================
-# CommandACL tests
-# ===============================
-
-
 class TestListCommandAcls:
     @pytest.mark.asyncio
     async def test_list_no_filter(self, mock_http_client, mock_token_manager):
@@ -291,11 +286,6 @@ class TestDeleteCommandAcl:
             endpoint='/api/security/command-acl/acl-1/',
             token='test-token',
         )
-
-
-# ===============================
-# ServerACL tests
-# ===============================
 
 
 class TestListServerAcls:
@@ -758,11 +748,6 @@ class TestBulkServerAcl:
 
         assert result['status'] == 'error'
         mock_http_client.post.assert_not_called()
-
-
-# ===============================
-# FileACL tests
-# ===============================
 
 
 class TestListFileAcls:

--- a/tests/test_security_tools.py
+++ b/tests/test_security_tools.py
@@ -719,6 +719,30 @@ class TestBulkServerAcl:
         mock_http_client.post.assert_not_called()
 
     @pytest.mark.asyncio
+    async def test_bulk_exactly_100_server_ids_succeeds(
+        self, mock_http_client, mock_token_manager
+    ):
+        server_ids = [f'00000000-0000-4000-8000-{i:012d}' for i in range(100)]
+        mock_http_client.post.return_value = []
+
+        result = await bulk_server_acl(
+            workspace='testworkspace',
+            action='add',
+            server_ids=server_ids,
+            api_token_id='token-uuid',
+            region='ap1',
+        )
+
+        assert result['status'] == 'success'
+        mock_http_client.post.assert_called_once_with(
+            region='ap1',
+            workspace='testworkspace',
+            endpoint='/api/security/server-acl/bulk/',
+            token='test-token',
+            data={'servers': server_ids, 'token': 'token-uuid'},
+        )
+
+    @pytest.mark.asyncio
     async def test_bulk_over_100_server_ids_returns_error(
         self, mock_http_client, mock_token_manager
     ):

--- a/tools/security_tools.py
+++ b/tools/security_tools.py
@@ -428,3 +428,237 @@ async def create_file_acl(
     )
 
     return success_response(data=result, region=region, workspace=workspace)
+
+
+@mcp_tool_handler(
+    description='Update an existing server ACL rule. Related: list_server_acls (find rule ID), delete_server_acl (remove rule).',
+    annotations=IDEMPOTENT_WRITE,
+    meta={'anthropic/searchHint': 'server acl update modify'},
+)
+async def update_server_acl(
+    acl_id: str,
+    workspace: str,
+    effect: str | None = None,
+    users: list[str] | None = None,
+    groups: list[str] | None = None,
+    servers: list[str] | None = None,
+    description: str | None = None,
+    priority: int | None = None,
+    region: str = '',
+    **kwargs,
+) -> dict[str, Any]:
+    """Update an existing server ACL rule.
+
+    Args:
+        acl_id: Server ACL rule ID to update
+        workspace: Workspace name. Required parameter
+        effect: ACL effect - 'allow' or 'deny' (optional)
+        users: List of user IDs this rule applies to (optional)
+        groups: List of group IDs this rule applies to (optional)
+        servers: List of server IDs this rule applies to (optional)
+        description: Description of the ACL rule (optional)
+        priority: Rule priority (optional)
+        region: Region (ap1, us1, eu1). Auto-detected if not provided
+
+    Returns:
+        Server ACL update response
+    """
+    token = kwargs.get('token')
+
+    update_data: dict[str, Any] = {}
+    if effect is not None:
+        update_data['effect'] = effect
+    if users is not None:
+        update_data['users'] = users
+    if groups is not None:
+        update_data['groups'] = groups
+    if servers is not None:
+        update_data['servers'] = servers
+    if description is not None:
+        update_data['description'] = description
+    if priority is not None:
+        update_data['priority'] = priority
+
+    if not update_data:
+        return error_response('No update data provided')
+
+    result = await http_client.patch(
+        region=region,
+        workspace=workspace,
+        endpoint=f'/api/security/server-acl/{acl_id}/',
+        token=token,
+        data=update_data,
+    )
+
+    return success_response(
+        data=result, acl_id=acl_id, region=region, workspace=workspace
+    )
+
+
+@mcp_tool_handler(
+    description='Delete a server ACL rule permanently. Related: list_server_acls (find rule ID), update_server_acl (modify instead). Note: Cannot be undone.',
+    annotations=DESTRUCTIVE,
+    meta={'anthropic/searchHint': 'server acl delete remove'},
+)
+async def delete_server_acl(
+    acl_id: str, workspace: str, region: str = '', **kwargs
+) -> dict[str, Any]:
+    """Delete a server ACL rule.
+
+    Args:
+        acl_id: Server ACL rule ID to delete
+        workspace: Workspace name. Required parameter
+        region: Region (ap1, us1, eu1). Auto-detected if not provided
+
+    Returns:
+        Server ACL deletion response
+    """
+    token = kwargs.get('token')
+
+    result = await http_client.delete(
+        region=region,
+        workspace=workspace,
+        endpoint=f'/api/security/server-acl/{acl_id}/',
+        token=token,
+    )
+
+    return success_response(
+        data=result, acl_id=acl_id, region=region, workspace=workspace
+    )
+
+
+@mcp_tool_handler(
+    description='Bulk add or remove server ACL entries in a single operation. When to use: applying multiple server ACL changes at once. Related: list_server_acls (view existing), create_server_acl (single create).',
+    annotations=ADDITIVE,
+    meta={'anthropic/searchHint': 'server acl bulk add remove multiple'},
+)
+async def bulk_server_acl(
+    workspace: str,
+    action: str,
+    acl_list: list[dict],
+    region: str = '',
+    **kwargs,
+) -> dict[str, Any]:
+    """Bulk add or remove server ACL entries.
+
+    Args:
+        workspace: Workspace name. Required parameter
+        action: Bulk action - 'add' or 'remove'
+        acl_list: List of ACL entry dicts to add or remove
+        region: Region (ap1, us1, eu1). Auto-detected if not provided
+
+    Returns:
+        Bulk server ACL operation response
+    """
+    token = kwargs.get('token')
+
+    result = await http_client.post(
+        region=region,
+        workspace=workspace,
+        endpoint='/api/security/server-acl/bulk/',
+        token=token,
+        data={'action': action, 'acls': acl_list},
+    )
+
+    return success_response(data=result, action=action, region=region, workspace=workspace)
+
+
+@mcp_tool_handler(
+    description='Update an existing file ACL rule. Related: list_file_acls (find rule ID), delete_file_acl (remove rule).',
+    annotations=IDEMPOTENT_WRITE,
+    meta={'anthropic/searchHint': 'file acl update modify'},
+)
+async def update_file_acl(
+    acl_id: str,
+    workspace: str,
+    effect: str | None = None,
+    file_pattern: str | None = None,
+    users: list[str] | None = None,
+    groups: list[str] | None = None,
+    servers: list[str] | None = None,
+    description: str | None = None,
+    priority: int | None = None,
+    region: str = '',
+    **kwargs,
+) -> dict[str, Any]:
+    """Update an existing file ACL rule.
+
+    Args:
+        acl_id: File ACL rule ID to update
+        workspace: Workspace name. Required parameter
+        effect: ACL effect - 'allow' or 'deny' (optional)
+        file_pattern: File path pattern to match (optional)
+        users: List of user IDs this rule applies to (optional)
+        groups: List of group IDs this rule applies to (optional)
+        servers: List of server IDs this rule applies to (optional)
+        description: Description of the ACL rule (optional)
+        priority: Rule priority (optional)
+        region: Region (ap1, us1, eu1). Auto-detected if not provided
+
+    Returns:
+        File ACL update response
+    """
+    token = kwargs.get('token')
+
+    update_data: dict[str, Any] = {}
+    if effect is not None:
+        update_data['effect'] = effect
+    if file_pattern is not None:
+        update_data['file_pattern'] = file_pattern
+    if users is not None:
+        update_data['users'] = users
+    if groups is not None:
+        update_data['groups'] = groups
+    if servers is not None:
+        update_data['servers'] = servers
+    if description is not None:
+        update_data['description'] = description
+    if priority is not None:
+        update_data['priority'] = priority
+
+    if not update_data:
+        return error_response('No update data provided')
+
+    result = await http_client.patch(
+        region=region,
+        workspace=workspace,
+        endpoint=f'/api/security/file-acl/{acl_id}/',
+        token=token,
+        data=update_data,
+    )
+
+    return success_response(
+        data=result, acl_id=acl_id, region=region, workspace=workspace
+    )
+
+
+@mcp_tool_handler(
+    description='Delete a file ACL rule permanently. Related: list_file_acls (find rule ID), update_file_acl (modify instead). Note: Cannot be undone.',
+    annotations=DESTRUCTIVE,
+    meta={'anthropic/searchHint': 'file acl delete remove'},
+)
+async def delete_file_acl(
+    acl_id: str, workspace: str, region: str = '', **kwargs
+) -> dict[str, Any]:
+    """Delete a file ACL rule.
+
+    Args:
+        acl_id: File ACL rule ID to delete
+        workspace: Workspace name. Required parameter
+        region: Region (ap1, us1, eu1). Auto-detected if not provided
+
+    Returns:
+        File ACL deletion response
+    """
+    token = kwargs.get('token')
+
+    result = await http_client.delete(
+        region=region,
+        workspace=workspace,
+        endpoint=f'/api/security/file-acl/{acl_id}/',
+        token=token,
+    )
+
+    return success_response(
+        data=result, acl_id=acl_id, region=region, workspace=workspace
+    )

--- a/tools/security_tools.py
+++ b/tools/security_tools.py
@@ -7,6 +7,31 @@ from utils.decorators import mcp_tool_handler
 from utils.http_client import http_client
 from utils.tool_annotations import ADDITIVE, DESTRUCTIVE, IDEMPOTENT_WRITE, READ_ONLY
 
+def _build_acl_patch_data(
+    effect: str | None,
+    users: list[str] | None,
+    groups: list[str] | None,
+    servers: list[str] | None,
+    description: str | None,
+    priority: int | None,
+) -> dict[str, Any]:
+    """Build partial-update payload for any ACL type from the six shared fields."""
+    data: dict[str, Any] = {}
+    if effect is not None:
+        data['effect'] = effect
+    if users is not None:
+        data['users'] = users
+    if groups is not None:
+        data['groups'] = groups
+    if servers is not None:
+        data['servers'] = servers
+    if description is not None:
+        data['description'] = description
+    if priority is not None:
+        data['priority'] = priority
+    return data
+
+
 # ===============================
 # COMMAND ACL TOOLS
 # ===============================
@@ -153,21 +178,9 @@ async def update_command_acl(
     """
     token = kwargs.get('token')
 
-    update_data: dict[str, Any] = {}
-    if effect is not None:
-        update_data['effect'] = effect
+    update_data = _build_acl_patch_data(effect, users, groups, servers, description, priority)
     if command_pattern is not None:
         update_data['command_pattern'] = command_pattern
-    if users is not None:
-        update_data['users'] = users
-    if groups is not None:
-        update_data['groups'] = groups
-    if servers is not None:
-        update_data['servers'] = servers
-    if description is not None:
-        update_data['description'] = description
-    if priority is not None:
-        update_data['priority'] = priority
 
     if not update_data:
         return error_response('No update data provided')
@@ -356,19 +369,7 @@ async def update_server_acl(
     """
     token = kwargs.get('token')
 
-    update_data: dict[str, Any] = {}
-    if effect is not None:
-        update_data['effect'] = effect
-    if users is not None:
-        update_data['users'] = users
-    if groups is not None:
-        update_data['groups'] = groups
-    if servers is not None:
-        update_data['servers'] = servers
-    if description is not None:
-        update_data['description'] = description
-    if priority is not None:
-        update_data['priority'] = priority
+    update_data = _build_acl_patch_data(effect, users, groups, servers, description, priority)
 
     if not update_data:
         return error_response('No update data provided')
@@ -605,21 +606,9 @@ async def update_file_acl(
     """
     token = kwargs.get('token')
 
-    update_data: dict[str, Any] = {}
-    if effect is not None:
-        update_data['effect'] = effect
+    update_data = _build_acl_patch_data(effect, users, groups, servers, description, priority)
     if file_pattern is not None:
         update_data['file_pattern'] = file_pattern
-    if users is not None:
-        update_data['users'] = users
-    if groups is not None:
-        update_data['groups'] = groups
-    if servers is not None:
-        update_data['servers'] = servers
-    if description is not None:
-        update_data['description'] = description
-    if priority is not None:
-        update_data['priority'] = priority
 
     if not update_data:
         return error_response('No update data provided')

--- a/tools/security_tools.py
+++ b/tools/security_tools.py
@@ -7,7 +7,8 @@ from utils.decorators import mcp_tool_handler
 from utils.http_client import http_client
 from utils.tool_annotations import ADDITIVE, DESTRUCTIVE, IDEMPOTENT_WRITE, READ_ONLY
 
-VALID_BULK_ACTIONS = frozenset({'add', 'remove'})
+VALID_BULK_ACTIONS = ('add', 'remove')
+_BULK_ACTIONS_STR = ', '.join(f"'{a}'" for a in VALID_BULK_ACTIONS)
 VALID_FILE_ACL_ACTIONS = ('upload', 'download', '*')
 _FILE_ACL_ACTIONS_STR = ', '.join(f"'{a}'" for a in VALID_FILE_ACL_ACTIONS)
 
@@ -163,8 +164,8 @@ async def update_command_acl(
         acl_id: Command ACL rule ID to update
         workspace: Workspace name. Required parameter
         command: Command pattern to allow (optional)
-        username: System username restriction (optional)
-        groupname: System groupname restriction (optional)
+        username: System username restriction. Pass '' explicitly to clear an existing restriction; omit to leave unchanged (optional)
+        groupname: System groupname restriction. Pass '' explicitly to clear an existing restriction; omit to leave unchanged (optional)
         region: Region (ap1, us1, eu1). Auto-detected if not provided
 
     Returns:
@@ -434,6 +435,7 @@ async def delete_server_acl(
 
 @mcp_tool_handler(
     description='Bulk add or remove server ACL entries for multiple servers in a single operation. When to use: applying the same token access to many servers at once. Related: list_server_acls (view existing), create_server_acl (single create).',
+    # Annotations are fixed at decorator-time; the destructive 'remove' path dominates.
     annotations=DESTRUCTIVE,
     meta={'anthropic/searchHint': 'server acl bulk add remove multiple'},
 )
@@ -462,7 +464,9 @@ async def bulk_server_acl(
         Bulk server ACL operation response
     """
     if action not in VALID_BULK_ACTIONS:
-        return error_response(f"Invalid action '{action}'. Must be 'add' or 'remove'.")
+        return error_response(
+            f"Invalid action '{action}'. Must be one of: {_BULK_ACTIONS_STR}."
+        )
     if not server_ids:
         return error_response('server_ids must not be empty')
     if len(server_ids) > _BULK_MAX_SERVERS:
@@ -647,8 +651,8 @@ async def update_file_acl(
         workspace: Workspace name. Required parameter
         path: New file path pattern (optional)
         action: New allowed action - 'upload', 'download', or '*' (optional)
-        username: System username restriction (optional)
-        groupname: System groupname restriction (optional)
+        username: System username restriction. Pass '' explicitly to clear an existing restriction; omit to leave unchanged (optional)
+        groupname: System groupname restriction. Pass '' explicitly to clear an existing restriction; omit to leave unchanged (optional)
         region: Region (ap1, us1, eu1). Auto-detected if not provided
 
     Returns:

--- a/tools/security_tools.py
+++ b/tools/security_tools.py
@@ -25,11 +25,6 @@ _BOTH_TOKENS_ERROR = 'Provide either api_token_id or service_token_id, not both'
 _TOKEN_REQUIRED_ERROR = 'Either api_token_id or service_token_id must be provided'
 
 
-# ===============================
-# COMMAND ACL TOOLS
-# ===============================
-
-
 @mcp_tool_handler(
     description='List command ACL rules that control which commands can be executed. When to use: checking command execution permissions or debugging 403 errors from execute_command. Related: create_command_acl (add rules), list_server_acls (server access rules), list_file_acls (file access rules).',
     annotations=READ_ONLY,
@@ -227,11 +222,6 @@ async def delete_command_acl(
     return success_response(
         data=result, acl_id=acl_id, region=region, workspace=workspace
     )
-
-
-# ===============================
-# SERVER ACL TOOLS
-# ===============================
 
 
 @mcp_tool_handler(
@@ -499,11 +489,6 @@ async def bulk_server_acl(
     return success_response(
         data=result, action=action, region=region, workspace=workspace
     )
-
-
-# ===============================
-# FILE ACL TOOLS
-# ===============================
 
 
 @mcp_tool_handler(

--- a/tools/security_tools.py
+++ b/tools/security_tools.py
@@ -7,29 +7,21 @@ from utils.decorators import mcp_tool_handler
 from utils.http_client import http_client
 from utils.tool_annotations import ADDITIVE, DESTRUCTIVE, IDEMPOTENT_WRITE, READ_ONLY
 
-def _build_acl_patch_data(
-    effect: str | None,
-    users: list[str] | None,
-    groups: list[str] | None,
-    servers: list[str] | None,
-    description: str | None,
-    priority: int | None,
-) -> dict[str, Any]:
-    """Build partial-update payload for any ACL type from the six shared fields."""
-    data: dict[str, Any] = {}
-    if effect is not None:
-        data['effect'] = effect
-    if users is not None:
-        data['users'] = users
-    if groups is not None:
-        data['groups'] = groups
-    if servers is not None:
-        data['servers'] = servers
-    if description is not None:
-        data['description'] = description
-    if priority is not None:
-        data['priority'] = priority
-    return data
+VALID_BULK_ACTIONS = frozenset({'add', 'remove'})
+VALID_FILE_ACL_ACTIONS = ('upload', 'download', '*')
+_FILE_ACL_ACTIONS_STR = ', '.join(f"'{a}'" for a in VALID_FILE_ACL_ACTIONS)
+
+_API_COMMAND_ACL = '/api/security/command-acl/'
+_API_SERVER_ACL = '/api/security/server-acl/'
+_API_FILE_ACL = '/api/security/file-acl/'
+_API_SERVER_ACL_BULK = f'{_API_SERVER_ACL}bulk/'
+_API_SERVER_ACL_BULK_DELETE = f'{_API_SERVER_ACL}bulk/delete/'
+
+# Mirrors the server-side bulk serializer cap (servers list max_length=100)
+_BULK_MAX_SERVERS = 100
+
+_BOTH_TOKENS_ERROR = 'Provide either api_token_id or service_token_id, not both'
+_TOKEN_REQUIRED_ERROR = 'Either api_token_id or service_token_id must be provided'
 
 
 # ===============================
@@ -45,6 +37,8 @@ def _build_acl_patch_data(
 async def list_command_acls(
     workspace: str,
     region: str = '',
+    api_token_id: str | None = None,
+    service_token_id: str | None = None,
     page: int | None = None,
     page_size: int | None = None,
     **kwargs,
@@ -54,15 +48,24 @@ async def list_command_acls(
     Args:
         workspace: Workspace name. Required parameter
         region: Region (ap1, us1, eu1). Auto-detected if not provided
+        api_token_id: Filter by API token ID (optional)
+        service_token_id: Filter by service token ID (optional)
         page: Page number for pagination (optional)
         page_size: Number of items per page (optional)
 
     Returns:
         Command ACL rules list response
     """
+    if api_token_id is not None and service_token_id is not None:
+        return error_response(_BOTH_TOKENS_ERROR)
+
     token = kwargs.get('token')
 
-    params = {}
+    params: dict[str, Any] = {}
+    if api_token_id is not None:
+        params['api_token'] = api_token_id
+    if service_token_id is not None:
+        params['service_token'] = service_token_id
     if page is not None:
         params['page'] = page
     if page_size is not None:
@@ -71,7 +74,7 @@ async def list_command_acls(
     result = await http_client.get(
         region=region,
         workspace=workspace,
-        endpoint='/api/security/command-acl/',
+        endpoint=_API_COMMAND_ACL,
         token=token,
         params=params,
     )
@@ -80,60 +83,57 @@ async def list_command_acls(
 
 
 @mcp_tool_handler(
-    description='Create a command ACL rule to allow or deny command execution. When to use: granting or restricting command execution permissions. Related: list_command_acls (view existing), update_command_acl (modify), delete_command_acl (remove). Note: Higher priority values take precedence.',
+    description='Create a command ACL rule to allow a token to execute specific commands. When to use: granting command execution permissions to an API or service token. Related: list_command_acls (view existing), update_command_acl (modify), delete_command_acl (remove).',
     annotations=ADDITIVE,
     meta={'anthropic/searchHint': 'command acl create permission allow deny'},
 )
 async def create_command_acl(
     workspace: str,
-    effect: str,
-    command_pattern: str,
-    users: list[str] | None = None,
-    groups: list[str] | None = None,
-    servers: list[str] | None = None,
-    description: str | None = None,
-    priority: int | None = None,
+    command: str,
+    api_token_id: str | None = None,
+    service_token_id: str | None = None,
+    username: str = '',
+    groupname: str = '',
     region: str = '',
     **kwargs,
 ) -> dict[str, Any]:
     """Create a command ACL rule.
 
+    Exactly one of api_token_id or service_token_id must be provided.
+
     Args:
         workspace: Workspace name. Required parameter
-        effect: ACL effect - 'allow' or 'deny'
-        command_pattern: Command pattern to match (e.g., 'rm -rf *', 'sudo *')
-        users: List of user IDs this rule applies to (optional)
-        groups: List of group IDs this rule applies to (optional)
-        servers: List of server IDs this rule applies to (optional)
-        description: Description of the ACL rule (optional)
-        priority: Rule priority - higher values take precedence (optional)
+        command: Command pattern to allow (e.g., 'docker *', 'ls -la'). Wildcards (*) supported
+        api_token_id: API token ID this rule applies to (mutually exclusive with service_token_id)
+        service_token_id: Service token ID this rule applies to (mutually exclusive with api_token_id)
+        username: System username restriction. Empty = token owner only, '*' = any user (optional)
+        groupname: System groupname restriction. Empty = no restriction (any group), exact name to restrict (optional)
         region: Region (ap1, us1, eu1). Auto-detected if not provided
 
     Returns:
         Command ACL creation response
     """
+    if api_token_id is None and service_token_id is None:
+        return error_response(_TOKEN_REQUIRED_ERROR)
+    if api_token_id is not None and service_token_id is not None:
+        return error_response(_BOTH_TOKENS_ERROR)
+
     token = kwargs.get('token')
 
     acl_data: dict[str, Any] = {
-        'effect': effect,
-        'command_pattern': command_pattern,
+        'command': command,
+        'username': username,
+        'groupname': groupname,
     }
-
-    if users is not None:
-        acl_data['users'] = users
-    if groups is not None:
-        acl_data['groups'] = groups
-    if servers is not None:
-        acl_data['servers'] = servers
-    if description is not None:
-        acl_data['description'] = description
-    if priority is not None:
-        acl_data['priority'] = priority
+    if api_token_id is not None:
+        acl_data['token'] = api_token_id
+    else:
+        acl_data['service_token'] = service_token_id
 
     result = await http_client.post(
         region=region,
         workspace=workspace,
-        endpoint='/api/security/command-acl/',
+        endpoint=_API_COMMAND_ACL,
         token=token,
         data=acl_data,
     )
@@ -142,35 +142,29 @@ async def create_command_acl(
 
 
 @mcp_tool_handler(
-    description='Update an existing command ACL rule. Related: list_command_acls (find rule ID).',
+    description='Update an existing command ACL rule. Related: list_command_acls (find rule ID), delete_command_acl (remove rule).',
     annotations=IDEMPOTENT_WRITE,
     meta={'anthropic/searchHint': 'command acl update modify'},
 )
 async def update_command_acl(
     acl_id: str,
     workspace: str,
-    effect: str | None = None,
-    command_pattern: str | None = None,
-    users: list[str] | None = None,
-    groups: list[str] | None = None,
-    servers: list[str] | None = None,
-    description: str | None = None,
-    priority: int | None = None,
+    command: str | None = None,
+    username: str | None = None,
+    groupname: str | None = None,
     region: str = '',
     **kwargs,
 ) -> dict[str, Any]:
     """Update an existing command ACL rule.
 
+    Note: This tool does not support changing the token binding. Delete and recreate to rebind to a different token.
+
     Args:
         acl_id: Command ACL rule ID to update
         workspace: Workspace name. Required parameter
-        effect: ACL effect - 'allow' or 'deny' (optional)
-        command_pattern: Command pattern to match (optional)
-        users: List of user IDs this rule applies to (optional)
-        groups: List of group IDs this rule applies to (optional)
-        servers: List of server IDs this rule applies to (optional)
-        description: Description of the ACL rule (optional)
-        priority: Rule priority (optional)
+        command: Command pattern to allow (optional)
+        username: System username restriction (optional)
+        groupname: System groupname restriction (optional)
         region: Region (ap1, us1, eu1). Auto-detected if not provided
 
     Returns:
@@ -178,9 +172,13 @@ async def update_command_acl(
     """
     token = kwargs.get('token')
 
-    update_data = _build_acl_patch_data(effect, users, groups, servers, description, priority)
-    if command_pattern is not None:
-        update_data['command_pattern'] = command_pattern
+    update_data: dict[str, Any] = {}
+    if command is not None:
+        update_data['command'] = command
+    if username is not None:
+        update_data['username'] = username
+    if groupname is not None:
+        update_data['groupname'] = groupname
 
     if not update_data:
         return error_response('No update data provided')
@@ -188,7 +186,7 @@ async def update_command_acl(
     result = await http_client.patch(
         region=region,
         workspace=workspace,
-        endpoint=f'/api/security/command-acl/{acl_id}/',
+        endpoint=f'{_API_COMMAND_ACL}{acl_id}/',
         token=token,
         data=update_data,
     )
@@ -221,7 +219,7 @@ async def delete_command_acl(
     result = await http_client.delete(
         region=region,
         workspace=workspace,
-        endpoint=f'/api/security/command-acl/{acl_id}/',
+        endpoint=f'{_API_COMMAND_ACL}{acl_id}/',
         token=token,
     )
 
@@ -236,13 +234,15 @@ async def delete_command_acl(
 
 
 @mcp_tool_handler(
-    description='List server ACL rules that control which users can access which servers. When to use: checking server access permissions. Related: create_server_acl, list_command_acls (command permissions), list_file_acls (file permissions).',
+    description='List server ACL rules that control which servers a token can access. When to use: checking server access permissions. Related: create_server_acl, list_command_acls (command permissions), list_file_acls (file permissions).',
     annotations=READ_ONLY,
     meta={'anthropic/searchHint': 'server acl access permission rules'},
 )
 async def list_server_acls(
     workspace: str,
     region: str = '',
+    api_token_id: str | None = None,
+    service_token_id: str | None = None,
     page: int | None = None,
     page_size: int | None = None,
     **kwargs,
@@ -252,15 +252,24 @@ async def list_server_acls(
     Args:
         workspace: Workspace name. Required parameter
         region: Region (ap1, us1, eu1). Auto-detected if not provided
+        api_token_id: Filter by API token ID (optional)
+        service_token_id: Filter by service token ID (optional)
         page: Page number for pagination (optional)
         page_size: Number of items per page (optional)
 
     Returns:
         Server ACL rules list response
     """
+    if api_token_id is not None and service_token_id is not None:
+        return error_response(_BOTH_TOKENS_ERROR)
+
     token = kwargs.get('token')
 
-    params = {}
+    params: dict[str, Any] = {}
+    if api_token_id is not None:
+        params['api_token'] = api_token_id
+    if service_token_id is not None:
+        params['service_token'] = service_token_id
     if page is not None:
         params['page'] = page
     if page_size is not None:
@@ -269,7 +278,7 @@ async def list_server_acls(
     result = await http_client.get(
         region=region,
         workspace=workspace,
-        endpoint='/api/security/server-acl/',
+        endpoint=_API_SERVER_ACL,
         token=token,
         params=params,
     )
@@ -278,55 +287,50 @@ async def list_server_acls(
 
 
 @mcp_tool_handler(
-    description='Create a server ACL rule to control server access. When to use: granting or restricting server access for users or groups. Related: list_server_acls (view existing). Note: Higher priority values take precedence.',
+    description='Create a server ACL rule granting a token access to a specific server. When to use: allowing an API or service token to execute commands on a server. Related: list_server_acls (view existing), bulk_server_acl (add multiple at once).',
     annotations=ADDITIVE,
-    meta={'anthropic/searchHint': 'server acl create permission allow deny'},
+    meta={'anthropic/searchHint': 'server acl create permission allow access'},
 )
 async def create_server_acl(
     workspace: str,
-    effect: str,
-    users: list[str] | None = None,
-    groups: list[str] | None = None,
-    servers: list[str] | None = None,
-    description: str | None = None,
-    priority: int | None = None,
+    server_id: str,
+    api_token_id: str | None = None,
+    service_token_id: str | None = None,
     region: str = '',
     **kwargs,
 ) -> dict[str, Any]:
     """Create a server ACL rule.
 
+    Exactly one of api_token_id or service_token_id must be provided.
+    Each rule grants the token access to exactly one server.
+
     Args:
         workspace: Workspace name. Required parameter
-        effect: ACL effect - 'allow' or 'deny'
-        users: List of user IDs this rule applies to (optional)
-        groups: List of group IDs this rule applies to (optional)
-        servers: List of server IDs this rule applies to (optional)
-        description: Description of the ACL rule (optional)
-        priority: Rule priority - higher values take precedence (optional)
+        server_id: Server UUID to grant access to
+        api_token_id: API token ID to grant access (mutually exclusive with service_token_id)
+        service_token_id: Service token ID to grant access (mutually exclusive with api_token_id)
         region: Region (ap1, us1, eu1). Auto-detected if not provided
 
     Returns:
         Server ACL creation response
     """
+    if api_token_id is None and service_token_id is None:
+        return error_response(_TOKEN_REQUIRED_ERROR)
+    if api_token_id is not None and service_token_id is not None:
+        return error_response(_BOTH_TOKENS_ERROR)
+
     token = kwargs.get('token')
 
-    acl_data: dict[str, Any] = {'effect': effect}
-
-    if users is not None:
-        acl_data['users'] = users
-    if groups is not None:
-        acl_data['groups'] = groups
-    if servers is not None:
-        acl_data['servers'] = servers
-    if description is not None:
-        acl_data['description'] = description
-    if priority is not None:
-        acl_data['priority'] = priority
+    acl_data: dict[str, Any] = {'server': server_id}
+    if api_token_id is not None:
+        acl_data['token'] = api_token_id
+    else:
+        acl_data['service_token'] = service_token_id
 
     result = await http_client.post(
         region=region,
         workspace=workspace,
-        endpoint='/api/security/server-acl/',
+        endpoint=_API_SERVER_ACL,
         token=token,
         data=acl_data,
     )
@@ -335,41 +339,50 @@ async def create_server_acl(
 
 
 @mcp_tool_handler(
-    description='Update an existing server ACL rule. Related: list_server_acls (find rule ID), delete_server_acl (remove rule). Note: Higher priority values take precedence.',
+    description='Update an existing server ACL rule. Related: list_server_acls (find rule ID), delete_server_acl (remove rule).',
     annotations=IDEMPOTENT_WRITE,
     meta={'anthropic/searchHint': 'server acl update modify'},
 )
 async def update_server_acl(
     acl_id: str,
     workspace: str,
-    effect: str | None = None,
-    users: list[str] | None = None,
-    groups: list[str] | None = None,
-    servers: list[str] | None = None,
-    description: str | None = None,
-    priority: int | None = None,
+    server_id: str | None = None,
+    api_token_id: str | None = None,
+    service_token_id: str | None = None,
     region: str = '',
     **kwargs,
 ) -> dict[str, Any]:
     """Update an existing server ACL rule.
 
+    Note: Token binding can be updated by providing api_token_id or service_token_id.
+
     Args:
         acl_id: Server ACL rule ID to update
         workspace: Workspace name. Required parameter
-        effect: ACL effect - 'allow' or 'deny' (optional)
-        users: List of user IDs this rule applies to (optional)
-        groups: List of group IDs this rule applies to (optional)
-        servers: List of server IDs this rule applies to (optional)
-        description: Description of the ACL rule (optional)
-        priority: Rule priority (optional)
+        server_id: New server UUID (optional)
+        api_token_id: New API token ID to rebind this rule to (optional)
+        service_token_id: New service token ID to rebind this rule to (optional)
         region: Region (ap1, us1, eu1). Auto-detected if not provided
 
     Returns:
         Server ACL update response
     """
+    if api_token_id is not None and service_token_id is not None:
+        return error_response(_BOTH_TOKENS_ERROR)
+
     token = kwargs.get('token')
 
-    update_data = _build_acl_patch_data(effect, users, groups, servers, description, priority)
+    update_data: dict[str, Any] = {}
+    if server_id is not None:
+        update_data['server'] = server_id
+    # When rebinding, null the opposing field explicitly: the server enforces
+    # exactly-one-token-type, and PATCH keeps the old binding otherwise.
+    if api_token_id is not None:
+        update_data['token'] = api_token_id
+        update_data['service_token'] = None
+    if service_token_id is not None:
+        update_data['service_token'] = service_token_id
+        update_data['token'] = None
 
     if not update_data:
         return error_response('No update data provided')
@@ -377,7 +390,7 @@ async def update_server_acl(
     result = await http_client.patch(
         region=region,
         workspace=workspace,
-        endpoint=f'/api/security/server-acl/{acl_id}/',
+        endpoint=f'{_API_SERVER_ACL}{acl_id}/',
         token=token,
         data=update_data,
     )
@@ -410,7 +423,7 @@ async def delete_server_acl(
     result = await http_client.delete(
         region=region,
         workspace=workspace,
-        endpoint=f'/api/security/server-acl/{acl_id}/',
+        endpoint=f'{_API_SERVER_ACL}{acl_id}/',
         token=token,
     )
 
@@ -420,44 +433,68 @@ async def delete_server_acl(
 
 
 @mcp_tool_handler(
-    description='Bulk add or remove server ACL entries in a single operation. When to use: applying multiple server ACL changes at once. Related: list_server_acls (view existing), create_server_acl (single create).',
+    description='Bulk add or remove server ACL entries for multiple servers in a single operation. When to use: applying the same token access to many servers at once. Related: list_server_acls (view existing), create_server_acl (single create).',
     annotations=DESTRUCTIVE,
     meta={'anthropic/searchHint': 'server acl bulk add remove multiple'},
 )
 async def bulk_server_acl(
     workspace: str,
     action: str,
-    acl_list: list[dict],
+    server_ids: list[str],
+    api_token_id: str | None = None,
+    service_token_id: str | None = None,
     region: str = '',
     **kwargs,
 ) -> dict[str, Any]:
     """Bulk add or remove server ACL entries.
 
+    Exactly one of api_token_id or service_token_id must be provided.
+
     Args:
         workspace: Workspace name. Required parameter
-        action: Bulk action - 'add' or 'remove'
-        acl_list: List of ACL entry dicts.
-                  For action='add': each dict should contain keys matching create_server_acl fields (effect, users, groups, servers, etc.).
-                  For action='remove': each dict should contain key 'id' (ACL rule ID to remove).
+        action: Bulk action - 'add' (grant access) or 'remove' (revoke access)
+        server_ids: List of server UUIDs to add or remove access for (1-100 items)
+        api_token_id: API token ID to operate on (mutually exclusive with service_token_id)
+        service_token_id: Service token ID to operate on (mutually exclusive with api_token_id)
         region: Region (ap1, us1, eu1). Auto-detected if not provided
 
     Returns:
         Bulk server ACL operation response
     """
-    if action not in ('add', 'remove'):
+    if action not in VALID_BULK_ACTIONS:
         return error_response(f"Invalid action '{action}'. Must be 'add' or 'remove'.")
+    if not server_ids:
+        return error_response('server_ids must not be empty')
+    if len(server_ids) > _BULK_MAX_SERVERS:
+        return error_response(
+            f'server_ids must contain at most {_BULK_MAX_SERVERS} items'
+        )
+    if api_token_id is None and service_token_id is None:
+        return error_response(_TOKEN_REQUIRED_ERROR)
+    if api_token_id is not None and service_token_id is not None:
+        return error_response(_BOTH_TOKENS_ERROR)
 
     token = kwargs.get('token')
+
+    body: dict[str, Any] = {'servers': server_ids}
+    if api_token_id is not None:
+        body['token'] = api_token_id
+    else:
+        body['service_token'] = service_token_id
+
+    endpoint = _API_SERVER_ACL_BULK if action == 'add' else _API_SERVER_ACL_BULK_DELETE
 
     result = await http_client.post(
         region=region,
         workspace=workspace,
-        endpoint='/api/security/server-acl/bulk/',
+        endpoint=endpoint,
         token=token,
-        data={'action': action, 'acls': acl_list},
+        data=body,
     )
 
-    return success_response(data=result, action=action, region=region, workspace=workspace)
+    return success_response(
+        data=result, action=action, region=region, workspace=workspace
+    )
 
 
 # ===============================
@@ -473,6 +510,8 @@ async def bulk_server_acl(
 async def list_file_acls(
     workspace: str,
     region: str = '',
+    api_token_id: str | None = None,
+    service_token_id: str | None = None,
     page: int | None = None,
     page_size: int | None = None,
     **kwargs,
@@ -482,15 +521,24 @@ async def list_file_acls(
     Args:
         workspace: Workspace name. Required parameter
         region: Region (ap1, us1, eu1). Auto-detected if not provided
+        api_token_id: Filter by API token ID (optional)
+        service_token_id: Filter by service token ID (optional)
         page: Page number for pagination (optional)
         page_size: Number of items per page (optional)
 
     Returns:
         File ACL rules list response
     """
+    if api_token_id is not None and service_token_id is not None:
+        return error_response(_BOTH_TOKENS_ERROR)
+
     token = kwargs.get('token')
 
-    params = {}
+    params: dict[str, Any] = {}
+    if api_token_id is not None:
+        params['api_token'] = api_token_id
+    if service_token_id is not None:
+        params['service_token'] = service_token_id
     if page is not None:
         params['page'] = page
     if page_size is not None:
@@ -499,7 +547,7 @@ async def list_file_acls(
     result = await http_client.get(
         region=region,
         workspace=workspace,
-        endpoint='/api/security/file-acl/',
+        endpoint=_API_FILE_ACL,
         token=token,
         params=params,
     )
@@ -508,60 +556,66 @@ async def list_file_acls(
 
 
 @mcp_tool_handler(
-    description='Create a file ACL rule to control file access. When to use: granting or restricting file transfer permissions for specific paths. Related: list_file_acls (view existing). Note: Higher priority values take precedence.',
+    description='Create a file ACL rule to control file upload/download access. When to use: granting or restricting file transfer permissions for specific paths. Related: list_file_acls (view existing), update_file_acl (modify), delete_file_acl (remove).',
     annotations=ADDITIVE,
-    meta={'anthropic/searchHint': 'file acl create permission allow deny'},
+    meta={
+        'anthropic/searchHint': 'file acl create permission allow deny path upload download'
+    },
 )
 async def create_file_acl(
     workspace: str,
-    effect: str,
-    file_pattern: str,
-    users: list[str] | None = None,
-    groups: list[str] | None = None,
-    servers: list[str] | None = None,
-    description: str | None = None,
-    priority: int | None = None,
+    path: str,
+    action: str,
+    api_token_id: str | None = None,
+    service_token_id: str | None = None,
+    username: str = '',
+    groupname: str = '',
     region: str = '',
     **kwargs,
 ) -> dict[str, Any]:
     """Create a file ACL rule.
 
+    Exactly one of api_token_id or service_token_id must be provided.
+
     Args:
         workspace: Workspace name. Required parameter
-        effect: ACL effect - 'allow' or 'deny'
-        file_pattern: File path pattern to match (e.g., '/etc/passwd', '/var/log/*')
-        users: List of user IDs this rule applies to (optional)
-        groups: List of group IDs this rule applies to (optional)
-        servers: List of server IDs this rule applies to (optional)
-        description: Description of the ACL rule (optional)
-        priority: Rule priority - higher values take precedence (optional)
+        path: File path pattern to match (e.g., '/etc/nginx/*', '/var/log/*.log'). Wildcards (*) supported
+        action: Allowed action - 'upload', 'download', or '*' (both)
+        api_token_id: API token ID this rule applies to (mutually exclusive with service_token_id)
+        service_token_id: Service token ID this rule applies to (mutually exclusive with api_token_id)
+        username: System username restriction. Empty = token owner only, '*' = any user (optional)
+        groupname: System groupname restriction. Empty = no restriction (any group), exact name to restrict (optional)
         region: Region (ap1, us1, eu1). Auto-detected if not provided
 
     Returns:
         File ACL creation response
     """
+    if action not in VALID_FILE_ACL_ACTIONS:
+        return error_response(
+            f"Invalid action '{action}'. Must be one of: {_FILE_ACL_ACTIONS_STR}."
+        )
+    if api_token_id is None and service_token_id is None:
+        return error_response(_TOKEN_REQUIRED_ERROR)
+    if api_token_id is not None and service_token_id is not None:
+        return error_response(_BOTH_TOKENS_ERROR)
+
     token = kwargs.get('token')
 
     acl_data: dict[str, Any] = {
-        'effect': effect,
-        'file_pattern': file_pattern,
+        'path': path,
+        'action': action,
+        'username': username,
+        'groupname': groupname,
     }
-
-    if users is not None:
-        acl_data['users'] = users
-    if groups is not None:
-        acl_data['groups'] = groups
-    if servers is not None:
-        acl_data['servers'] = servers
-    if description is not None:
-        acl_data['description'] = description
-    if priority is not None:
-        acl_data['priority'] = priority
+    if api_token_id is not None:
+        acl_data['token'] = api_token_id
+    else:
+        acl_data['service_token'] = service_token_id
 
     result = await http_client.post(
         region=region,
         workspace=workspace,
-        endpoint='/api/security/file-acl/',
+        endpoint=_API_FILE_ACL,
         token=token,
         data=acl_data,
     )
@@ -570,45 +624,52 @@ async def create_file_acl(
 
 
 @mcp_tool_handler(
-    description='Update an existing file ACL rule. Related: list_file_acls (find rule ID), delete_file_acl (remove rule). Note: Higher priority values take precedence.',
+    description='Update an existing file ACL rule. Related: list_file_acls (find rule ID), delete_file_acl (remove rule).',
     annotations=IDEMPOTENT_WRITE,
-    meta={'anthropic/searchHint': 'file acl update modify'},
+    meta={'anthropic/searchHint': 'file acl update modify path action'},
 )
 async def update_file_acl(
     acl_id: str,
     workspace: str,
-    effect: str | None = None,
-    file_pattern: str | None = None,
-    users: list[str] | None = None,
-    groups: list[str] | None = None,
-    servers: list[str] | None = None,
-    description: str | None = None,
-    priority: int | None = None,
+    path: str | None = None,
+    action: str | None = None,
+    username: str | None = None,
+    groupname: str | None = None,
     region: str = '',
     **kwargs,
 ) -> dict[str, Any]:
     """Update an existing file ACL rule.
 
+    Note: This tool does not support changing the token binding. Delete and recreate to rebind to a different token.
+
     Args:
         acl_id: File ACL rule ID to update
         workspace: Workspace name. Required parameter
-        effect: ACL effect - 'allow' or 'deny' (optional)
-        file_pattern: File path pattern to match (optional)
-        users: List of user IDs this rule applies to (optional)
-        groups: List of group IDs this rule applies to (optional)
-        servers: List of server IDs this rule applies to (optional)
-        description: Description of the ACL rule (optional)
-        priority: Rule priority (optional)
+        path: New file path pattern (optional)
+        action: New allowed action - 'upload', 'download', or '*' (optional)
+        username: System username restriction (optional)
+        groupname: System groupname restriction (optional)
         region: Region (ap1, us1, eu1). Auto-detected if not provided
 
     Returns:
         File ACL update response
     """
+    if action is not None and action not in VALID_FILE_ACL_ACTIONS:
+        return error_response(
+            f"Invalid action '{action}'. Must be one of: {_FILE_ACL_ACTIONS_STR}."
+        )
+
     token = kwargs.get('token')
 
-    update_data = _build_acl_patch_data(effect, users, groups, servers, description, priority)
-    if file_pattern is not None:
-        update_data['file_pattern'] = file_pattern
+    update_data: dict[str, Any] = {}
+    if path is not None:
+        update_data['path'] = path
+    if action is not None:
+        update_data['action'] = action
+    if username is not None:
+        update_data['username'] = username
+    if groupname is not None:
+        update_data['groupname'] = groupname
 
     if not update_data:
         return error_response('No update data provided')
@@ -616,7 +677,7 @@ async def update_file_acl(
     result = await http_client.patch(
         region=region,
         workspace=workspace,
-        endpoint=f'/api/security/file-acl/{acl_id}/',
+        endpoint=f'{_API_FILE_ACL}{acl_id}/',
         token=token,
         data=update_data,
     )
@@ -649,7 +710,7 @@ async def delete_file_acl(
     result = await http_client.delete(
         region=region,
         workspace=workspace,
-        endpoint=f'/api/security/file-acl/{acl_id}/',
+        endpoint=f'{_API_FILE_ACL}{acl_id}/',
         token=token,
     )
 

--- a/tools/security_tools.py
+++ b/tools/security_tools.py
@@ -321,6 +321,144 @@ async def create_server_acl(
     return success_response(data=result, region=region, workspace=workspace)
 
 
+@mcp_tool_handler(
+    description='Update an existing server ACL rule. Related: list_server_acls (find rule ID), delete_server_acl (remove rule). Note: Higher priority values take precedence.',
+    annotations=IDEMPOTENT_WRITE,
+    meta={'anthropic/searchHint': 'server acl update modify'},
+)
+async def update_server_acl(
+    acl_id: str,
+    workspace: str,
+    effect: str | None = None,
+    users: list[str] | None = None,
+    groups: list[str] | None = None,
+    servers: list[str] | None = None,
+    description: str | None = None,
+    priority: int | None = None,
+    region: str = '',
+    **kwargs,
+) -> dict[str, Any]:
+    """Update an existing server ACL rule.
+
+    Args:
+        acl_id: Server ACL rule ID to update
+        workspace: Workspace name. Required parameter
+        effect: ACL effect - 'allow' or 'deny' (optional)
+        users: List of user IDs this rule applies to (optional)
+        groups: List of group IDs this rule applies to (optional)
+        servers: List of server IDs this rule applies to (optional)
+        description: Description of the ACL rule (optional)
+        priority: Rule priority (optional)
+        region: Region (ap1, us1, eu1). Auto-detected if not provided
+
+    Returns:
+        Server ACL update response
+    """
+    token = kwargs.get('token')
+
+    update_data: dict[str, Any] = {}
+    if effect is not None:
+        update_data['effect'] = effect
+    if users is not None:
+        update_data['users'] = users
+    if groups is not None:
+        update_data['groups'] = groups
+    if servers is not None:
+        update_data['servers'] = servers
+    if description is not None:
+        update_data['description'] = description
+    if priority is not None:
+        update_data['priority'] = priority
+
+    if not update_data:
+        return error_response('No update data provided')
+
+    result = await http_client.patch(
+        region=region,
+        workspace=workspace,
+        endpoint=f'/api/security/server-acl/{acl_id}/',
+        token=token,
+        data=update_data,
+    )
+
+    return success_response(
+        data=result, acl_id=acl_id, region=region, workspace=workspace
+    )
+
+
+@mcp_tool_handler(
+    description='Delete a server ACL rule permanently. Related: list_server_acls (find rule ID), update_server_acl (modify instead). Note: Cannot be undone.',
+    annotations=DESTRUCTIVE,
+    meta={'anthropic/searchHint': 'server acl delete remove'},
+)
+async def delete_server_acl(
+    acl_id: str, workspace: str, region: str = '', **kwargs
+) -> dict[str, Any]:
+    """Delete a server ACL rule.
+
+    Args:
+        acl_id: Server ACL rule ID to delete
+        workspace: Workspace name. Required parameter
+        region: Region (ap1, us1, eu1). Auto-detected if not provided
+
+    Returns:
+        Server ACL deletion response
+    """
+    token = kwargs.get('token')
+
+    result = await http_client.delete(
+        region=region,
+        workspace=workspace,
+        endpoint=f'/api/security/server-acl/{acl_id}/',
+        token=token,
+    )
+
+    return success_response(
+        data=result, acl_id=acl_id, region=region, workspace=workspace
+    )
+
+
+@mcp_tool_handler(
+    description='Bulk add or remove server ACL entries in a single operation. When to use: applying multiple server ACL changes at once. Related: list_server_acls (view existing), create_server_acl (single create).',
+    annotations=DESTRUCTIVE,
+    meta={'anthropic/searchHint': 'server acl bulk add remove multiple'},
+)
+async def bulk_server_acl(
+    workspace: str,
+    action: str,
+    acl_list: list[dict],
+    region: str = '',
+    **kwargs,
+) -> dict[str, Any]:
+    """Bulk add or remove server ACL entries.
+
+    Args:
+        workspace: Workspace name. Required parameter
+        action: Bulk action - 'add' or 'remove'
+        acl_list: List of ACL entry dicts.
+                  For action='add': each dict should contain keys matching create_server_acl fields (effect, users, groups, servers, etc.).
+                  For action='remove': each dict should contain key 'id' (ACL rule ID to remove).
+        region: Region (ap1, us1, eu1). Auto-detected if not provided
+
+    Returns:
+        Bulk server ACL operation response
+    """
+    if action not in ('add', 'remove'):
+        return error_response(f"Invalid action '{action}'. Must be 'add' or 'remove'.")
+
+    token = kwargs.get('token')
+
+    result = await http_client.post(
+        region=region,
+        workspace=workspace,
+        endpoint='/api/security/server-acl/bulk/',
+        token=token,
+        data={'action': action, 'acls': acl_list},
+    )
+
+    return success_response(data=result, action=action, region=region, workspace=workspace)
+
+
 # ===============================
 # FILE ACL TOOLS
 # ===============================
@@ -431,140 +569,7 @@ async def create_file_acl(
 
 
 @mcp_tool_handler(
-    description='Update an existing server ACL rule. Related: list_server_acls (find rule ID), delete_server_acl (remove rule).',
-    annotations=IDEMPOTENT_WRITE,
-    meta={'anthropic/searchHint': 'server acl update modify'},
-)
-async def update_server_acl(
-    acl_id: str,
-    workspace: str,
-    effect: str | None = None,
-    users: list[str] | None = None,
-    groups: list[str] | None = None,
-    servers: list[str] | None = None,
-    description: str | None = None,
-    priority: int | None = None,
-    region: str = '',
-    **kwargs,
-) -> dict[str, Any]:
-    """Update an existing server ACL rule.
-
-    Args:
-        acl_id: Server ACL rule ID to update
-        workspace: Workspace name. Required parameter
-        effect: ACL effect - 'allow' or 'deny' (optional)
-        users: List of user IDs this rule applies to (optional)
-        groups: List of group IDs this rule applies to (optional)
-        servers: List of server IDs this rule applies to (optional)
-        description: Description of the ACL rule (optional)
-        priority: Rule priority (optional)
-        region: Region (ap1, us1, eu1). Auto-detected if not provided
-
-    Returns:
-        Server ACL update response
-    """
-    token = kwargs.get('token')
-
-    update_data: dict[str, Any] = {}
-    if effect is not None:
-        update_data['effect'] = effect
-    if users is not None:
-        update_data['users'] = users
-    if groups is not None:
-        update_data['groups'] = groups
-    if servers is not None:
-        update_data['servers'] = servers
-    if description is not None:
-        update_data['description'] = description
-    if priority is not None:
-        update_data['priority'] = priority
-
-    if not update_data:
-        return error_response('No update data provided')
-
-    result = await http_client.patch(
-        region=region,
-        workspace=workspace,
-        endpoint=f'/api/security/server-acl/{acl_id}/',
-        token=token,
-        data=update_data,
-    )
-
-    return success_response(
-        data=result, acl_id=acl_id, region=region, workspace=workspace
-    )
-
-
-@mcp_tool_handler(
-    description='Delete a server ACL rule permanently. Related: list_server_acls (find rule ID), update_server_acl (modify instead). Note: Cannot be undone.',
-    annotations=DESTRUCTIVE,
-    meta={'anthropic/searchHint': 'server acl delete remove'},
-)
-async def delete_server_acl(
-    acl_id: str, workspace: str, region: str = '', **kwargs
-) -> dict[str, Any]:
-    """Delete a server ACL rule.
-
-    Args:
-        acl_id: Server ACL rule ID to delete
-        workspace: Workspace name. Required parameter
-        region: Region (ap1, us1, eu1). Auto-detected if not provided
-
-    Returns:
-        Server ACL deletion response
-    """
-    token = kwargs.get('token')
-
-    result = await http_client.delete(
-        region=region,
-        workspace=workspace,
-        endpoint=f'/api/security/server-acl/{acl_id}/',
-        token=token,
-    )
-
-    return success_response(
-        data=result, acl_id=acl_id, region=region, workspace=workspace
-    )
-
-
-@mcp_tool_handler(
-    description='Bulk add or remove server ACL entries in a single operation. When to use: applying multiple server ACL changes at once. Related: list_server_acls (view existing), create_server_acl (single create).',
-    annotations=ADDITIVE,
-    meta={'anthropic/searchHint': 'server acl bulk add remove multiple'},
-)
-async def bulk_server_acl(
-    workspace: str,
-    action: str,
-    acl_list: list[dict],
-    region: str = '',
-    **kwargs,
-) -> dict[str, Any]:
-    """Bulk add or remove server ACL entries.
-
-    Args:
-        workspace: Workspace name. Required parameter
-        action: Bulk action - 'add' or 'remove'
-        acl_list: List of ACL entry dicts to add or remove
-        region: Region (ap1, us1, eu1). Auto-detected if not provided
-
-    Returns:
-        Bulk server ACL operation response
-    """
-    token = kwargs.get('token')
-
-    result = await http_client.post(
-        region=region,
-        workspace=workspace,
-        endpoint='/api/security/server-acl/bulk/',
-        token=token,
-        data={'action': action, 'acls': acl_list},
-    )
-
-    return success_response(data=result, action=action, region=region, workspace=workspace)
-
-
-@mcp_tool_handler(
-    description='Update an existing file ACL rule. Related: list_file_acls (find rule ID), delete_file_acl (remove rule).',
+    description='Update an existing file ACL rule. Related: list_file_acls (find rule ID), delete_file_acl (remove rule). Note: Higher priority values take precedence.',
     annotations=IDEMPOTENT_WRITE,
     meta={'anthropic/searchHint': 'file acl update modify'},
 )


### PR DESCRIPTION
## Summary

Completes the security ACL toolset (closes #82). Adds update/delete tools for server and file ACLs plus bulk server ACL operations, then hardens the whole module based on iterative review against the server-side implementation.

### New tools
- `update_server_acl` / `delete_server_acl` / `bulk_server_acl`
- `update_file_acl` / `delete_file_acl`

### Breaking changes
- `create_command_acl` and `create_file_acl` parameter schemas changed: the previous `effect`/`command_pattern`/`users`/`groups`/`servers`/`priority` parameters never matched the upstream API (`CommandACLSerializer` accepts `token`/`service_token`/`command`/`username`/`groupname` only), so those calls failed server-side. The new schemas mirror the actual serializer contracts. There is no working old behavior to alias, so no deprecation shim is provided.

### Review fixes
- **Cross-type token rebind**: `update_server_acl` now explicitly nulls the opposing token field on PATCH—without this, rebinding an api-token-bound ACL to a service token violates the server's `exactly_one_token_type` check constraint and fails with a misleading `ACL_EXISTS` error
- Mutual exclusivity guards (`api_token_id` vs `service_token_id`) on all list/create/update/bulk functions
- `bulk_server_acl` guards: action whitelist, empty list, and 100-item cap (mirrors server-side `ServerACLBulk*Serializer` limits)
- Docstrings clarified: token rebind is supported by `update_server_acl` only; command/file ACL updates require delete-and-recreate

### Code quality
- Module constants for endpoints (`_API_*`), valid actions (`VALID_*`), and repeated error messages, following `webftp_tools`/`iam_tools` conventions
- Consistent validation order across functions (value-format checks before token checks)
- Test classes reordered to match source declaration order

### Endpoint contract note
Bulk remove uses `POST /api/security/server-acl/bulk/delete/`—verified against the server's `ServerACLViewSet.bulk_delete` action (`url_path='bulk/delete'`). Issue #82's description listing only `/bulk/` for both directions is imprecise.

## Test plan
- [x] 50 unit tests pass (`tests/test_security_tools.py`), covering payload construction, endpoint routing, and all validation error paths
- [ ] Verify cross-type token rebind (`update_server_acl` api token ↔ service token) against a dev workspace

Closes #82
