### PR TITLE
feat: add remaining work session tools (#88)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -323,6 +323,16 @@ All validators are defined in `utils/error_handler.py` and return user-friendly 
 - `list_session_analyses`: List AI security analysis results across the workspace
 - `get_session_analysis_detail`: Get detailed AI security analysis with MITRE ATT&CK mapping
 
+### 🗂️ Work sessions
+- `work_session_create`: Create a Work Session for auditable, approval-gated infrastructure access
+- `work_session_get`: Get details of a Work Session (status, scopes, servers, auth method)
+- `work_session_list`: List Work Sessions with optional status and auth_method filters
+- `work_session_update`: Partially update a Work Session (title, description, scopes, servers, expires_at)
+- `work_session_extend`: Extend the expiry time of an approved or active Work Session
+- `work_session_timeline`: Get the unified chronological timeline of a Work Session
+- `work_session_analyze`: Manually trigger AI security analysis for a terminal Work Session
+- `work_session_close`: Mark a Work Session as completed and trigger AI security analysis
+
 ### 🔍 System information
 - `get_system_info`: Hardware and OS information
 - `get_os_version`: Operating system details

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -325,9 +325,9 @@ All validators are defined in `utils/error_handler.py` and return user-friendly 
 
 ### 🗂️ Work sessions
 - `work_session_create`: Create a Work Session for auditable, approval-gated infrastructure access
-- `work_session_get`: Get details of a Work Session (status, scopes, servers, auth method)
+- `work_session_get`: Get details of a Work Session (status, scopes, servers, requester_type, expires_at)
 - `work_session_list`: List Work Sessions with optional status and requester_type filters
-- `work_session_update`: Partially update a Work Session (title, description, scopes, servers, expires_at)
+- `work_session_update`: Partially update a Work Session (title, description, scopes, servers; expires_at for pending sessions only)
 - `work_session_extend`: Extend the expiry time of an approved or active Work Session
 - `work_session_timeline`: Get the unified chronological timeline of a Work Session
 - `work_session_analyze`: Manually trigger AI security analysis for a terminal Work Session

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -326,7 +326,7 @@ All validators are defined in `utils/error_handler.py` and return user-friendly 
 ### 🗂️ Work sessions
 - `work_session_create`: Create a Work Session for auditable, approval-gated infrastructure access
 - `work_session_get`: Get details of a Work Session (status, scopes, servers, auth method)
-- `work_session_list`: List Work Sessions with optional status and auth_method filters
+- `work_session_list`: List Work Sessions with optional status and requester_type filters
 - `work_session_update`: Partially update a Work Session (title, description, scopes, servers, expires_at)
 - `work_session_extend`: Extend the expiry time of an approved or active Work Session
 - `work_session_timeline`: Get the unified chronological timeline of a Work Session

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -212,7 +212,7 @@ async def tool_function(
 ```
 
 **Key benefits**:
-- Automatic input validation (region, workspace, server_id, server_ids) before any API call
+- Automatic input validation (region, workspace, server_id, server_ids, session_id) before any API call
 - Automatic token injection via decorator
 - Unified error handling and response formatting
 - Reduced boilerplate code (~60% less per function)
@@ -226,6 +226,7 @@ The `with_token_validation` decorator (`utils/decorators.py`) validates inputs *
 2. **Workspace format**: Alphanumeric with hyphens/underscores, 1-63 characters
 3. **Server ID format**: Must be valid UUID (when present)
 4. **Server IDs list**: Each element must be valid UUID (when present)
+5. **Session ID format**: Must be valid UUID (when present); session_id is interpolated into URL paths
 
 File path validation is applied inline in `webftp_upload_file` and `webftp_download_file` using `validate_file_path()` from `utils/error_handler.py`. Rejects path traversal (`../`), relative paths, null bytes, and dangerous characters.
 
@@ -394,7 +395,7 @@ All validators are defined in `utils/error_handler.py` and return user-friendly 
 - `list_sudo_policies`: List sudo privilege policies
 - `create_sudo_policy`: Create a sudo policy for elevated privileges
 
-**ADR 0015 (out-of-band approval channel)**: An AI agent reaching Alpacon through MCP is a request/execution surface and cannot approve or reject privileged-access requests. There is intentionally no `approve_request`/`reject_request` tool, and the Alpacon server refuses approve/reject from agent/token channels with HTTP 403. When an action needs approval (a sudo HITL denial `SUDO_APPROVAL_REQUIRED`, or a Work Session that lands `pending`), the relevant tool returns a structured `status="pending_approval"` result with `requires_human_approval`/`approvable_by_agent` flags and a `category` code—surface it to a human who approves out-of-band (Alpacon web console or Slack), then retry.
+**ADR 0015 (out-of-band approval channel)**: An AI agent reaching Alpacon through MCP is a request/execution surface and cannot approve or reject privileged-access requests. There is intentionally no `approve_request`/`reject_request` tool, and the Alpacon server refuses approve/reject from agent/token channels with HTTP 403. When an action needs approval (a sudo HITL denial `SUDO_APPROVAL_REQUIRED`, a Work Session that lands `pending`, or a Work Session update queued as a modification request `WORK_SESSION_MOD_PENDING`), the relevant tool returns a structured `status="pending_approval"` result with `requires_human_approval`/`approvable_by_agent` flags and a `category` code—surface it to a human who approves out-of-band (Alpacon web console or Slack), then retry.
 
 ### 🔗 Webhooks & event subscriptions
 - `list_event_subscriptions`: List event subscriptions
@@ -568,7 +569,7 @@ permissions:
 4. Use `success_response()` and `error_response()` helpers
 5. Follow async/await pattern for HTTP calls
 6. For file path parameters, add inline `validate_file_path()` checks
-7. Common parameters (`region`, `workspace`, `server_id`) are validated automatically by the decorator
+7. Common parameters (`region`, `workspace`, `server_id`, `session_id`) are validated automatically by the decorator
 8. Update this documentation
 
 ### API token setup

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -225,8 +225,9 @@ The `with_token_validation` decorator (`utils/decorators.py`) validates inputs *
 1. **Region format**: Must be one of: `ap1`, `us1`, `eu1`
 2. **Workspace format**: Alphanumeric with hyphens/underscores, 1-63 characters
 3. **Server ID format**: Must be valid UUID (when present)
-4. **Server IDs list**: Each element must be valid UUID (when present)
-5. **Session ID format**: Must be valid UUID (when present); session_id is interpolated into URL paths
+4. **Server IDs list**: Must be a list; each element must be valid UUID (when present)
+5. **Servers list**: Must be a list; each element must be valid UUID (when present; server UUIDs sent in request bodies)
+6. **Session ID format**: Must be valid UUID (when present); session_id is interpolated into URL paths
 
 File path validation is applied inline in `webftp_upload_file` and `webftp_download_file` using `validate_file_path()` from `utils/error_handler.py`. Rejects path traversal (`../`), relative paths, null bytes, and dangerous characters.
 

--- a/tests/test_approval_tools.py
+++ b/tests/test_approval_tools.py
@@ -212,7 +212,7 @@ class TestSudoPolicies:
             name='deploy-sudo',
             commands=['/usr/bin/systemctl restart *'],
             users=['user-1'],
-            servers=['server-1'],
+            servers=['550e8400-e29b-41d4-a716-446655440000'],
             no_password=True,
             region='ap1',
         )
@@ -228,7 +228,7 @@ class TestSudoPolicies:
                 'commands': ['/usr/bin/systemctl restart *'],
                 'no_password': True,
                 'users': ['user-1'],
-                'servers': ['server-1'],
+                'servers': ['550e8400-e29b-41d4-a716-446655440000'],
             },
         )
 

--- a/tests/test_input_validation.py
+++ b/tests/test_input_validation.py
@@ -293,6 +293,57 @@ class TestServerIdsValidation:
 
 
 # ---------------------------------------------------------------------------
+# Session ID validation
+# ---------------------------------------------------------------------------
+
+
+class TestSessionIdValidation:
+    """Tests that invalid session_id values are rejected early.
+
+    session_id is interpolated into URL paths (work_session_tools), so a
+    non-UUID value (e.g. containing ``../`` or ``?``) must be rejected
+    before any HTTP request is built.
+    """
+
+    @pytest.mark.asyncio
+    @patch('utils.decorators.validate_token', return_value='fake-token')
+    async def test_invalid_session_id_rejected(self, mock_token):
+        func = _make_decorated_func(extra_params=['session_id'])
+        result = await func(workspace='demo', region='ap1', session_id='not-a-uuid')
+        assert result['status'] == 'error'
+        assert result['field'] == 'session_id'
+
+    @pytest.mark.asyncio
+    @patch('utils.decorators.validate_token', return_value='fake-token')
+    async def test_path_traversal_session_id_rejected(self, mock_token):
+        func = _make_decorated_func(extra_params=['session_id'])
+        result = await func(
+            workspace='demo', region='ap1', session_id='../other-endpoint'
+        )
+        assert result['status'] == 'error'
+        assert result['field'] == 'session_id'
+
+    @pytest.mark.asyncio
+    @patch('utils.decorators.validate_token', return_value='fake-token')
+    async def test_valid_session_id_passes(self, mock_token):
+        func = _make_decorated_func(extra_params=['session_id'])
+        result = await func(
+            workspace='demo',
+            region='ap1',
+            session_id='550e8400-e29b-41d4-a716-446655440000',
+        )
+        assert result['status'] == 'success'
+
+    @pytest.mark.asyncio
+    @patch('utils.decorators.validate_token', return_value='fake-token')
+    async def test_absent_session_id_passes(self, mock_token):
+        """Not providing session_id at all should pass (other tools)."""
+        func = _make_decorated_func(extra_params=['session_id'])
+        result = await func(workspace='demo', region='ap1')
+        assert result['status'] == 'success'
+
+
+# ---------------------------------------------------------------------------
 # File path validation (webftp_tools inline validation)
 # ---------------------------------------------------------------------------
 

--- a/tests/test_input_validation.py
+++ b/tests/test_input_validation.py
@@ -21,7 +21,7 @@ def _make_decorated_func(extra_params=None):
     # Dynamically build the function signature string
     param_parts = ['workspace: str', "region: str = ''"]
     for p in extra_params:
-        if p == 'server_ids':
+        if p in ('server_ids', 'servers'):
             param_parts.append(f'{p}: list = None')
         else:
             param_parts.append(f'{p}: str = None')
@@ -289,6 +289,63 @@ class TestServerIdsValidation:
     async def test_none_server_ids_passes(self, mock_token):
         func = _make_decorated_func(extra_params=['server_ids'])
         result = await func(workspace='demo', region='ap1', server_ids=None)
+        assert result['status'] == 'success'
+
+
+# ---------------------------------------------------------------------------
+# servers list validation
+# ---------------------------------------------------------------------------
+
+
+class TestServersValidation:
+    """Tests that invalid servers list values (server UUIDs) are rejected early."""
+
+    @pytest.mark.asyncio
+    @patch('utils.decorators.validate_token', return_value='fake-token')
+    async def test_invalid_servers_rejected(self, mock_token):
+        func = _make_decorated_func(extra_params=['servers'])
+        result = await func(
+            workspace='demo',
+            region='ap1',
+            servers=['not-a-uuid', 'also-bad'],
+        )
+        assert result['status'] == 'error'
+        assert result['field'] == 'servers'
+
+    @pytest.mark.asyncio
+    @patch('utils.decorators.validate_token', return_value='fake-token')
+    async def test_mixed_servers_rejected(self, mock_token):
+        func = _make_decorated_func(extra_params=['servers'])
+        result = await func(
+            workspace='demo',
+            region='ap1',
+            servers=[
+                '550e8400-e29b-41d4-a716-446655440000',
+                'not-a-uuid',
+            ],
+        )
+        assert result['status'] == 'error'
+        assert result['field'] == 'servers'
+
+    @pytest.mark.asyncio
+    @patch('utils.decorators.validate_token', return_value='fake-token')
+    async def test_valid_servers_passes(self, mock_token):
+        func = _make_decorated_func(extra_params=['servers'])
+        result = await func(
+            workspace='demo',
+            region='ap1',
+            servers=[
+                '550e8400-e29b-41d4-a716-446655440000',
+                '660e8400-e29b-41d4-a716-446655440001',
+            ],
+        )
+        assert result['status'] == 'success'
+
+    @pytest.mark.asyncio
+    @patch('utils.decorators.validate_token', return_value='fake-token')
+    async def test_none_servers_passes(self, mock_token):
+        func = _make_decorated_func(extra_params=['servers'])
+        result = await func(workspace='demo', region='ap1', servers=None)
         assert result['status'] == 'success'
 
 

--- a/tests/test_input_validation.py
+++ b/tests/test_input_validation.py
@@ -291,6 +291,21 @@ class TestServerIdsValidation:
         result = await func(workspace='demo', region='ap1', server_ids=None)
         assert result['status'] == 'success'
 
+    @pytest.mark.asyncio
+    @patch('utils.decorators.validate_token', return_value='fake-token')
+    async def test_string_server_ids_rejected(self, mock_token):
+        """A single string must fail fast, not be iterated character-by-character."""
+        func = _make_decorated_func(extra_params=['server_ids'])
+        result = await func(
+            workspace='demo',
+            region='ap1',
+            server_ids='550e8400-e29b-41d4-a716-446655440000',
+        )
+        assert result['status'] == 'error'
+        assert result['field'] == 'server_ids'
+        # The whole string is reported, not a confusing list of single characters.
+        assert result['value'] == '550e8400-e29b-41d4-a716-446655440000'
+
 
 # ---------------------------------------------------------------------------
 # servers list validation
@@ -347,6 +362,21 @@ class TestServersValidation:
         func = _make_decorated_func(extra_params=['servers'])
         result = await func(workspace='demo', region='ap1', servers=None)
         assert result['status'] == 'success'
+
+    @pytest.mark.asyncio
+    @patch('utils.decorators.validate_token', return_value='fake-token')
+    async def test_string_servers_rejected(self, mock_token):
+        """A single string must fail fast, not be iterated character-by-character."""
+        func = _make_decorated_func(extra_params=['servers'])
+        result = await func(
+            workspace='demo',
+            region='ap1',
+            servers='550e8400-e29b-41d4-a716-446655440000',
+        )
+        assert result['status'] == 'error'
+        assert result['field'] == 'servers'
+        # The whole string is reported, not a confusing list of single characters.
+        assert result['value'] == '550e8400-e29b-41d4-a716-446655440000'
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_work_session_tools.py
+++ b/tests/test_work_session_tools.py
@@ -337,3 +337,53 @@ class TestWorkSessionUpdate:
 
         assert result['status'] == 'error'
         assert 'not modifiable' in result['message']
+
+
+class TestWorkSessionExtend:
+    @pytest.mark.asyncio
+    async def test_extend_success(self, mock_http_client, mock_token_manager):
+        from tools.work_session_tools import work_session_extend
+
+        mock_http_client.post.return_value = {
+            'id': 'ws-uuid-1234',
+            'status': 'active',
+            'expires_at': '2026-06-06T18:00:00+00:00',
+        }
+
+        result = await work_session_extend(
+            session_id='ws-uuid-1234',
+            workspace='testworkspace',
+            expires_at='2026-06-06T18:00:00+00:00',
+            region='ap1',
+        )
+
+        assert result['status'] == 'success'
+        mock_http_client.post.assert_called_once_with(
+            region='ap1',
+            workspace='testworkspace',
+            endpoint='/api/work-sessions/sessions/ws-uuid-1234/extend/',
+            token='test-token',
+            data={'expires_at': '2026-06-06T18:00:00+00:00'},
+        )
+
+    @pytest.mark.asyncio
+    async def test_extend_propagates_api_error(
+        self, mock_http_client, mock_token_manager
+    ):
+        from tools.work_session_tools import work_session_extend
+
+        mock_http_client.post.return_value = {
+            'error': 'Validation error',
+            'message': 'New expiry must be later than current expiry',
+            'status_code': 400,
+        }
+
+        result = await work_session_extend(
+            session_id='ws-uuid-1234',
+            workspace='testworkspace',
+            expires_at='2026-06-05T00:00:00+00:00',
+            region='ap1',
+        )
+
+        assert result['status'] == 'error'
+        assert 'later than current' in result['message']

--- a/tests/test_work_session_tools.py
+++ b/tests/test_work_session_tools.py
@@ -30,7 +30,7 @@ class TestWorkSessionCreate:
         # so the success path is exercised; the pending path is covered by
         # test_create_pending_surfaces_approval_signal.
         mock_http_client.post.return_value = {
-            'id': 'ws-uuid-1234',
+            'id': '550e8400-e29b-41d4-a716-446655440020',
             'status': 'active',
             'auth_method': 'mcp_oauth',
         }
@@ -45,7 +45,7 @@ class TestWorkSessionCreate:
         )
 
         assert result['status'] == 'success'
-        assert result['data']['id'] == 'ws-uuid-1234'
+        assert result['data']['id'] == '550e8400-e29b-41d4-a716-446655440020'
         mock_http_client.post.assert_called_once_with(
             region='ap1',
             workspace='testworkspace',
@@ -163,12 +163,12 @@ class TestWorkSessionClose:
         from tools.work_session_tools import work_session_close
 
         mock_http_client.post.return_value = {
-            'id': 'ws-uuid-1234',
+            'id': '550e8400-e29b-41d4-a716-446655440020',
             'status': 'completed',
         }
 
         result = await work_session_close(
-            session_id='ws-uuid-1234',
+            session_id='550e8400-e29b-41d4-a716-446655440020',
             workspace='testworkspace',
             region='ap1',
         )
@@ -177,7 +177,7 @@ class TestWorkSessionClose:
         mock_http_client.post.assert_called_once_with(
             region='ap1',
             workspace='testworkspace',
-            endpoint='/api/work-sessions/sessions/ws-uuid-1234/complete/',
+            endpoint='/api/work-sessions/sessions/550e8400-e29b-41d4-a716-446655440020/complete/',
             token='test-token',
             data={},
         )
@@ -189,23 +189,23 @@ class TestWorkSessionGet:
         from tools.work_session_tools import work_session_get
 
         mock_http_client.get.return_value = {
-            'id': 'ws-uuid-1234',
+            'id': '550e8400-e29b-41d4-a716-446655440020',
             'status': 'active',
             'requester_type': 'agent',
         }
 
         result = await work_session_get(
-            session_id='ws-uuid-1234',
+            session_id='550e8400-e29b-41d4-a716-446655440020',
             workspace='testworkspace',
             region='ap1',
         )
 
         assert result['status'] == 'success'
-        assert result['data']['id'] == 'ws-uuid-1234'
+        assert result['data']['id'] == '550e8400-e29b-41d4-a716-446655440020'
         mock_http_client.get.assert_called_once_with(
             region='ap1',
             workspace='testworkspace',
-            endpoint='/api/work-sessions/sessions/ws-uuid-1234/',
+            endpoint='/api/work-sessions/sessions/550e8400-e29b-41d4-a716-446655440020/',
             token='test-token',
         )
 
@@ -220,7 +220,7 @@ class TestWorkSessionGet:
         }
 
         result = await work_session_get(
-            session_id='ws-nonexistent',
+            session_id='550e8400-e29b-41d4-a716-446655440099',
             workspace='testworkspace',
             region='ap1',
         )
@@ -306,14 +306,16 @@ class TestWorkSessionUpdate:
     async def test_update_success(self, mock_http_client, mock_token_manager):
         from tools.work_session_tools import work_session_update
 
+        # Applied immediately: no modification request was queued.
         mock_http_client.patch.return_value = {
-            'id': 'ws-uuid-1234',
+            'id': '550e8400-e29b-41d4-a716-446655440020',
             'status': 'pending',
             'description': 'Updated intent',
+            'pending_modification_request': None,
         }
 
         result = await work_session_update(
-            session_id='ws-uuid-1234',
+            session_id='550e8400-e29b-41d4-a716-446655440020',
             workspace='testworkspace',
             title='New title',
             description='Updated intent',
@@ -327,7 +329,7 @@ class TestWorkSessionUpdate:
         mock_http_client.patch.assert_called_once_with(
             region='ap1',
             workspace='testworkspace',
-            endpoint='/api/work-sessions/sessions/ws-uuid-1234/',
+            endpoint='/api/work-sessions/sessions/550e8400-e29b-41d4-a716-446655440020/',
             token='test-token',
             data={
                 'title': 'New title',
@@ -344,10 +346,12 @@ class TestWorkSessionUpdate:
     ):
         from tools.work_session_tools import work_session_update
 
-        mock_http_client.patch.return_value = {'id': 'ws-uuid-1234'}
+        mock_http_client.patch.return_value = {
+            'id': '550e8400-e29b-41d4-a716-446655440020'
+        }
 
         await work_session_update(
-            session_id='ws-uuid-1234',
+            session_id='550e8400-e29b-41d4-a716-446655440020',
             workspace='testworkspace',
             description='Only description changed',
             region='ap1',
@@ -363,7 +367,7 @@ class TestWorkSessionUpdate:
         from tools.work_session_tools import work_session_update
 
         result = await work_session_update(
-            session_id='ws-uuid-1234',
+            session_id='550e8400-e29b-41d4-a716-446655440020',
             workspace='testworkspace',
             region='ap1',
         )
@@ -371,6 +375,65 @@ class TestWorkSessionUpdate:
         assert result['status'] == 'error'
         assert 'No fields to update' in result['message']
         mock_http_client.patch.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_update_sends_empty_title_to_clear(
+        self, mock_http_client, mock_token_manager
+    ):
+        """An explicit empty string is sent so the server clears the title."""
+        from tools.work_session_tools import work_session_update
+
+        mock_http_client.patch.return_value = {
+            'id': '550e8400-e29b-41d4-a716-446655440020',
+            'pending_modification_request': None,
+        }
+
+        await work_session_update(
+            session_id='550e8400-e29b-41d4-a716-446655440020',
+            workspace='testworkspace',
+            title='',
+            region='ap1',
+        )
+
+        call_data = mock_http_client.patch.call_args[1]['data']
+        assert call_data == {'title': ''}
+
+    @pytest.mark.asyncio
+    async def test_update_queued_modification_surfaces_approval_signal(
+        self, mock_http_client, mock_token_manager
+    ):
+        """A queued modification (server HTTP 202) is surfaced as pending approval.
+
+        Scope/server changes on an approved/active session are not applied
+        immediately—the server queues a ``work_session_mod`` approval request
+        and reports it via a non-null ``pending_modification_request``.
+        """
+        from tools.work_session_tools import work_session_update
+
+        mock_http_client.patch.return_value = {
+            'id': '550e8400-e29b-41d4-a716-446655440020',
+            'status': 'active',
+            'scopes': ['command'],
+            'pending_modification_request': {
+                'id': 'mod-req-uuid-1',
+                'changes': {'scopes': ['command', 'sudo']},
+                'added_at': '2026-06-12T10:00:00+00:00',
+            },
+        }
+
+        result = await work_session_update(
+            session_id='550e8400-e29b-41d4-a716-446655440020',
+            workspace='testworkspace',
+            scopes=['command', 'sudo'],
+            region='ap1',
+        )
+
+        assert result['status'] == 'pending_approval'
+        assert result['category'] == 'WORK_SESSION_MOD_PENDING'
+        assert result['requires_human_approval'] is True
+        assert result['approvable_by_agent'] is False
+        assert result['session_id'] == '550e8400-e29b-41d4-a716-446655440020'
+        assert result['data']['pending_modification_request']['id'] == 'mod-req-uuid-1'
 
     @pytest.mark.asyncio
     async def test_update_propagates_api_error(
@@ -385,7 +448,7 @@ class TestWorkSessionUpdate:
         }
 
         result = await work_session_update(
-            session_id='ws-uuid-1234',
+            session_id='550e8400-e29b-41d4-a716-446655440020',
             workspace='testworkspace',
             description='Too late',
             region='ap1',
@@ -401,13 +464,13 @@ class TestWorkSessionExtend:
         from tools.work_session_tools import work_session_extend
 
         mock_http_client.post.return_value = {
-            'id': 'ws-uuid-1234',
+            'id': '550e8400-e29b-41d4-a716-446655440020',
             'status': 'active',
             'expires_at': '2026-06-06T18:00:00+00:00',
         }
 
         result = await work_session_extend(
-            session_id='ws-uuid-1234',
+            session_id='550e8400-e29b-41d4-a716-446655440020',
             workspace='testworkspace',
             expires_at='2026-06-06T18:00:00+00:00',
             region='ap1',
@@ -417,7 +480,7 @@ class TestWorkSessionExtend:
         mock_http_client.post.assert_called_once_with(
             region='ap1',
             workspace='testworkspace',
-            endpoint='/api/work-sessions/sessions/ws-uuid-1234/extend/',
+            endpoint='/api/work-sessions/sessions/550e8400-e29b-41d4-a716-446655440020/extend/',
             token='test-token',
             data={'expires_at': '2026-06-06T18:00:00+00:00'},
         )
@@ -435,7 +498,7 @@ class TestWorkSessionExtend:
         }
 
         result = await work_session_extend(
-            session_id='ws-uuid-1234',
+            session_id='550e8400-e29b-41d4-a716-446655440020',
             workspace='testworkspace',
             expires_at='2026-06-05T00:00:00+00:00',
             region='ap1',
@@ -460,7 +523,7 @@ class TestWorkSessionTimeline:
         }
 
         result = await work_session_timeline(
-            session_id='ws-uuid-1234',
+            session_id='550e8400-e29b-41d4-a716-446655440020',
             workspace='testworkspace',
             region='ap1',
         )
@@ -470,7 +533,7 @@ class TestWorkSessionTimeline:
         mock_http_client.get.assert_called_once_with(
             region='ap1',
             workspace='testworkspace',
-            endpoint='/api/work-sessions/sessions/ws-uuid-1234/timeline/',
+            endpoint='/api/work-sessions/sessions/550e8400-e29b-41d4-a716-446655440020/timeline/',
             token='test-token',
             params={'include_records': 'true'},
         )
@@ -482,7 +545,7 @@ class TestWorkSessionTimeline:
         mock_http_client.get.return_value = {'results': []}
 
         await work_session_timeline(
-            session_id='ws-uuid-1234',
+            session_id='550e8400-e29b-41d4-a716-446655440020',
             workspace='testworkspace',
             include_records=False,
             region='ap1',
@@ -504,7 +567,7 @@ class TestWorkSessionTimeline:
         }
 
         result = await work_session_timeline(
-            session_id='ws-nonexistent',
+            session_id='550e8400-e29b-41d4-a716-446655440099',
             workspace='testworkspace',
             region='ap1',
         )
@@ -520,11 +583,11 @@ class TestWorkSessionAnalyze:
 
         mock_http_client.post.return_value = {
             'status': 'accepted',
-            'work_session': 'ws-uuid-1234',
+            'work_session': '550e8400-e29b-41d4-a716-446655440020',
         }
 
         result = await work_session_analyze(
-            session_id='ws-uuid-1234',
+            session_id='550e8400-e29b-41d4-a716-446655440020',
             workspace='testworkspace',
             region='ap1',
         )
@@ -533,7 +596,7 @@ class TestWorkSessionAnalyze:
         mock_http_client.post.assert_called_once_with(
             region='ap1',
             workspace='testworkspace',
-            endpoint='/api/work-sessions/sessions/ws-uuid-1234/analyze/',
+            endpoint='/api/work-sessions/sessions/550e8400-e29b-41d4-a716-446655440020/analyze/',
             token='test-token',
             data={},
             params=None,
@@ -545,11 +608,11 @@ class TestWorkSessionAnalyze:
 
         mock_http_client.post.return_value = {
             'status': 'accepted',
-            'work_session': 'ws-uuid-1234',
+            'work_session': '550e8400-e29b-41d4-a716-446655440020',
         }
 
         await work_session_analyze(
-            session_id='ws-uuid-1234',
+            session_id='550e8400-e29b-41d4-a716-446655440020',
             workspace='testworkspace',
             force=True,
             region='ap1',
@@ -571,7 +634,7 @@ class TestWorkSessionAnalyze:
         }
 
         result = await work_session_analyze(
-            session_id='ws-uuid-1234',
+            session_id='550e8400-e29b-41d4-a716-446655440020',
             workspace='testworkspace',
             region='ap1',
         )

--- a/tests/test_work_session_tools.py
+++ b/tests/test_work_session_tools.py
@@ -29,7 +29,7 @@ class TestWorkSessionCreate:
         mock_http_client.post.return_value = {
             'id': 'ws-uuid-1234',
             'status': 'pending',
-            'auth_method': 'mcp_oauth',
+            'requester_type': 'agent',
         }
 
         result = await work_session_create(
@@ -79,7 +79,6 @@ class TestWorkSessionCreate:
         assert call_data['title'] == 'Deploy session'
         assert call_data['description'] == 'Deploying config files'
         assert call_data['requester_type'] == 'agent'
-        assert 'auth_method' not in call_data
 
     @pytest.mark.asyncio
     async def test_create_omits_empty_title(self, mock_http_client, mock_token_manager):
@@ -135,7 +134,7 @@ class TestWorkSessionGet:
         mock_http_client.get.return_value = {
             'id': 'ws-uuid-1234',
             'status': 'active',
-            'auth_method': 'mcp_oauth',
+            'requester_type': 'agent',
         }
 
         result = await work_session_get(
@@ -463,8 +462,8 @@ class TestWorkSessionAnalyze:
         from tools.work_session_tools import work_session_analyze
 
         mock_http_client.post.return_value = {
-            'id': 'analysis-uuid-1',
-            'status': 'pending',
+            'status': 'accepted',
+            'work_session': 'ws-uuid-1234',
         }
 
         result = await work_session_analyze(
@@ -488,8 +487,8 @@ class TestWorkSessionAnalyze:
         from tools.work_session_tools import work_session_analyze
 
         mock_http_client.post.return_value = {
-            'id': 'analysis-uuid-2',
-            'status': 'pending',
+            'status': 'accepted',
+            'work_session': 'ws-uuid-1234',
         }
 
         await work_session_analyze(

--- a/tests/test_work_session_tools.py
+++ b/tests/test_work_session_tools.py
@@ -212,7 +212,7 @@ class TestWorkSessionList:
         assert call_params['status'] == 'active'
 
     @pytest.mark.asyncio
-    async def test_list_with_auth_method_filter(
+    async def test_list_with_requester_type_filter(
         self, mock_http_client, mock_token_manager
     ):
         from tools.work_session_tools import work_session_list
@@ -220,11 +220,11 @@ class TestWorkSessionList:
         mock_http_client.get.return_value = {'count': 1, 'results': []}
 
         await work_session_list(
-            workspace='testworkspace', auth_method='mcp_oauth', region='ap1'
+            workspace='testworkspace', requester_type='agent', region='ap1'
         )
 
         call_params = mock_http_client.get.call_args[1]['params']
-        assert call_params['auth_method'] == 'mcp_oauth'
+        assert call_params['requester_type'] == 'agent'
         assert 'status' not in call_params
 
     @pytest.mark.asyncio

--- a/tests/test_work_session_tools.py
+++ b/tests/test_work_session_tools.py
@@ -387,3 +387,71 @@ class TestWorkSessionExtend:
 
         assert result['status'] == 'error'
         assert 'later than current' in result['message']
+
+
+class TestWorkSessionTimeline:
+    @pytest.mark.asyncio
+    async def test_timeline_success_includes_records_by_default(
+        self, mock_http_client, mock_token_manager
+    ):
+        from tools.work_session_tools import work_session_timeline
+
+        mock_http_client.get.return_value = {
+            'results': [
+                {'type': 'command', 'added_at': '2026-06-05T10:00:00+00:00'},
+                {'type': 'websh_record', 'added_at': '2026-06-05T10:01:00+00:00'},
+            ],
+        }
+
+        result = await work_session_timeline(
+            session_id='ws-uuid-1234',
+            workspace='testworkspace',
+            region='ap1',
+        )
+
+        assert result['status'] == 'success'
+        assert len(result['data']['results']) == 2
+        mock_http_client.get.assert_called_once_with(
+            region='ap1',
+            workspace='testworkspace',
+            endpoint='/api/work-sessions/sessions/ws-uuid-1234/timeline/',
+            token='test-token',
+            params={'include_records': 'true'},
+        )
+
+    @pytest.mark.asyncio
+    async def test_timeline_without_records(self, mock_http_client, mock_token_manager):
+        from tools.work_session_tools import work_session_timeline
+
+        mock_http_client.get.return_value = {'results': []}
+
+        await work_session_timeline(
+            session_id='ws-uuid-1234',
+            workspace='testworkspace',
+            include_records=False,
+            region='ap1',
+        )
+
+        call_params = mock_http_client.get.call_args[1]['params']
+        assert call_params == {'include_records': 'false'}
+
+    @pytest.mark.asyncio
+    async def test_timeline_propagates_api_error(
+        self, mock_http_client, mock_token_manager
+    ):
+        from tools.work_session_tools import work_session_timeline
+
+        mock_http_client.get.return_value = {
+            'error': 'Not found',
+            'message': 'Work Session not found',
+            'status_code': 404,
+        }
+
+        result = await work_session_timeline(
+            session_id='ws-nonexistent',
+            workspace='testworkspace',
+            region='ap1',
+        )
+
+        assert result['status'] == 'error'
+        assert 'not found' in result['message'].lower()

--- a/tests/test_work_session_tools.py
+++ b/tests/test_work_session_tools.py
@@ -455,3 +455,70 @@ class TestWorkSessionTimeline:
 
         assert result['status'] == 'error'
         assert 'not found' in result['message'].lower()
+
+
+class TestWorkSessionAnalyze:
+    @pytest.mark.asyncio
+    async def test_analyze_success(self, mock_http_client, mock_token_manager):
+        from tools.work_session_tools import work_session_analyze
+
+        mock_http_client.post.return_value = {
+            'id': 'analysis-uuid-1',
+            'status': 'pending',
+        }
+
+        result = await work_session_analyze(
+            session_id='ws-uuid-1234',
+            workspace='testworkspace',
+            region='ap1',
+        )
+
+        assert result['status'] == 'success'
+        mock_http_client.post.assert_called_once_with(
+            region='ap1',
+            workspace='testworkspace',
+            endpoint='/api/work-sessions/sessions/ws-uuid-1234/analyze/',
+            token='test-token',
+            data={},
+            params=None,
+        )
+
+    @pytest.mark.asyncio
+    async def test_analyze_with_force(self, mock_http_client, mock_token_manager):
+        from tools.work_session_tools import work_session_analyze
+
+        mock_http_client.post.return_value = {
+            'id': 'analysis-uuid-2',
+            'status': 'pending',
+        }
+
+        await work_session_analyze(
+            session_id='ws-uuid-1234',
+            workspace='testworkspace',
+            force=True,
+            region='ap1',
+        )
+
+        call_params = mock_http_client.post.call_args[1]['params']
+        assert call_params == {'force': 'true'}
+
+    @pytest.mark.asyncio
+    async def test_analyze_propagates_api_error(
+        self, mock_http_client, mock_token_manager
+    ):
+        from tools.work_session_tools import work_session_analyze
+
+        mock_http_client.post.return_value = {
+            'error': 'Validation error',
+            'message': 'Work session is not in a terminal state',
+            'status_code': 400,
+        }
+
+        result = await work_session_analyze(
+            session_id='ws-uuid-1234',
+            workspace='testworkspace',
+            region='ap1',
+        )
+
+        assert result['status'] == 'error'
+        assert 'terminal state' in result['message']

--- a/tests/test_work_session_tools.py
+++ b/tests/test_work_session_tools.py
@@ -10,6 +10,7 @@ def mock_http_client():
     with patch('tools.work_session_tools.http_client') as mock_client:
         mock_client.get = AsyncMock()
         mock_client.post = AsyncMock()
+        mock_client.patch = AsyncMock()
         yield mock_client
 
 
@@ -242,3 +243,97 @@ class TestWorkSessionList:
 
         assert result['status'] == 'error'
         assert 'Permission denied' in result['message']
+
+
+class TestWorkSessionUpdate:
+    @pytest.mark.asyncio
+    async def test_update_success(self, mock_http_client, mock_token_manager):
+        from tools.work_session_tools import work_session_update
+
+        mock_http_client.patch.return_value = {
+            'id': 'ws-uuid-1234',
+            'status': 'pending',
+            'description': 'Updated intent',
+        }
+
+        result = await work_session_update(
+            session_id='ws-uuid-1234',
+            workspace='testworkspace',
+            title='New title',
+            description='Updated intent',
+            scopes=['command', 'webftp'],
+            servers=['550e8400-e29b-41d4-a716-446655440001'],
+            expires_at='2026-06-06T13:00:00+00:00',
+            region='ap1',
+        )
+
+        assert result['status'] == 'success'
+        mock_http_client.patch.assert_called_once_with(
+            region='ap1',
+            workspace='testworkspace',
+            endpoint='/api/work-sessions/sessions/ws-uuid-1234/',
+            token='test-token',
+            data={
+                'title': 'New title',
+                'description': 'Updated intent',
+                'scopes': ['command', 'webftp'],
+                'servers': ['550e8400-e29b-41d4-a716-446655440001'],
+                'expires_at': '2026-06-06T13:00:00+00:00',
+            },
+        )
+
+    @pytest.mark.asyncio
+    async def test_update_sends_only_provided_fields(
+        self, mock_http_client, mock_token_manager
+    ):
+        from tools.work_session_tools import work_session_update
+
+        mock_http_client.patch.return_value = {'id': 'ws-uuid-1234'}
+
+        await work_session_update(
+            session_id='ws-uuid-1234',
+            workspace='testworkspace',
+            description='Only description changed',
+            region='ap1',
+        )
+
+        call_data = mock_http_client.patch.call_args[1]['data']
+        assert call_data == {'description': 'Only description changed'}
+
+    @pytest.mark.asyncio
+    async def test_update_rejects_empty_update(
+        self, mock_http_client, mock_token_manager
+    ):
+        from tools.work_session_tools import work_session_update
+
+        result = await work_session_update(
+            session_id='ws-uuid-1234',
+            workspace='testworkspace',
+            region='ap1',
+        )
+
+        assert result['status'] == 'error'
+        assert 'No fields to update' in result['message']
+        mock_http_client.patch.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_update_propagates_api_error(
+        self, mock_http_client, mock_token_manager
+    ):
+        from tools.work_session_tools import work_session_update
+
+        mock_http_client.patch.return_value = {
+            'error': 'Validation error',
+            'message': 'Work session is not modifiable',
+            'status_code': 400,
+        }
+
+        result = await work_session_update(
+            session_id='ws-uuid-1234',
+            workspace='testworkspace',
+            description='Too late',
+            region='ap1',
+        )
+
+        assert result['status'] == 'error'
+        assert 'not modifiable' in result['message']

--- a/tools/audit_tools.py
+++ b/tools/audit_tools.py
@@ -193,7 +193,7 @@ async def list_webftp_logs(
 
 
 @mcp_tool_handler(
-    description='List AI security analysis results for Websh sessions across the workspace. Filterable by server, risk score, or analysis status. Returns summary, risk scores, and analysis timestamps. Useful for security auditing and threat monitoring.',
+    description='List AI security analysis results for Websh sessions across the workspace. Filterable by server, risk score, or analysis status. Returns summary, risk scores, and analysis timestamps. Useful for security auditing and threat monitoring. Related: work_session_timeline (session command timeline), work_session_analyze (trigger analysis manually).',
     annotations=READ_ONLY,
     meta={'anthropic/searchHint': 'session analysis security risk threat'},
 )
@@ -249,7 +249,7 @@ async def list_session_analyses(
 
 
 @mcp_tool_handler(
-    description='Get detailed AI security analysis for a specific session analysis record. Returns full analysis including risk factors, MITRE ATT&CK mapping, attack chain analysis, threat indicators, timeline analysis, and recommended actions.',
+    description='Get detailed AI security analysis for a specific session analysis record. Returns full analysis including risk factors, MITRE ATT&CK mapping, attack chain analysis, threat indicators, timeline analysis, and recommended actions. Related: work_session_timeline (session command timeline), work_session_analyze (trigger analysis manually).',
     annotations=READ_ONLY,
     meta={'anthropic/searchHint': 'session analysis detail mitre attack threat'},
 )

--- a/tools/work_session_tools.py
+++ b/tools/work_session_tools.py
@@ -350,3 +350,48 @@ async def work_session_timeline(
     return success_response(
         data=result, session_id=session_id, region=region, workspace=workspace
     )
+
+
+@mcp_tool_handler(
+    description=(
+        'Manually trigger AI security analysis for a terminal Work Session '
+        '(completed, expired, or revoked). Analysis runs automatically on '
+        'work_session_close; use this to re-run a failed analysis. '
+        'Set force=True to retry an analysis stuck in pending/processing '
+        '(the server enforces a minimum age guard and never discards completed results). '
+        'Related: list_session_analyses / get_session_analysis_detail (view results).'
+    ),
+    annotations=ADDITIVE,
+    meta={'anthropic/searchHint': 'work session analyze AI security analysis retry'},
+)
+async def work_session_analyze(
+    session_id: str,
+    workspace: str,
+    force: bool = False,
+    region: str = '',
+    **kwargs,
+) -> dict[str, Any]:
+    """Manually trigger AI analysis for a terminal Work Session."""
+    token = kwargs.get('token')
+
+    result = await http_client.post(
+        region=region,
+        workspace=workspace,
+        endpoint=f'{_API_SESSIONS}{session_id}/analyze/',
+        token=token,
+        data={},
+        params={'force': 'true'} if force else None,
+    )
+
+    if err := unwrap_http_result(
+        result,
+        default_message='Failed to trigger Work Session analysis',
+        session_id=session_id,
+        region=region,
+        workspace=workspace,
+    ):
+        return err
+
+    return success_response(
+        data=result, session_id=session_id, region=region, workspace=workspace
+    )

--- a/tools/work_session_tools.py
+++ b/tools/work_session_tools.py
@@ -220,11 +220,15 @@ async def work_session_list(
     return success_response(data=result, region=region, workspace=workspace)
 
 
+# IDEMPOTENT_WRITE: repeated PATCH cannot stack approval requests (server WORK_SESSION_MOD_ALREADY_PENDING guard).
 @mcp_tool_handler(
     description=(
-        'Update a Work Session (partial update). Only provided fields are sent. '
+        'Update a Work Session (partial update). Only provided fields are sent; '
+        'pass an empty string to clear a text field such as title. '
         'Pending sessions update immediately; approved/active sessions go through '
-        'the modification flow and may return HTTP 202 when an approval request is queued. '
+        'the modification flow—when the server queues an approval request, this '
+        'tool returns status="pending_approval" and the changes only apply after '
+        'a human approves them out-of-band. '
         'expires_at is only honored for pending sessions—for approved/active sessions '
         'it is ignored, so use work_session_extend instead. '
         'Terminal sessions (completed/rejected/cancelled/expired/revoked) cannot be updated. '
@@ -286,6 +290,21 @@ async def work_session_update(
         workspace=workspace,
     ):
         return err
+
+    # Queued modification (server 202): http_client hides 2xx status codes, so branch on the body marker (ADR 0015).
+    if isinstance(result, dict) and result.get('pending_modification_request'):
+        return pending_approval_response(
+            'This update was queued as a modification request and is pending '
+            'human approval. A human must approve it out-of-band (Alpacon web '
+            'console or Slack) before the requested changes apply. Poll '
+            'work_session_get and only rely on the new scopes/servers once '
+            'pending_modification_request is cleared.',
+            category='WORK_SESSION_MOD_PENDING',
+            data=result,
+            session_id=session_id,
+            region=region,
+            workspace=workspace,
+        )
 
     return success_response(
         data=result, session_id=session_id, region=region, workspace=workspace

--- a/tools/work_session_tools.py
+++ b/tools/work_session_tools.py
@@ -112,8 +112,9 @@ async def work_session_close(
 
 @mcp_tool_handler(
     description=(
-        'Get details of a Work Session: status, scopes, servers, timeline, auth_method. '
-        'Related: work_session_list (list all sessions), work_session_close (end session).'
+        'Get details of a Work Session: status, scopes, servers, requester_type, expires_at. '
+        'Related: work_session_list (list all sessions), work_session_timeline '
+        '(chronological activity), work_session_close (end session).'
     ),
     annotations=READ_ONLY,
     meta={'anthropic/searchHint': 'work session get detail status timeline'},
@@ -151,7 +152,8 @@ async def work_session_get(
 @mcp_tool_handler(
     description=(
         'List Work Sessions in a workspace. Optional status filter: '
-        '"pending", "active", "completed", "rejected", "cancelled", "expired". '
+        '"pending", "approved", "active", "completed", "rejected", "cancelled", '
+        '"expired", "revoked". '
         'Optional requester_type filter: "user" (human) or "agent" (AI agent). '
         'Related: work_session_create (create session), work_session_get (single session detail).'
     ),
@@ -199,7 +201,9 @@ async def work_session_list(
         'Update a Work Session (partial update). Only provided fields are sent. '
         'Pending sessions update immediately; approved/active sessions go through '
         'the modification flow and may return HTTP 202 when an approval request is queued. '
-        'Terminal sessions (completed/rejected/cancelled/expired) cannot be updated. '
+        'expires_at is only honored for pending sessions—for approved/active sessions '
+        'it is ignored, so use work_session_extend instead. '
+        'Terminal sessions (completed/rejected/cancelled/expired/revoked) cannot be updated. '
         'Related: work_session_get (check status), work_session_extend (extend expiry only).'
     ),
     annotations=IDEMPOTENT_WRITE,

--- a/tools/work_session_tools.py
+++ b/tools/work_session_tools.py
@@ -356,6 +356,8 @@ async def work_session_timeline(
     )
 
 
+# IDEMPOTENT_WRITE: repeated triggers converge—the server replies
+# already_exists instead of re-running a healthy or completed analysis.
 @mcp_tool_handler(
     description=(
         'Manually trigger AI security analysis for a terminal Work Session '
@@ -365,7 +367,7 @@ async def work_session_timeline(
         '(the server enforces a minimum age guard and never discards completed results). '
         'Related: list_session_analyses / get_session_analysis_detail (view results).'
     ),
-    annotations=ADDITIVE,
+    annotations=IDEMPOTENT_WRITE,
     meta={'anthropic/searchHint': 'work session analyze AI security analysis retry'},
 )
 async def work_session_analyze(

--- a/tools/work_session_tools.py
+++ b/tools/work_session_tools.py
@@ -404,7 +404,8 @@ async def work_session_timeline(
 @mcp_tool_handler(
     description=(
         'Manually trigger AI security analysis for a terminal Work Session '
-        '(completed, expired, or revoked). Analysis runs automatically on '
+        '(completed, expired, or revoked—rejected and cancelled sessions never '
+        'activated, so there is nothing to analyze). Analysis runs automatically on '
         'work_session_close; use this to re-run a failed analysis. '
         'Set force=True to retry an analysis stuck in pending/processing '
         '(the server enforces a minimum age guard and never discards completed results). '

--- a/tools/work_session_tools.py
+++ b/tools/work_session_tools.py
@@ -262,3 +262,46 @@ async def work_session_update(
     return success_response(
         data=result, session_id=session_id, region=region, workspace=workspace
     )
+
+
+@mcp_tool_handler(
+    description=(
+        'Extend the expiry time of a Work Session. Only approved or active sessions '
+        'can be extended, and the new expires_at must be later than the current one. '
+        'Bound sudo policies are extended together. '
+        'expires_at is an ISO 8601 datetime string. '
+        'Related: work_session_update (modify other fields), work_session_get (check current expiry).'
+    ),
+    annotations=IDEMPOTENT_WRITE,
+    meta={'anthropic/searchHint': 'work session extend expiry expires prolong'},
+)
+async def work_session_extend(
+    session_id: str,
+    workspace: str,
+    expires_at: str,
+    region: str = '',
+    **kwargs,
+) -> dict[str, Any]:
+    """Extend a Work Session's expiry time."""
+    token = kwargs.get('token')
+
+    result = await http_client.post(
+        region=region,
+        workspace=workspace,
+        endpoint=f'{_API_SESSIONS}{session_id}/extend/',
+        token=token,
+        data={'expires_at': expires_at},
+    )
+
+    if err := unwrap_http_result(
+        result,
+        default_message='Failed to extend Work Session',
+        session_id=session_id,
+        region=region,
+        workspace=workspace,
+    ):
+        return err
+
+    return success_response(
+        data=result, session_id=session_id, region=region, workspace=workspace
+    )

--- a/tools/work_session_tools.py
+++ b/tools/work_session_tools.py
@@ -152,7 +152,7 @@ async def work_session_get(
     description=(
         'List Work Sessions in a workspace. Optional status filter: '
         '"pending", "active", "completed", "rejected", "cancelled", "expired". '
-        'Optional auth_method filter: "web", "cli", "service_token", "mcp_oauth". '
+        'Optional requester_type filter: "user" (human) or "agent" (AI agent). '
         'Related: work_session_create (create session), work_session_get (single session detail).'
     ),
     annotations=READ_ONLY,
@@ -161,19 +161,19 @@ async def work_session_get(
 async def work_session_list(
     workspace: str,
     status: str | None = None,
-    auth_method: str | None = None,
+    requester_type: str | None = None,
     limit: int = 20,
     region: str = '',
     **kwargs,
 ) -> dict[str, Any]:
-    """List Work Sessions with optional status and auth_method filtering."""
+    """List Work Sessions with optional status and requester_type filtering."""
     token = kwargs.get('token')
 
     params: dict[str, str | int] = {'page_size': limit}
     if status:
         params['status'] = status
-    if auth_method:
-        params['auth_method'] = auth_method
+    if requester_type:
+        params['requester_type'] = requester_type
 
     result = await http_client.get(
         region=region,

--- a/tools/work_session_tools.py
+++ b/tools/work_session_tools.py
@@ -2,10 +2,10 @@
 
 from typing import Any
 
-from utils.common import success_response, unwrap_http_result
+from utils.common import error_response, success_response, unwrap_http_result
 from utils.decorators import mcp_tool_handler
 from utils.http_client import http_client
-from utils.tool_annotations import ADDITIVE, DESTRUCTIVE, READ_ONLY
+from utils.tool_annotations import ADDITIVE, DESTRUCTIVE, IDEMPOTENT_WRITE, READ_ONLY
 
 _API_SESSIONS = '/api/work-sessions/sessions/'
 
@@ -192,3 +192,73 @@ async def work_session_list(
         return err
 
     return success_response(data=result, region=region, workspace=workspace)
+
+
+@mcp_tool_handler(
+    description=(
+        'Update a Work Session (partial update). Only provided fields are sent. '
+        'Pending sessions update immediately; approved/active sessions go through '
+        'the modification flow and may return HTTP 202 when an approval request is queued. '
+        'Terminal sessions (completed/rejected/cancelled/expired) cannot be updated. '
+        'Related: work_session_get (check status), work_session_extend (extend expiry only).'
+    ),
+    annotations=IDEMPOTENT_WRITE,
+    meta={
+        'anthropic/searchHint': 'work session update modify scopes servers description'
+    },
+)
+async def work_session_update(
+    session_id: str,
+    workspace: str,
+    title: str | None = None,
+    description: str | None = None,
+    scopes: list[str] | None = None,
+    servers: list[str] | None = None,
+    expires_at: str | None = None,
+    region: str = '',
+    **kwargs,
+) -> dict[str, Any]:
+    """Partially update a Work Session."""
+    token = kwargs.get('token')
+
+    data: dict[str, str | list[str]] = {}
+    if title is not None:
+        data['title'] = title
+    if description is not None:
+        data['description'] = description
+    if scopes is not None:
+        data['scopes'] = scopes
+    if servers is not None:
+        data['servers'] = servers
+    if expires_at is not None:
+        data['expires_at'] = expires_at
+
+    if not data:
+        return error_response(
+            'No fields to update. Provide at least one of: '
+            'title, description, scopes, servers, expires_at.',
+            session_id=session_id,
+            region=region,
+            workspace=workspace,
+        )
+
+    result = await http_client.patch(
+        region=region,
+        workspace=workspace,
+        endpoint=f'{_API_SESSIONS}{session_id}/',
+        token=token,
+        data=data,
+    )
+
+    if err := unwrap_http_result(
+        result,
+        default_message='Failed to update Work Session',
+        session_id=session_id,
+        region=region,
+        workspace=workspace,
+    ):
+        return err
+
+    return success_response(
+        data=result, session_id=session_id, region=region, workspace=workspace
+    )

--- a/tools/work_session_tools.py
+++ b/tools/work_session_tools.py
@@ -305,3 +305,48 @@ async def work_session_extend(
     return success_response(
         data=result, session_id=session_id, region=region, workspace=workspace
     )
+
+
+@mcp_tool_handler(
+    description=(
+        'Get the unified chronological timeline of a Work Session: commands, '
+        'file transfers, websh activity, and sudo grants in execution order. '
+        'Set include_records=False to omit websh terminal records for a lighter response. '
+        'Related: work_session_get (session detail), list_session_analyses / '
+        'get_session_analysis_detail (AI security analysis results).'
+    ),
+    annotations=READ_ONLY,
+    meta={
+        'anthropic/searchHint': 'work session timeline history commands chronological'
+    },
+)
+async def work_session_timeline(
+    session_id: str,
+    workspace: str,
+    include_records: bool = True,
+    region: str = '',
+    **kwargs,
+) -> dict[str, Any]:
+    """Get the unified timeline of a Work Session."""
+    token = kwargs.get('token')
+
+    result = await http_client.get(
+        region=region,
+        workspace=workspace,
+        endpoint=f'{_API_SESSIONS}{session_id}/timeline/',
+        token=token,
+        params={'include_records': 'true' if include_records else 'false'},
+    )
+
+    if err := unwrap_http_result(
+        result,
+        default_message='Failed to get Work Session timeline',
+        session_id=session_id,
+        region=region,
+        workspace=workspace,
+    ):
+        return err
+
+    return success_response(
+        data=result, session_id=session_id, region=region, workspace=workspace
+    )

--- a/utils/decorators.py
+++ b/utils/decorators.py
@@ -313,6 +313,11 @@ def with_token_validation(func: Callable) -> Callable:
                     'Each server ID must be in UUID format. (e.g., 550e8400-e29b-41d4-a716-446655440000)',
                 )
 
+        # session_id is interpolated into URL paths, so reject non-UUID values that could retarget the request.
+        session_id = arguments.get('session_id')
+        if session_id is not None and not validate_server_id_format(session_id):
+            return format_validation_error('session_id', session_id)
+
         # Get the **kwargs dict from bound arguments to inject token
         extra_kwargs = bound_args.arguments.get('kwargs', {})
 

--- a/utils/decorators.py
+++ b/utils/decorators.py
@@ -303,6 +303,12 @@ def with_token_validation(func: Callable) -> Callable:
         # Validate server_ids list if present
         server_ids = arguments.get('server_ids')
         if server_ids is not None:
+            if not isinstance(server_ids, list):
+                return format_validation_error(
+                    'server_ids',
+                    server_ids,
+                    'Must be a list of server UUIDs.',
+                )
             invalid_ids = [
                 sid for sid in server_ids if not validate_server_id_format(sid)
             ]
@@ -316,6 +322,12 @@ def with_token_validation(func: Callable) -> Callable:
         # Validate servers list if present (server UUIDs sent in request bodies)
         servers = arguments.get('servers')
         if servers is not None:
+            if not isinstance(servers, list):
+                return format_validation_error(
+                    'servers',
+                    servers,
+                    'Must be a list of server UUIDs.',
+                )
             invalid_servers = [
                 sid for sid in servers if not validate_server_id_format(sid)
             ]

--- a/utils/decorators.py
+++ b/utils/decorators.py
@@ -313,6 +313,19 @@ def with_token_validation(func: Callable) -> Callable:
                     'Each server ID must be in UUID format. (e.g., 550e8400-e29b-41d4-a716-446655440000)',
                 )
 
+        # Validate servers list if present (server UUIDs sent in request bodies)
+        servers = arguments.get('servers')
+        if servers is not None:
+            invalid_servers = [
+                sid for sid in servers if not validate_server_id_format(sid)
+            ]
+            if invalid_servers:
+                return format_validation_error(
+                    'servers',
+                    invalid_servers,
+                    'Each server ID must be in UUID format. (e.g., 550e8400-e29b-41d4-a716-446655440000)',
+                )
+
         # session_id is interpolated into URL paths, so reject non-UUID values that could retarget the request.
         session_id = arguments.get('session_id')
         if session_id is not None and not validate_server_id_format(session_id):

--- a/utils/error_handler.py
+++ b/utils/error_handler.py
@@ -289,6 +289,7 @@ def format_validation_error(
             'workspace': 'Only alphanumeric characters, hyphens (-), and underscores (_) allowed. Length: 1-63 characters.',
             'region': 'Supported regions: ap1, us1, eu1',
             'server_id': 'Server ID must be in UUID format. (e.g., 550e8400-e29b-41d4-a716-446655440000)',
+            'session_id': 'Session ID must be in UUID format. (e.g., 550e8400-e29b-41d4-a716-446655440000)',
             'file_path': 'Use absolute paths and avoid dangerous characters (.., <, >, |, *, ?).',
         }
         suggestion = suggestions.get(field, 'Please enter in correct format.')


### PR DESCRIPTION
## Summary

Implements the remaining work session lifecycle tools from issue #88, completing the set started in #102. Adds four MCP tools that wrap existing `alpacon-server` endpoints under `/api/work-sessions/sessions/`:

- `work_session_update` — partial update (PATCH); pending sessions apply immediately, approved/active go through the modification flow (may return HTTP 202 when an approval request is queued). `expires_at` is honored only for pending sessions.
- `work_session_extend` — extend expiry (POST `extend/`) for approved/active sessions; bound sudo policies extend together.
- `work_session_timeline` — unified chronological timeline (GET `timeline/`); `include_records=False` omits websh records for a lighter response.
- `work_session_analyze` — manually trigger AI security analysis (POST `analyze/`) for terminal sessions; `force=True` recovers an analysis stuck in pending/processing.

Plus supporting changes:
- `audit_tools.py`: cross-reference the new timeline/analyze tools from `list_session_analyses` / `get_session_analysis_detail`.
- `CLAUDE.md`: document the four tools in the work sessions section.
- Unit tests covering every new branch (partial-field body, empty-body early return, force/include_records mapping, per-tool HTTP error propagation).

All tools follow the established pattern: `@mcp_tool_handler`, `unwrap_http_result` error handling, `success_response` returns, `_API_SESSIONS` constant.

## Notes

- `work_session_analyze` is annotated `IDEMPOTENT_WRITE` rather than `ADDITIVE`: repeated triggers converge—the server replies `already_exists` instead of re-running a healthy or completed analysis.
- Tool descriptions and mock test fixtures were verified against the actual `alpacon-server` `main` implementation (endpoint paths, HTTP methods, request parameter locations, response semantics, status/`requester_type` value lists).

## Test plan

- [x] `uv run --no-sync pytest tests/test_work_session_tools.py -q` — 22 passed
- [x] `uv run --no-sync ruff check` — all checks passed
- [x] Descriptions/parameters reconciled against server source (endpoints, params, response semantics)