### PR TITLE
ci: bump create-github-app-token to v3 (Node 24)

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -66,9 +66,9 @@ jobs:
       # logic here (App token + workflow-dispatch).
       - name: Generate App token
         id: app-token
-        uses: actions/create-github-app-token@v1
+        uses: actions/create-github-app-token@v3
         with:
-          app-id: ${{ secrets.DEPLOY_DISPATCHER_APP_ID }}
+          client-id: ${{ secrets.DEPLOY_DISPATCHER_APP_CLIENT_ID }}
           private-key: ${{ secrets.DEPLOY_DISPATCHER_PRIVATE_KEY }}
           owner: alpacax
           repositories: alpacon-gitops
@@ -91,9 +91,9 @@ jobs:
     steps:
       - name: Generate App token
         id: app-token
-        uses: actions/create-github-app-token@v1
+        uses: actions/create-github-app-token@v3
         with:
-          app-id: ${{ secrets.DEPLOY_DISPATCHER_APP_ID }}
+          client-id: ${{ secrets.DEPLOY_DISPATCHER_APP_CLIENT_ID }}
           private-key: ${{ secrets.DEPLOY_DISPATCHER_PRIVATE_KEY }}
           owner: alpacax
           repositories: alpacon-gitops


### PR DESCRIPTION
## Summary
GitHub blocks Node 20-based actions starting 2026-06-16. `actions/create-github-app-token@v1` is the last Node 20 action left in this repo (the rest are already on Node 24). Bump v1 → v3 in both deploy jobs and switch `app-id` → `client-id`.

## Changes
### .github/workflows/docker.yml
- `actions/create-github-app-token` v1 → v3 (deploy-dev + deploy-prod, 2 uses)
- `app-id` → `client-id`, referencing new org secret `DEPLOY_DISPATCHER_APP_CLIENT_ID`

### Secrets
- New org secret `DEPLOY_DISPATCHER_APP_CLIENT_ID` (visibility: all, matching `DEPLOY_DISPATCHER_APP_ID`) holds the deploy-dispatcher App Client ID.

## Notes
- This repo is public, so it mirrors the shared-ci dispatch wrapper inline (cannot reference the Internal `shared-ci` action). The deploy-dispatcher org secrets are `visibility: all`, available to public repos.
- `benc-uk/workflow-dispatch@v1.3.1` is already Node 24 (Docker-based) — no change.

## Test plan
- [ ] After merge, a build on `main` / a tag triggers the deploy job → App token mint (client-id) succeeds and dispatches `image-tag-update-pr.yaml` to alpacon-gitops

🤖 Generated with [Claude Code](https://claude.com/claude-code)
