### PR TITLE
feat(approval): surface pending human approval, remove agent self-approve (ADR 0015)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -375,10 +375,11 @@ All validators are defined in `utils/error_handler.py` and return user-friendly 
 ### ✅ Approval management
 - `list_approval_requests`: List pending and historical approval requests
 - `get_approval_request`: Get detailed approval request information
-- `approve_request`: Approve a pending approval request
-- `reject_request`: Reject a pending approval request
+- `explain_approval_decision`: Explain that approving/rejecting a request is human-only and out-of-band (no mutation; returns ADR 0015 pending-approval guidance)
 - `list_sudo_policies`: List sudo privilege policies
 - `create_sudo_policy`: Create a sudo policy for elevated privileges
+
+**ADR 0015 (out-of-band approval channel)**: An AI agent reaching Alpacon through MCP is a request/execution surface and cannot approve or reject privileged-access requests. There is intentionally no `approve_request`/`reject_request` tool, and the Alpacon server refuses approve/reject from agent/token channels with HTTP 403. When an action needs approval (a sudo HITL denial `SUDO_APPROVAL_REQUIRED`, or a Work Session that lands `pending`), the relevant tool returns a structured `status="pending_approval"` result with `requires_human_approval`/`approvable_by_agent` flags and a `category` code—surface it to a human who approves out-of-band (Alpacon web console or Slack), then retry.
 
 ### 🔗 Webhooks & event subscriptions
 - `list_event_subscriptions`: List event subscriptions

--- a/tests/test_approval_tools.py
+++ b/tests/test_approval_tools.py
@@ -5,12 +5,11 @@ from unittest.mock import AsyncMock, patch
 import pytest
 
 from tools.approval_tools import (
-    approve_request,
     create_sudo_policy,
+    explain_approval_decision,
     get_approval_request,
     list_approval_requests,
     list_sudo_policies,
-    reject_request,
 )
 
 
@@ -125,95 +124,53 @@ class TestGetApprovalRequest:
         )
 
 
-class TestApproveRequest:
-    """Test approval request approval."""
+class TestApprovalDecisionIsHumanOnly:
+    """ADR 0015: an agent cannot approve/reject; there is no mutation tool."""
+
+    def test_no_approve_or_reject_tool_exists(self):
+        """The approve/reject mutation tools must not be importable."""
+        import tools.approval_tools as approval_tools
+
+        assert not hasattr(approval_tools, 'approve_request')
+        assert not hasattr(approval_tools, 'reject_request')
 
     @pytest.mark.asyncio
-    async def test_approve_request_success(self, mock_http_client, mock_token_manager):
-        """Test successful request approval."""
-        mock_http_client.post.return_value = {'id': 'req-1', 'status': 'approved'}
-
-        result = await approve_request(
+    async def test_explain_returns_structured_pending_guidance(
+        self, mock_http_client, mock_token_manager
+    ):
+        """explain_approval_decision surfaces the human-only, out-of-band signal."""
+        result = await explain_approval_decision(
             request_id='req-1', workspace='testworkspace', region='ap1'
         )
 
-        assert result['status'] == 'success'
+        assert result['status'] == 'pending_approval'
+        assert result['category'] == 'APPROVAL_DECISION_HUMAN_ONLY'
+        assert result['requires_human_approval'] is True
+        assert result['approvable_by_agent'] is False
         assert result['request_id'] == 'req-1'
-        mock_http_client.post.assert_called_once_with(
-            region='ap1',
-            workspace='testworkspace',
-            endpoint='/api/approvals/approvals/req-1/approve/',
-            token='test-token',
-            data={},
-        )
+        assert 'out-of-band' in result['next_action']
 
     @pytest.mark.asyncio
-    async def test_approve_request_with_comment(
+    async def test_explain_never_calls_the_server(
         self, mock_http_client, mock_token_manager
     ):
-        """Test request approval with comment."""
-        mock_http_client.post.return_value = {'id': 'req-1', 'status': 'approved'}
+        """The agent must never be the actor: no approve/reject HTTP call is made."""
+        await explain_approval_decision(workspace='testworkspace', region='ap1')
 
-        result = await approve_request(
-            request_id='req-1',
-            workspace='testworkspace',
-            comment='Approved for production access',
-            region='ap1',
-        )
-
-        assert result['status'] == 'success'
-        mock_http_client.post.assert_called_once_with(
-            region='ap1',
-            workspace='testworkspace',
-            endpoint='/api/approvals/approvals/req-1/approve/',
-            token='test-token',
-            data={'comment': 'Approved for production access'},
-        )
-
-
-class TestRejectRequest:
-    """Test approval request rejection."""
+        mock_http_client.post.assert_not_called()
+        mock_http_client.get.assert_not_called()
 
     @pytest.mark.asyncio
-    async def test_reject_request_success(self, mock_http_client, mock_token_manager):
-        """Test successful request rejection."""
-        mock_http_client.post.return_value = {'id': 'req-1', 'status': 'rejected'}
-
-        result = await reject_request(
-            request_id='req-1', workspace='testworkspace', region='ap1'
-        )
-
-        assert result['status'] == 'success'
-        mock_http_client.post.assert_called_once_with(
-            region='ap1',
-            workspace='testworkspace',
-            endpoint='/api/approvals/approvals/req-1/reject/',
-            token='test-token',
-            data={},
-        )
-
-    @pytest.mark.asyncio
-    async def test_reject_request_with_comment(
+    async def test_explain_omits_request_id_when_absent(
         self, mock_http_client, mock_token_manager
     ):
-        """Test request rejection with reason."""
-        mock_http_client.post.return_value = {'id': 'req-1', 'status': 'rejected'}
-
-        result = await reject_request(
-            request_id='req-1',
-            workspace='testworkspace',
-            comment='Insufficient justification',
-            region='ap1',
+        """request_id is optional and omitted from the payload when not given."""
+        result = await explain_approval_decision(
+            workspace='testworkspace', region='ap1'
         )
 
-        assert result['status'] == 'success'
-        mock_http_client.post.assert_called_once_with(
-            region='ap1',
-            workspace='testworkspace',
-            endpoint='/api/approvals/approvals/req-1/reject/',
-            token='test-token',
-            data={'comment': 'Insufficient justification'},
-        )
+        assert 'request_id' not in result
+        assert result['status'] == 'pending_approval'
 
 
 class TestSudoPolicies:

--- a/tests/test_command_tools.py
+++ b/tests/test_command_tools.py
@@ -6,6 +6,7 @@ import pytest
 
 from tools.command_tools import (
     _submit_command,
+    _sudo_denial,
     _sudo_denial_hint,
     execute_command,
     execute_command_multi_server,
@@ -17,27 +18,19 @@ class TestSudoDenialHint:
     """The exec-sudo denial code -> agent guidance mapping."""
 
     def test_presence_required(self):
-        out = {
-            'result': 'Alpacon denied this sudo command '
-            '(SUDO_PRESENCE_REQUIRED).\n'
-        }
+        out = {'result': 'Alpacon denied this sudo command (SUDO_PRESENCE_REQUIRED).\n'}
         hint = _sudo_denial_hint(out)
         assert hint is not None
         assert 'step-up' in hint
 
     def test_approval_required(self):
-        out = {
-            'result': 'Alpacon denied this sudo command '
-            '(SUDO_APPROVAL_REQUIRED).\n'
-        }
+        out = {'result': 'Alpacon denied this sudo command (SUDO_APPROVAL_REQUIRED).\n'}
         hint = _sudo_denial_hint(out)
         assert hint is not None
         assert 'approv' in hint
 
     def test_risk_denied_no_score_disclosed(self):
-        out = {
-            'result': 'Alpacon denied this sudo command (SUDO_RISK_DENIED).\n'
-        }
+        out = {'result': 'Alpacon denied this sudo command (SUDO_RISK_DENIED).\n'}
         hint = _sudo_denial_hint(out)
         assert hint is not None
         assert 'risk' in hint
@@ -83,7 +76,6 @@ class TestSubmitCommand:
 
     @pytest.mark.asyncio
     async def test_submit_basic(self, mock_http_client):
-
         mock_http_client.post.return_value = {'id': 'cmd-123', 'status': 'running'}
 
         result = await _submit_command(
@@ -110,7 +102,6 @@ class TestSubmitCommand:
 
     @pytest.mark.asyncio
     async def test_submit_with_optional_params(self, mock_http_client):
-
         mock_http_client.post.return_value = {'id': 'cmd-456'}
 
         await _submit_command(
@@ -135,7 +126,6 @@ class TestSubmitCommand:
 
     @pytest.mark.asyncio
     async def test_submit_omits_none_params(self, mock_http_client):
-
         mock_http_client.post.return_value = {'id': 'cmd-789'}
 
         await _submit_command(
@@ -157,7 +147,6 @@ class TestListCommands:
 
     @pytest.mark.asyncio
     async def test_list_commands_success(self, mock_http_client, mock_token_manager):
-
         mock_http_client.get.return_value = {
             'count': 2,
             'results': [
@@ -182,7 +171,6 @@ class TestListCommands:
     async def test_list_commands_with_server_filter(
         self, mock_http_client, mock_token_manager
     ):
-
         mock_http_client.get.return_value = {'count': 1, 'results': []}
 
         result = await list_commands(
@@ -198,7 +186,6 @@ class TestListCommands:
 
     @pytest.mark.asyncio
     async def test_list_commands_no_token(self, mock_http_client, mock_token_manager):
-
         mock_token_manager.get_token.return_value = None
 
         result = await list_commands(workspace='testworkspace')
@@ -208,7 +195,6 @@ class TestListCommands:
 
     @pytest.mark.asyncio
     async def test_list_commands_http_error(self, mock_http_client, mock_token_manager):
-
         mock_http_client.get.return_value = {
             'error': 'Forbidden',
             'message': 'Permission denied',
@@ -226,7 +212,6 @@ class TestExecuteCommand:
 
     @pytest.mark.asyncio
     async def test_success(self, mock_http_client, mock_token_manager):
-
         with (
             patch('tools.command_tools._submit_command') as mock_submit,
             patch('tools.command_tools._get_command_result') as mock_poll,
@@ -252,7 +237,6 @@ class TestExecuteCommand:
 
     @pytest.mark.asyncio
     async def test_array_response(self, mock_http_client, mock_token_manager):
-
         with (
             patch('tools.command_tools._submit_command') as mock_submit,
             patch('tools.command_tools._get_command_result') as mock_poll,
@@ -274,7 +258,6 @@ class TestExecuteCommand:
 
     @pytest.mark.asyncio
     async def test_timeout(self, mock_http_client, mock_token_manager):
-
         with (
             patch('tools.command_tools._submit_command') as mock_submit,
             patch('tools.command_tools._get_command_result') as mock_poll,
@@ -299,7 +282,6 @@ class TestExecuteCommand:
 
     @pytest.mark.asyncio
     async def test_acl_error(self, mock_http_client, mock_token_manager):
-
         with patch('tools.command_tools._submit_command') as mock_submit:
             mock_submit.return_value = {
                 'error': 'Permission denied',
@@ -317,7 +299,6 @@ class TestExecuteCommand:
 
     @pytest.mark.asyncio
     async def test_empty_data_array(self, mock_http_client, mock_token_manager):
-
         with patch('tools.command_tools._submit_command') as mock_submit:
             mock_submit.return_value = []
 
@@ -332,7 +313,6 @@ class TestExecuteCommand:
 
     @pytest.mark.asyncio
     async def test_stuck_status(self, mock_http_client, mock_token_manager):
-
         with (
             patch('tools.command_tools._submit_command') as mock_submit,
             patch('tools.command_tools._get_command_result') as mock_poll,
@@ -356,7 +336,6 @@ class TestExecuteCommand:
 
     @pytest.mark.asyncio
     async def test_forwards_all_params(self, mock_http_client, mock_token_manager):
-
         with (
             patch('tools.command_tools._submit_command') as mock_submit,
             patch('tools.command_tools._get_command_result') as mock_poll,
@@ -384,7 +363,6 @@ class TestExecuteCommand:
 
     @pytest.mark.asyncio
     async def test_no_token(self, mock_http_client, mock_token_manager):
-
         mock_token_manager.get_token.return_value = None
 
         result = await execute_command(
@@ -428,6 +406,80 @@ class TestExecuteCommand:
             assert 'step-up' in result['sudo_hint']
             # Disclosure guard: never echo a score/reasoning, only the category.
             assert 'score' not in result['sudo_hint']
+            # Structured, machine-actionable pending-approval block (ADR 0015).
+            assert result['sudo_denial']['status'] == 'pending_approval'
+            assert result['sudo_denial']['category'] == 'SUDO_PRESENCE_REQUIRED'
+            assert result['sudo_denial']['requires_human_approval'] is True
+            assert result['sudo_denial']['approvable_by_agent'] is False
+
+    @pytest.mark.asyncio
+    async def test_approval_required_surfaces_structured_block(
+        self, mock_http_client, mock_token_manager
+    ):
+        # SUDO_APPROVAL_REQUIRED is the ADR 0015 case: a human must approve
+        # out-of-band, so a structured pending-approval block is attached.
+        with (
+            patch('tools.command_tools._submit_command') as mock_submit,
+            patch('tools.command_tools._get_command_result') as mock_poll,
+        ):
+            mock_submit.return_value = {'id': 'cmd-791'}
+            mock_poll.return_value = {
+                'id': 'cmd-791',
+                'status': 'completed',
+                'exit_code': 1,
+                'result': 'Alpacon denied this sudo command '
+                '(SUDO_APPROVAL_REQUIRED).\n',
+                'finished_at': '2024-01-01T00:00:01Z',
+            }
+
+            result = await execute_command(
+                server_id='550e8400-e29b-41d4-a716-446655440001',
+                command='sudo systemctl restart nginx',
+                workspace='testworkspace',
+                timeout=10,
+            )
+
+            assert result['sudo_denial']['category'] == 'SUDO_APPROVAL_REQUIRED'
+            assert result['sudo_denial']['approvable_by_agent'] is False
+
+    @pytest.mark.asyncio
+    async def test_risk_denied_has_hint_but_no_pending_block(
+        self, mock_http_client, mock_token_manager
+    ):
+        # A hard risk denial is not a pending human approval: it gets the
+        # free-text hint but no machine-actionable pending-approval block, so an
+        # agent does not wait for an approval that will never come.
+        with (
+            patch('tools.command_tools._submit_command') as mock_submit,
+            patch('tools.command_tools._get_command_result') as mock_poll,
+        ):
+            mock_submit.return_value = {'id': 'cmd-792'}
+            mock_poll.return_value = {
+                'id': 'cmd-792',
+                'status': 'completed',
+                'exit_code': 1,
+                'result': 'Alpacon denied this sudo command (SUDO_RISK_DENIED).\n',
+                'finished_at': '2024-01-01T00:00:01Z',
+            }
+
+            result = await execute_command(
+                server_id='550e8400-e29b-41d4-a716-446655440001',
+                command='sudo rm -rf /',
+                workspace='testworkspace',
+                timeout=10,
+            )
+
+            assert 'sudo_hint' in result
+            assert 'sudo_denial' not in result
+
+    def test_sudo_denial_returns_code_and_hint(self):
+        out = {'result': 'Alpacon denied this sudo command (SUDO_APPROVAL_REQUIRED).\n'}
+        denial = _sudo_denial(out)
+        assert denial is not None
+        code, hint = denial
+        assert code == 'SUDO_APPROVAL_REQUIRED'
+        assert 'approv' in hint
+        assert _sudo_denial({'result': 'uid=0(root)\n'}) is None
 
     @pytest.mark.asyncio
     async def test_no_sudo_hint_when_no_denial(
@@ -456,6 +508,7 @@ class TestExecuteCommand:
 
             assert result['status'] == 'success'
             assert 'sudo_hint' not in result
+            assert 'sudo_denial' not in result
 
 
 class TestSubmitCommandWithSession:
@@ -463,7 +516,6 @@ class TestSubmitCommandWithSession:
 
     @pytest.mark.asyncio
     async def test_submit_includes_work_session_when_provided(self, mock_http_client):
-
         mock_http_client.post.return_value = {'id': 'cmd-ws-001'}
 
         await _submit_command(
@@ -480,7 +532,6 @@ class TestSubmitCommandWithSession:
 
     @pytest.mark.asyncio
     async def test_submit_omits_work_session_when_none(self, mock_http_client):
-
         mock_http_client.post.return_value = {'id': 'cmd-ws-002'}
 
         await _submit_command(
@@ -500,7 +551,6 @@ class TestExecuteCommandWithSession:
     async def test_execute_command_passes_session_id(
         self, mock_http_client, mock_token_manager
     ):
-
         mock_http_client.post.return_value = {'id': 'cmd-123'}
         mock_http_client.get.return_value = {
             'id': 'cmd-123',
@@ -525,7 +575,6 @@ class TestExecuteCommandMultiServerWithSession:
     async def test_multi_server_passes_session_id(
         self, mock_http_client, mock_token_manager
     ):
-
         mock_http_client.post.return_value = {'id': 'cmd-multi-1'}
 
         await execute_command_multi_server(

--- a/tests/test_work_session_tools.py
+++ b/tests/test_work_session_tools.py
@@ -25,9 +25,12 @@ class TestWorkSessionCreate:
     async def test_create_success(self, mock_http_client, mock_token_manager):
         from tools.work_session_tools import work_session_create
 
+        # Verifies the request payload sent to the server. Use an active session
+        # so the success path is exercised; the pending path is covered by
+        # test_create_pending_surfaces_approval_signal.
         mock_http_client.post.return_value = {
             'id': 'ws-uuid-1234',
-            'status': 'pending',
+            'status': 'active',
             'auth_method': 'mcp_oauth',
         }
 
@@ -55,6 +58,60 @@ class TestWorkSessionCreate:
                 'description': 'Fix nginx config',
             },
         )
+
+    @pytest.mark.asyncio
+    async def test_create_pending_surfaces_approval_signal(
+        self, mock_http_client, mock_token_manager
+    ):
+        """A pending Work Session is surfaced as a structured approval signal."""
+        from tools.work_session_tools import work_session_create
+
+        mock_http_client.post.return_value = {
+            'id': 'ws-uuid-pending',
+            'status': 'pending',
+            'auth_method': 'mcp_oauth',
+        }
+
+        result = await work_session_create(
+            workspace='testworkspace',
+            scopes=['command'],
+            servers=['550e8400-e29b-41d4-a716-446655440001'],
+            expires_at='2026-05-19T13:00:00+00:00',
+            description='Fix nginx config',
+            region='ap1',
+        )
+
+        assert result['status'] == 'pending_approval'
+        assert result['category'] == 'WORK_SESSION_PENDING'
+        assert result['requires_human_approval'] is True
+        assert result['approvable_by_agent'] is False
+        assert result['session_id'] == 'ws-uuid-pending'
+        assert result['data']['status'] == 'pending'
+        assert 'out-of-band' in result['next_action']
+
+    @pytest.mark.asyncio
+    async def test_create_active_returns_success(
+        self, mock_http_client, mock_token_manager
+    ):
+        """A non-pending session (e.g. auto-approved) returns a normal success."""
+        from tools.work_session_tools import work_session_create
+
+        mock_http_client.post.return_value = {
+            'id': 'ws-uuid-active',
+            'status': 'active',
+        }
+
+        result = await work_session_create(
+            workspace='testworkspace',
+            scopes=['command'],
+            servers=['550e8400-e29b-41d4-a716-446655440001'],
+            expires_at='2026-05-19T13:00:00+00:00',
+            description='Fix nginx config',
+            region='ap1',
+        )
+
+        assert result['status'] == 'success'
+        assert result['data']['id'] == 'ws-uuid-active'
 
     @pytest.mark.asyncio
     async def test_create_with_title_and_description(

--- a/tools/approval_tools.py
+++ b/tools/approval_tools.py
@@ -1,11 +1,20 @@
-"""Approval and sudo policy tools for Alpacon MCP server."""
+"""Approval and sudo policy tools for Alpacon MCP server.
+
+ADR 0015 (out-of-band approval channel): AI agents reach Alpacon through MCP and
+are a request/execution surface only. They CANNOT approve or reject
+privileged-access requests—the Alpacon server refuses approve/reject from
+agent/token channels with HTTP 403. These tools therefore expose approval
+requests read-only (list/get) so an agent can observe what is pending and tell a
+human, but provide no approve/reject mutation. The agent must escalate to a human
+who approves out-of-band (Alpacon web console or Slack).
+"""
 
 from typing import Any
 
-from utils.common import success_response
+from utils.common import pending_approval_response, success_response
 from utils.decorators import mcp_tool_handler
 from utils.http_client import http_client
-from utils.tool_annotations import ADDITIVE, DESTRUCTIVE, READ_ONLY
+from utils.tool_annotations import ADDITIVE, READ_ONLY
 
 # ===============================
 # APPROVAL REQUEST TOOLS
@@ -90,87 +99,56 @@ async def get_approval_request(
     )
 
 
-@mcp_tool_handler(
-    description='Approve a pending approval request by its ID. Optionally include a comment explaining the approval decision. Only pending requests can be approved. Requires superuser or approval permission. Related: list_approval_requests (find pending requests), reject_request (deny instead).',
-    annotations=ADDITIVE,
-    meta={'anthropic/searchHint': 'approval approve accept grant'},
-)
-async def approve_request(
-    request_id: str,
-    workspace: str,
-    comment: str | None = None,
-    region: str = '',
-    **kwargs,
-) -> dict[str, Any]:
-    """Approve a pending approval request.
-
-    Args:
-        request_id: Approval request ID to approve
-        workspace: Workspace name. Required parameter
-        comment: Comment explaining the approval decision (optional)
-        region: Region (ap1, us1, eu1). Auto-detected if not provided
-
-    Returns:
-        Approval response
-    """
-    token = kwargs.get('token')
-
-    data: dict[str, Any] = {}
-    if comment is not None:
-        data['comment'] = comment
-
-    result = await http_client.post(
-        region=region,
-        workspace=workspace,
-        endpoint=f'/api/approvals/approvals/{request_id}/approve/',
-        token=token,
-        data=data,
-    )
-
-    return success_response(
-        data=result, request_id=request_id, region=region, workspace=workspace
-    )
+# ===============================
+# APPROVAL DECISION (HUMAN-ONLY, OUT-OF-BAND)
+# ===============================
+#
+# Per ADR 0015 there is intentionally NO approve_request / reject_request tool.
+# An AI agent is the requester/executor and must never be the approver:
+# approving its own (or any) privileged-access request would defeat the
+# human-in-the-loop control. The Alpacon server enforces this server-side by
+# refusing approve/reject from agent/token channels with HTTP 403, so even a
+# direct POST would fail; we do not expose such a tool here. To act on a pending
+# request, use list_approval_requests / get_approval_request to observe it, then
+# escalate to a human who approves it out-of-band (Alpacon web console or Slack).
 
 
 @mcp_tool_handler(
-    description='Reject a pending approval request by its ID. Optionally include a comment explaining the rejection reason. Only pending requests can be rejected. Requires superuser or approval permission. Related: list_approval_requests (find pending requests), approve_request (approve instead). Note: Rejection is irreversible.',
-    annotations=DESTRUCTIVE,
-    meta={'anthropic/searchHint': 'approval reject deny refuse'},
+    description='Explains how a pending approval request gets decided. Approval and rejection are human-only and happen out-of-band (Alpacon web console or Slack); an AI agent cannot approve or reject requests and there is no MCP tool to do so. Use this to understand what to tell a human, or after you hit SUDO_APPROVAL_REQUIRED or a pending Work Session. Related: list_approval_requests (observe pending requests), get_approval_request (single request detail).',
+    annotations=READ_ONLY,
+    meta={'anthropic/searchHint': 'approve reject approval decision human out-of-band'},
 )
-async def reject_request(
-    request_id: str,
+async def explain_approval_decision(
     workspace: str,
-    comment: str | None = None,
+    request_id: str | None = None,
     region: str = '',
     **kwargs,
 ) -> dict[str, Any]:
-    """Reject a pending approval request.
+    """Explain that approving/rejecting a request is a human-only, out-of-band action.
+
+    This tool performs no mutation and contacts no server endpoint—an agent must
+    never be the approver. It returns the structured ADR 0015 pending-approval
+    guidance so the agent waits/escalates instead of attempting to self-approve.
 
     Args:
-        request_id: Approval request ID to reject
         workspace: Workspace name. Required parameter
-        comment: Reason for the rejection (optional)
+        request_id: Approval request ID this guidance refers to (optional)
         region: Region (ap1, us1, eu1). Auto-detected if not provided
 
     Returns:
-        Rejection response
+        Structured pending-approval guidance (no approve/reject is performed)
     """
-    token = kwargs.get('token')
+    context: dict[str, Any] = {'region': region, 'workspace': workspace}
+    if request_id is not None:
+        context['request_id'] = request_id
 
-    data: dict[str, Any] = {}
-    if comment is not None:
-        data['comment'] = comment
-
-    result = await http_client.post(
-        region=region,
-        workspace=workspace,
-        endpoint=f'/api/approvals/approvals/{request_id}/reject/',
-        token=token,
-        data=data,
-    )
-
-    return success_response(
-        data=result, request_id=request_id, region=region, workspace=workspace
+    return pending_approval_response(
+        'Approval requests can only be approved or rejected by a human, '
+        'out-of-band (Alpacon web console or Slack). As an AI agent you cannot '
+        'approve or reject this request, and no MCP tool can do it for you. '
+        'Surface the request to a human reviewer and wait for their decision.',
+        category='APPROVAL_DECISION_HUMAN_ONLY',
+        **context,
     )
 
 

--- a/tools/command_tools.py
+++ b/tools/command_tools.py
@@ -3,7 +3,12 @@
 import asyncio
 from typing import Any
 
-from utils.common import error_response, success_response, unwrap_http_result
+from utils.common import (
+    error_response,
+    pending_approval_response,
+    success_response,
+    unwrap_http_result,
+)
 from utils.decorators import mcp_tool_handler
 from utils.http_client import http_client
 from utils.tool_annotations import ADDITIVE, READ_ONLY
@@ -46,10 +51,27 @@ _SUDO_DENIAL_HINTS: tuple[tuple[str, str], ...] = (
 _SUDO_DENIAL_LINE_PREFIX = 'Alpacon denied this sudo command'
 
 
-def _sudo_denial_hint(result: dict[str, Any]) -> str | None:
-    """Return category-level guidance when a non-interactive sudo was denied in
-    the command output, so an agent can act (have a human step up / request
-    approval / stop) without parsing free text. None when no denial is present.
+# Denial categories that a human can resolve out-of-band (approve / step-up).
+# For these we attach a machine-actionable pending-approval block (ADR 0015) in
+# addition to the free-text hint, so an agent can branch on stable flags instead
+# of parsing prose, and waits/escalates rather than retry-spamming. Risk-denied
+# is excluded: it is a hard policy denial, not a pending human approval.
+_SUDO_HUMAN_APPROVAL_CODES = frozenset(
+    {
+        'SUDO_NO_WORKSESSION_POLICY',
+        'SUDO_PRESENCE_REQUIRED',
+        'SUDO_APPROVAL_REQUIRED',
+    }
+)
+
+
+def _sudo_denial(result: dict[str, Any]) -> tuple[str, str] | None:
+    """Detect a non-interactive sudo denial in the command output.
+
+    Returns ``(code, hint)`` for the matched denial category so the caller can
+    surface category-level guidance—and, for human-resolvable categories, a
+    structured pending-approval signal—without the agent parsing free text.
+    Returns None when no denial is present.
     """
     output = result.get('result') or ''
     if not isinstance(output, str):
@@ -60,8 +82,18 @@ def _sudo_denial_hint(result: dict[str, Any]) -> str | None:
         # forge a hint on a command that actually succeeded and mislead the
         # agent into a wrong action.
         if f'{_SUDO_DENIAL_LINE_PREFIX} ({code})' in output:
-            return hint
+            return code, hint
     return None
+
+
+def _sudo_denial_hint(result: dict[str, Any]) -> str | None:
+    """Return the free-text denial hint for a sudo denial, or None.
+
+    Thin wrapper over :func:`_sudo_denial` kept for callers/tests that only need
+    the human-readable guidance string.
+    """
+    denial = _sudo_denial(result)
+    return denial[1] if denial else None
 
 
 async def _submit_command(
@@ -281,9 +313,20 @@ async def execute_command(
                     region=region,
                     workspace=workspace,
                 )
-                hint = _sudo_denial_hint(result)
-                if hint:
+                denial = _sudo_denial(result)
+                if denial:
+                    code, hint = denial
+                    # Backward-compatible free-text hint.
                     response['sudo_hint'] = hint
+                    # For human-resolvable denials, also attach a structured,
+                    # machine-actionable pending-approval block (ADR 0015): the
+                    # command did not run and a human must act out-of-band. Only
+                    # the category is disclosed—never the risk score/reasoning.
+                    if code in _SUDO_HUMAN_APPROVAL_CODES:
+                        response['sudo_denial'] = pending_approval_response(
+                            hint,
+                            category=code,
+                        )
                 return response
 
             if status in ('stuck', 'error'):

--- a/tools/work_session_tools.py
+++ b/tools/work_session_tools.py
@@ -2,7 +2,11 @@
 
 from typing import Any
 
-from utils.common import success_response, unwrap_http_result
+from utils.common import (
+    pending_approval_response,
+    success_response,
+    unwrap_http_result,
+)
 from utils.decorators import mcp_tool_handler
 from utils.http_client import http_client
 from utils.tool_annotations import ADDITIVE, DESTRUCTIVE, READ_ONLY
@@ -66,6 +70,25 @@ async def work_session_create(
         workspace=workspace,
     ):
         return err
+
+    # A Work Session created by an agent commonly lands in `pending`: it must be
+    # approved by a human out-of-band before any scoped action (command/file
+    # transfer) is allowed (ADR 0015). Surface that as a structured
+    # pending-approval signal so the agent waits/escalates instead of proceeding
+    # to run commands against a session that is not yet active.
+    if isinstance(result, dict) and result.get('status') == 'pending':
+        session_id = result.get('id')
+        return pending_approval_response(
+            'This Work Session was created but is pending human approval. A '
+            'human must approve it out-of-band (Alpacon web console or Slack) '
+            'before any command or file transfer in this session will run. Poll '
+            'work_session_get for status, and only proceed once it is active.',
+            category='WORK_SESSION_PENDING',
+            data=result,
+            session_id=session_id,
+            region=region,
+            workspace=workspace,
+        )
 
     return success_response(data=result, region=region, workspace=workspace)
 

--- a/utils/common.py
+++ b/utils/common.py
@@ -73,7 +73,8 @@ def success_response(data: Any = None, **kwargs) -> dict[str, Any]:
 # The human-resolvable next action differs by category: SUDO_APPROVAL_REQUIRED /
 # WORK_SESSION_PENDING need an out-of-band approval, while SUDO_PRESENCE_REQUIRED
 # is an MFA step-up and SUDO_NO_WORKSESSION_POLICY is a scope addition — none of
-# which the agent can perform itself.
+# which the agent can perform itself. APPROVAL_DECISION_HUMAN_ONLY is a pure
+# explanation that approving/rejecting is human-only; there is nothing to retry.
 _NEXT_ACTION_BY_CATEGORY: dict[str, str] = {
     'SUDO_APPROVAL_REQUIRED': (
         'A human must approve this out-of-band (Alpacon web console or Slack). '
@@ -93,6 +94,12 @@ _NEXT_ACTION_BY_CATEGORY: dict[str, str] = {
         'This command is not covered by the Work Session sudo policy. A human '
         'must add it to the session scope (which may itself require approval), '
         'then retry. You cannot grant it yourself.'
+    ),
+    'APPROVAL_DECISION_HUMAN_ONLY': (
+        'Surface this request to a human reviewer; only a human can approve or '
+        'reject it, out-of-band (Alpacon web console or Slack). You cannot make '
+        'this decision and no MCP tool does it for you. Wait for the human '
+        'decision — there is nothing for you to retry or resubmit.'
     ),
 }
 _DEFAULT_NEXT_ACTION = _NEXT_ACTION_BY_CATEGORY['SUDO_APPROVAL_REQUIRED']
@@ -140,9 +147,7 @@ def pending_approval_response(
             # Machine-actionable flags: the agent must wait/escalate, not act.
             'requires_human_approval': True,
             'approvable_by_agent': False,
-            'next_action': _NEXT_ACTION_BY_CATEGORY.get(
-                category, _DEFAULT_NEXT_ACTION
-            ),
+            'next_action': _NEXT_ACTION_BY_CATEGORY.get(category, _DEFAULT_NEXT_ACTION),
         }
     )
     return response

--- a/utils/common.py
+++ b/utils/common.py
@@ -70,6 +70,54 @@ def success_response(data: Any = None, **kwargs) -> dict[str, Any]:
     return response
 
 
+def pending_approval_response(
+    message: str,
+    *,
+    category: str,
+    **kwargs: Any,
+) -> dict[str, Any]:
+    """Create a structured "pending human approval" result (ADR 0015).
+
+    AI agents reaching Alpacon through MCP are a request/execution surface and
+    cannot approve privileged-access requests. When an action needs human
+    approval (a sudo HITL denial such as ``SUDO_APPROVAL_REQUIRED``, or a Work
+    Session that lands ``pending``), the agent must be told—in a
+    machine-actionable way—that the request is pending, a human must approve it
+    out-of-band (web/Slack), and the agent cannot approve it itself. This keeps
+    the agent waiting/escalating instead of retry-spamming or hallucinating
+    success.
+
+    The result uses ``status='pending_approval'`` (distinct from ``success`` and
+    ``error``) plus stable boolean flags so a caller can branch without parsing
+    free text. Only the denial *category* and the next action are disclosed—
+    never internal risk scores or factors.
+
+    Args:
+        message: Human-readable explanation of what is pending and what to do.
+        category: Stable machine code for the denial/pending category
+            (e.g. ``SUDO_APPROVAL_REQUIRED``, ``WORK_SESSION_PENDING``).
+        **kwargs: Additional context fields (region, workspace, ids, raw data).
+
+    Returns:
+        Structured pending-approval response dict.
+    """
+    response: dict[str, Any] = {
+        'status': 'pending_approval',
+        'category': category,
+        'message': message,
+        # Machine-actionable flags: the agent must wait/escalate, not act.
+        'requires_human_approval': True,
+        'approvable_by_agent': False,
+        'next_action': (
+            'A human must approve this out-of-band (Alpacon web console or '
+            'Slack). You cannot approve it yourself. Wait for approval, then '
+            'retry; do not repeatedly resubmit.'
+        ),
+    }
+    response.update(kwargs)
+    return response
+
+
 def token_error_response(region: str, workspace: str) -> dict[str, Any]:
     """Create standardized token error response.
 

--- a/utils/common.py
+++ b/utils/common.py
@@ -70,6 +70,34 @@ def success_response(data: Any = None, **kwargs) -> dict[str, Any]:
     return response
 
 
+# The human-resolvable next action differs by category: SUDO_APPROVAL_REQUIRED /
+# WORK_SESSION_PENDING need an out-of-band approval, while SUDO_PRESENCE_REQUIRED
+# is an MFA step-up and SUDO_NO_WORKSESSION_POLICY is a scope addition — none of
+# which the agent can perform itself.
+_NEXT_ACTION_BY_CATEGORY: dict[str, str] = {
+    'SUDO_APPROVAL_REQUIRED': (
+        'A human must approve this out-of-band (Alpacon web console or Slack). '
+        'You cannot approve it yourself. Wait for approval, then retry; do not '
+        'repeatedly resubmit.'
+    ),
+    'WORK_SESSION_PENDING': (
+        'A human must approve this Work Session out-of-band (Alpacon web console '
+        'or Slack) before it activates. You cannot approve it yourself. Wait for '
+        'approval, then retry.'
+    ),
+    'SUDO_PRESENCE_REQUIRED': (
+        'A human must complete a fresh MFA step-up out-of-band, then retry. You '
+        'cannot complete MFA yourself.'
+    ),
+    'SUDO_NO_WORKSESSION_POLICY': (
+        'This command is not covered by the Work Session sudo policy. A human '
+        'must add it to the session scope (which may itself require approval), '
+        'then retry. You cannot grant it yourself.'
+    ),
+}
+_DEFAULT_NEXT_ACTION = _NEXT_ACTION_BY_CATEGORY['SUDO_APPROVAL_REQUIRED']
+
+
 def pending_approval_response(
     message: str,
     *,
@@ -101,20 +129,22 @@ def pending_approval_response(
     Returns:
         Structured pending-approval response dict.
     """
-    response: dict[str, Any] = {
-        'status': 'pending_approval',
-        'category': category,
-        'message': message,
-        # Machine-actionable flags: the agent must wait/escalate, not act.
-        'requires_human_approval': True,
-        'approvable_by_agent': False,
-        'next_action': (
-            'A human must approve this out-of-band (Alpacon web console or '
-            'Slack). You cannot approve it yourself. Wait for approval, then '
-            'retry; do not repeatedly resubmit.'
-        ),
-    }
-    response.update(kwargs)
+    # Apply caller context first so the fixed, security-relevant fields below
+    # (the flags and category) always win and cannot be overridden by a kwarg.
+    response: dict[str, Any] = {**kwargs}
+    response.update(
+        {
+            'status': 'pending_approval',
+            'category': category,
+            'message': message,
+            # Machine-actionable flags: the agent must wait/escalate, not act.
+            'requires_human_approval': True,
+            'approvable_by_agent': False,
+            'next_action': _NEXT_ACTION_BY_CATEGORY.get(
+                category, _DEFAULT_NEXT_ACTION
+            ),
+        }
+    )
     return response
 
 


### PR DESCRIPTION
## Summary

Aligns the alpacon-mcp client with **ADR 0015 (out-of-band approval channel)**. AI agents reaching Alpacon through MCP are a request/execution surface and **cannot approve privileged-access requests**. When an agent action needs human approval, the MCP now surfaces a clear, structured "pending — a human must approve out-of-band; you cannot approve this yourself" outcome so the agent waits/escalates instead of retry-spamming or hallucinating success.

## Changes

- **Remove `approve_request` / `reject_request`.** An agent must never be the approver, and the server already refuses approve/reject from agent/token channels with HTTP 403. Replaced with read-only `explain_approval_decision`, which returns structured human-only/out-of-band guidance and **contacts no server endpoint** (the agent can never be the actor). `list_approval_requests` / `get_approval_request` remain so an agent can observe a pending request and tell a human.
- **New `pending_approval_response()` helper** (`utils/common.py`): machine-actionable result with `status="pending_approval"`, a stable `category` code, and `requires_human_approval` / `approvable_by_agent` flags. Discloses only the denial category + next action — never internal risk scores/factors.
- **`work_session_create`:** when a session lands `pending`, surface the structured pending-approval signal so the agent waits for human approval instead of running commands against a not-yet-active session.
- **`execute_command`:** in addition to the existing free-text `sudo_hint`, attach a structured `sudo_denial` block for human-resolvable sudo denials (`SUDO_APPROVAL_REQUIRED`, `SUDO_PRESENCE_REQUIRED`, `SUDO_NO_WORKSESSION_POLICY`). Hard risk denials (`SUDO_RISK_DENIED`) keep the hint but get no pending block, so an agent does not wait for an approval that will never come.
- Docs (`CLAUDE.md`) updated to reflect the removed tools and the ADR 0015 policy.

## Disclosure constraint

All surfacing discloses only the denial **category** and what to do (human approval needed) — never internal risk scores or factors. Covered by tests asserting `'score' not in` the surfaced text.

## Tests / lint

- `pytest`: 694 passed (3 new command-tool tests; approval/work-session tests updated).
- `ruff check` + `ruff format --check`: clean.
- `mypy`: clean on changed source.

🤖 Generated with [Claude Code](https://claude.com/claude-code)