### PR TITLE
fix: standardize http_client error-envelope unwrapping to prevent false success

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -8,6 +8,14 @@ from unittest.mock import MagicMock, patch
 
 import pytest
 
+# Canonical http_client error envelope (the shape utils/http_client returns on
+# 4xx/5xx). Shared across error-path tests so the envelope is defined once.
+HTTP_ERROR_ENVELOPE = {
+    'error': 'HTTP Error',
+    'status_code': 404,
+    'message': 'Not found',
+}
+
 
 @pytest.fixture(autouse=True)
 def mock_region_auto_detect():

--- a/tests/test_alert_tools.py
+++ b/tests/test_alert_tools.py
@@ -1,0 +1,218 @@
+"""Unit tests for alert management tools."""
+
+from unittest.mock import AsyncMock, patch
+
+import pytest
+
+from tests.conftest import HTTP_ERROR_ENVELOPE
+from tools.alert_tools import (
+    create_alert_rule,
+    delete_alert_rule,
+    get_alert,
+    list_alerts,
+    mute_alert,
+    update_alert_rule,
+)
+
+ALERT_ID = 'alert-1'
+RULE_ID = 'rule-1'
+
+
+@pytest.fixture
+def mock_http_client():
+    with patch('tools.alert_tools.http_client') as mock_client:
+        mock_client.get = AsyncMock()
+        mock_client.post = AsyncMock()
+        mock_client.patch = AsyncMock()
+        mock_client.delete = AsyncMock()
+        yield mock_client
+
+
+@pytest.fixture
+def mock_token_manager():
+    with patch('utils.common.token_manager') as mock_manager:
+        mock_manager.get_token.return_value = 'test-token'
+        yield mock_manager
+
+
+class TestListAlerts:
+    @pytest.mark.asyncio
+    async def test_list_success(self, mock_http_client, mock_token_manager):
+        mock_http_client.get.return_value = {'results': [], 'count': 0}
+
+        result = await list_alerts(workspace='testworkspace', region='ap1')
+
+        assert result['status'] == 'success'
+        mock_http_client.get.assert_called_once_with(
+            region='ap1',
+            workspace='testworkspace',
+            endpoint='/api/alerts/',
+            token='test-token',
+            params={},
+        )
+
+
+class TestGetAlert:
+    @pytest.mark.asyncio
+    async def test_get_success(self, mock_http_client, mock_token_manager):
+        mock_http_client.get.return_value = {'id': ALERT_ID, 'status': 'triggered'}
+
+        result = await get_alert(
+            alert_id=ALERT_ID, workspace='testworkspace', region='ap1'
+        )
+
+        assert result['status'] == 'success'
+        assert result['alert_id'] == ALERT_ID
+        mock_http_client.get.assert_called_once_with(
+            region='ap1',
+            workspace='testworkspace',
+            endpoint=f'/api/alerts/{ALERT_ID}/',
+            token='test-token',
+        )
+
+
+class TestMuteAlert:
+    @pytest.mark.asyncio
+    async def test_mute_success(self, mock_http_client, mock_token_manager):
+        mock_http_client.post.return_value = {'id': ALERT_ID, 'muted': True}
+
+        result = await mute_alert(
+            alert_id=ALERT_ID,
+            workspace='testworkspace',
+            duration=30,
+            region='ap1',
+        )
+
+        assert result['status'] == 'success'
+        assert result['alert_id'] == ALERT_ID
+        mock_http_client.post.assert_called_once_with(
+            region='ap1',
+            workspace='testworkspace',
+            endpoint=f'/api/alerts/{ALERT_ID}/mute/',
+            token='test-token',
+            data={'duration': 30},
+        )
+
+
+class TestCreateAlertRule:
+    @pytest.mark.asyncio
+    async def test_create_success(self, mock_http_client, mock_token_manager):
+        mock_http_client.post.return_value = {'id': RULE_ID, 'name': 'cpu-high'}
+
+        result = await create_alert_rule(
+            workspace='testworkspace',
+            name='cpu-high',
+            metric_type='cpu',
+            condition='gt',
+            threshold=90.0,
+            region='ap1',
+        )
+
+        assert result['status'] == 'success'
+        mock_http_client.post.assert_called_once_with(
+            region='ap1',
+            workspace='testworkspace',
+            endpoint='/api/metrics/alert-rules/',
+            token='test-token',
+            data={
+                'name': 'cpu-high',
+                'metric_type': 'cpu',
+                'condition': 'gt',
+                'threshold': 90.0,
+                'enabled': True,
+            },
+        )
+
+
+class TestUpdateAlertRule:
+    @pytest.mark.asyncio
+    async def test_update_success(self, mock_http_client, mock_token_manager):
+        mock_http_client.patch.return_value = {'id': RULE_ID, 'threshold': 80.0}
+
+        result = await update_alert_rule(
+            rule_id=RULE_ID,
+            workspace='testworkspace',
+            threshold=80.0,
+            region='ap1',
+        )
+
+        assert result['status'] == 'success'
+        assert result['rule_id'] == RULE_ID
+        mock_http_client.patch.assert_called_once_with(
+            region='ap1',
+            workspace='testworkspace',
+            endpoint=f'/api/metrics/alert-rules/{RULE_ID}/',
+            token='test-token',
+            data={'threshold': 80.0},
+        )
+
+    @pytest.mark.asyncio
+    async def test_update_no_data_returns_error(
+        self, mock_http_client, mock_token_manager
+    ):
+        result = await update_alert_rule(
+            rule_id=RULE_ID, workspace='testworkspace', region='ap1'
+        )
+
+        assert result['status'] == 'error'
+        mock_http_client.patch.assert_not_called()
+
+
+class TestDeleteAlertRule:
+    @pytest.mark.asyncio
+    async def test_delete_success(self, mock_http_client, mock_token_manager):
+        mock_http_client.delete.return_value = {}
+
+        result = await delete_alert_rule(
+            rule_id=RULE_ID, workspace='testworkspace', region='ap1'
+        )
+
+        assert result['status'] == 'success'
+        assert result['rule_id'] == RULE_ID
+        mock_http_client.delete.assert_called_once_with(
+            region='ap1',
+            workspace='testworkspace',
+            endpoint=f'/api/metrics/alert-rules/{RULE_ID}/',
+            token='test-token',
+        )
+
+
+# Each endpoint's error-envelope path is identical; one parametrized case per
+# tool (with its HTTP verb) replaces six near-duplicate per-class tests.
+@pytest.mark.parametrize(
+    'verb, func, kwargs',
+    [
+        ('get', list_alerts, {}),
+        ('get', get_alert, {'alert_id': ALERT_ID}),
+        ('post', mute_alert, {'alert_id': ALERT_ID}),
+        (
+            'post',
+            create_alert_rule,
+            {
+                'name': 'cpu-high',
+                'metric_type': 'cpu',
+                'condition': 'gt',
+                'threshold': 90.0,
+            },
+        ),
+        ('patch', update_alert_rule, {'rule_id': RULE_ID, 'threshold': 80.0}),
+        ('delete', delete_alert_rule, {'rule_id': RULE_ID}),
+    ],
+    ids=[
+        'list_alerts',
+        'get_alert',
+        'mute_alert',
+        'create_alert_rule',
+        'update_alert_rule',
+        'delete_alert_rule',
+    ],
+)
+@pytest.mark.asyncio
+async def test_http_error_returns_error(
+    verb, func, kwargs, mock_http_client, mock_token_manager
+):
+    getattr(mock_http_client, verb).return_value = HTTP_ERROR_ENVELOPE
+
+    result = await func(workspace='testworkspace', region='ap1', **kwargs)
+
+    assert result['status'] == 'error'

--- a/tests/test_approval_tools.py
+++ b/tests/test_approval_tools.py
@@ -4,6 +4,7 @@ from unittest.mock import AsyncMock, patch
 
 import pytest
 
+from tests.conftest import HTTP_ERROR_ENVELOPE
 from tools.approval_tools import (
     create_sudo_policy,
     explain_approval_decision,
@@ -123,6 +124,21 @@ class TestGetApprovalRequest:
             token='test-token',
         )
 
+    @pytest.mark.asyncio
+    async def test_get_approval_request_http_error(
+        self, mock_http_client, mock_token_manager
+    ):
+        """An http_client error envelope must surface as status='error'."""
+        mock_http_client.get.return_value = HTTP_ERROR_ENVELOPE
+
+        result = await get_approval_request(
+            request_id='req-1', workspace='testworkspace', region='ap1'
+        )
+
+        assert result['status'] == 'error'
+        assert result['status_code'] == 404
+        assert result['message'] == 'Not found'
+
 
 class TestApprovalDecisionIsHumanOnly:
     """ADR 0015: an agent cannot approve/reject; there is no mutation tool."""
@@ -198,6 +214,19 @@ class TestSudoPolicies:
         )
 
     @pytest.mark.asyncio
+    async def test_list_sudo_policies_http_error(
+        self, mock_http_client, mock_token_manager
+    ):
+        """An http_client error envelope must surface as status='error'."""
+        mock_http_client.get.return_value = HTTP_ERROR_ENVELOPE
+
+        result = await list_sudo_policies(workspace='testworkspace', region='ap1')
+
+        assert result['status'] == 'error'
+        assert result['status_code'] == 404
+        assert result['message'] == 'Not found'
+
+    @pytest.mark.asyncio
     async def test_create_sudo_policy_success(
         self, mock_http_client, mock_token_manager
     ):
@@ -258,3 +287,21 @@ class TestSudoPolicies:
                 'no_password': False,
             },
         )
+
+    @pytest.mark.asyncio
+    async def test_create_sudo_policy_http_error(
+        self, mock_http_client, mock_token_manager
+    ):
+        """An http_client error envelope must surface as status='error'."""
+        mock_http_client.post.return_value = HTTP_ERROR_ENVELOPE
+
+        result = await create_sudo_policy(
+            workspace='testworkspace',
+            name='basic',
+            commands=['/usr/bin/apt update'],
+            region='ap1',
+        )
+
+        assert result['status'] == 'error'
+        assert result['status_code'] == 404
+        assert result['message'] == 'Not found'

--- a/tests/test_audit_tools.py
+++ b/tests/test_audit_tools.py
@@ -1,0 +1,144 @@
+"""Unit tests for audit and logging tools."""
+
+from unittest.mock import AsyncMock, patch
+
+import pytest
+
+from tests.conftest import HTTP_ERROR_ENVELOPE
+from tools.audit_tools import (
+    get_activity_log,
+    get_session_analysis_detail,
+    list_activity_logs,
+    list_server_logs,
+    list_session_analyses,
+    list_webftp_logs,
+)
+
+
+@pytest.fixture
+def mock_http_client():
+    with patch('tools.audit_tools.http_client') as mock_client:
+        mock_client.get = AsyncMock()
+        mock_client.post = AsyncMock()
+        mock_client.patch = AsyncMock()
+        mock_client.delete = AsyncMock()
+        yield mock_client
+
+
+@pytest.fixture
+def mock_token_manager():
+    with patch('utils.common.token_manager') as mock_manager:
+        mock_manager.get_token.return_value = 'test-token'
+        yield mock_manager
+
+
+class TestListActivityLogs:
+    @pytest.mark.asyncio
+    async def test_success(self, mock_http_client, mock_token_manager):
+        mock_http_client.get.return_value = {'results': [], 'count': 0}
+
+        result = await list_activity_logs(workspace='test-ws', region='ap1')
+
+        assert result['status'] == 'success'
+        mock_http_client.get.assert_called_once_with(
+            region='ap1',
+            workspace='test-ws',
+            endpoint='/api/audit/activity/',
+            token='test-token',
+            params={},
+        )
+
+
+class TestGetActivityLog:
+    @pytest.mark.asyncio
+    async def test_success(self, mock_http_client, mock_token_manager):
+        mock_http_client.get.return_value = {'id': 'log-1'}
+
+        result = await get_activity_log(
+            log_id='log-1', workspace='test-ws', region='ap1'
+        )
+
+        assert result['status'] == 'success'
+        assert result['log_id'] == 'log-1'
+
+
+class TestListServerLogs:
+    @pytest.mark.asyncio
+    async def test_success(self, mock_http_client, mock_token_manager):
+        mock_http_client.get.return_value = {'results': []}
+
+        result = await list_server_logs(workspace='test-ws', region='ap1')
+
+        assert result['status'] == 'success'
+        mock_http_client.get.assert_called_once_with(
+            region='ap1',
+            workspace='test-ws',
+            endpoint='/api/history/logs/',
+            token='test-token',
+            params={},
+        )
+
+
+class TestListWebftpLogs:
+    @pytest.mark.asyncio
+    async def test_success(self, mock_http_client, mock_token_manager):
+        mock_http_client.get.return_value = {'results': []}
+
+        result = await list_webftp_logs(workspace='test-ws', region='ap1')
+
+        assert result['status'] == 'success'
+
+
+class TestListSessionAnalyses:
+    @pytest.mark.asyncio
+    async def test_success(self, mock_http_client, mock_token_manager):
+        mock_http_client.get.return_value = {'results': []}
+
+        result = await list_session_analyses(workspace='test-ws', region='ap1')
+
+        assert result['status'] == 'success'
+
+
+class TestGetSessionAnalysisDetail:
+    @pytest.mark.asyncio
+    async def test_success(self, mock_http_client, mock_token_manager):
+        mock_http_client.get.return_value = {'id': 'analysis-1'}
+
+        result = await get_session_analysis_detail(
+            analysis_id='analysis-1', workspace='test-ws', region='ap1'
+        )
+
+        assert result['status'] == 'success'
+        assert result['analysis_id'] == 'analysis-1'
+
+
+# All audit endpoints are GET reads; one parametrized case covers every tool's
+# error-envelope path instead of repeating an identical test per class.
+@pytest.mark.parametrize(
+    'func, kwargs',
+    [
+        (list_activity_logs, {}),
+        (get_activity_log, {'log_id': 'log-1'}),
+        (list_server_logs, {}),
+        (list_webftp_logs, {}),
+        (list_session_analyses, {}),
+        (get_session_analysis_detail, {'analysis_id': 'analysis-1'}),
+    ],
+    ids=[
+        'list_activity_logs',
+        'get_activity_log',
+        'list_server_logs',
+        'list_webftp_logs',
+        'list_session_analyses',
+        'get_session_analysis_detail',
+    ],
+)
+@pytest.mark.asyncio
+async def test_http_error_returns_error(
+    func, kwargs, mock_http_client, mock_token_manager
+):
+    mock_http_client.get.return_value = HTTP_ERROR_ENVELOPE
+
+    result = await func(workspace='test-ws', region='ap1', **kwargs)
+
+    assert result['status'] == 'error'

--- a/tests/test_cert_tools.py
+++ b/tests/test_cert_tools.py
@@ -4,6 +4,7 @@ from unittest.mock import AsyncMock, patch
 
 import pytest
 
+from tests.conftest import HTTP_ERROR_ENVELOPE
 from tools.cert_tools import (
     approve_revoke_request,
     approve_sign_request,
@@ -629,6 +630,45 @@ class TestSignRequestDetails:
             token='test-token',
             data={},
         )
+
+
+class TestErrorPropagation:
+    """Test that http_client error envelopes are reported as status='error'."""
+
+    @pytest.mark.asyncio
+    async def test_approve_sign_request_error(
+        self, mock_http_client, mock_token_manager
+    ):
+        """Test approve sign request reports upstream 404 as an error."""
+        mock_http_client.post.return_value = HTTP_ERROR_ENVELOPE
+
+        result = await approve_sign_request(
+            csr_id='csr-1', workspace='testworkspace', region='ap1'
+        )
+
+        assert result['status'] == 'error'
+
+    @pytest.mark.asyncio
+    async def test_revoke_certificate_error(self, mock_http_client, mock_token_manager):
+        """Test revoke certificate reports upstream 404 as an error."""
+        mock_http_client.post.return_value = HTTP_ERROR_ENVELOPE
+
+        result = await revoke_certificate(
+            certificate_id='cert-1', workspace='testworkspace', region='ap1'
+        )
+
+        assert result['status'] == 'error'
+
+    @pytest.mark.asyncio
+    async def test_get_certificate_error(self, mock_http_client, mock_token_manager):
+        """Test get certificate reports upstream 404 as an error."""
+        mock_http_client.get.return_value = HTTP_ERROR_ENVELOPE
+
+        result = await get_certificate(
+            certificate_id='cert-1', workspace='testworkspace', region='ap1'
+        )
+
+        assert result['status'] == 'error'
 
 
 class TestGetCertificate:

--- a/tests/test_events_tools.py
+++ b/tests/test_events_tools.py
@@ -9,6 +9,8 @@ from unittest.mock import AsyncMock, patch
 
 import pytest
 
+from tests.conftest import HTTP_ERROR_ENVELOPE
+
 
 @pytest.fixture
 def mock_http_client():
@@ -146,6 +148,19 @@ class TestListEvents:
         assert result['status'] == 'error'
         assert 'HTTP 500' in result['message']
 
+    @pytest.mark.asyncio
+    async def test_list_events_error_envelope(
+        self, mock_http_client, mock_token_manager
+    ):
+        """Test events listing surfaces http_client error envelope as error."""
+        from tools.events_tools import list_events
+
+        mock_http_client.get.return_value = HTTP_ERROR_ENVELOPE
+
+        result = await list_events(workspace='testworkspace')
+
+        assert result['status'] == 'error'
+
 
 class TestGetEvent:
     """Test get_event function."""
@@ -211,6 +226,17 @@ class TestGetEvent:
 
         assert result['status'] == 'error'
         assert '404' in result['message']
+
+    @pytest.mark.asyncio
+    async def test_get_event_error_envelope(self, mock_http_client, mock_token_manager):
+        """Test event retrieval surfaces http_client error envelope as error."""
+        from tools.events_tools import get_event
+
+        mock_http_client.get.return_value = HTTP_ERROR_ENVELOPE
+
+        result = await get_event(event_id='event-123', workspace='testworkspace')
+
+        assert result['status'] == 'error'
 
 
 class TestSearchEvents:
@@ -335,6 +361,19 @@ class TestSearchEvents:
 
         assert result['status'] == 'error'
         assert 'Search service unavailable' in result['message']
+
+    @pytest.mark.asyncio
+    async def test_search_events_error_envelope(
+        self, mock_http_client, mock_token_manager
+    ):
+        """Test event search surfaces http_client error envelope as error."""
+        from tools.events_tools import search_events
+
+        mock_http_client.get.return_value = HTTP_ERROR_ENVELOPE
+
+        result = await search_events(search_query='test', workspace='testworkspace')
+
+        assert result['status'] == 'error'
 
 
 if __name__ == '__main__':

--- a/tests/test_iam_tools.py
+++ b/tests/test_iam_tools.py
@@ -8,6 +8,7 @@ from unittest.mock import AsyncMock, patch
 
 import pytest
 
+from tests.conftest import HTTP_ERROR_ENVELOPE
 from tools.iam_tools import (
     add_iam_member,
     assign_application_system_users,
@@ -397,6 +398,43 @@ class TestErrorHandling:
         assert result['status'] == 'error'
         assert 'No token found' in result['message']
         mock_http_client.post.assert_not_called()
+
+
+class TestHTTPErrorEnvelope:
+    """Test that http_client error envelopes surface as error responses."""
+
+    @pytest.mark.asyncio
+    async def test_get_iam_user_http_error(self, mock_http_client, mock_token_manager):
+        """get_iam_user reports error when http_client returns an error envelope."""
+        mock_http_client.get.return_value = HTTP_ERROR_ENVELOPE
+
+        result = await get_iam_user(user_id=USER_ID, workspace='testworkspace')
+
+        assert result['status'] == 'error'
+
+    @pytest.mark.asyncio
+    async def test_create_iam_user_http_error(
+        self, mock_http_client, mock_token_manager
+    ):
+        """create_iam_user reports error when http_client returns an error envelope."""
+        mock_http_client.post.return_value = HTTP_ERROR_ENVELOPE
+
+        result = await create_iam_user(
+            username='testuser', email='test@example.com', workspace='testworkspace'
+        )
+
+        assert result['status'] == 'error'
+
+    @pytest.mark.asyncio
+    async def test_delete_iam_user_http_error(
+        self, mock_http_client, mock_token_manager
+    ):
+        """delete_iam_user reports error when http_client returns an error envelope."""
+        mock_http_client.delete.return_value = HTTP_ERROR_ENVELOPE
+
+        result = await delete_iam_user(user_id=USER_ID, workspace='testworkspace')
+
+        assert result['status'] == 'error'
 
 
 class TestParameterValidation:

--- a/tests/test_metrics_tools.py
+++ b/tests/test_metrics_tools.py
@@ -9,6 +9,8 @@ from unittest.mock import AsyncMock, patch
 
 import pytest
 
+from tests.conftest import HTTP_ERROR_ENVELOPE
+
 
 @pytest.fixture
 def mock_http_client():
@@ -92,6 +94,23 @@ class TestGetCpuUsage:
         params = call_args[1]['params']
         assert params['server'] == '550e8400-e29b-41d4-a716-446655440001'
         assert 'start' in params  # Default start date is auto-generated
+
+    @pytest.mark.asyncio
+    async def test_cpu_usage_http_error_envelope(
+        self, mock_http_client, mock_token_manager
+    ):
+        """Test CPU usage returns error when http_client returns an error envelope."""
+        from tools.metrics_tools import get_cpu_usage
+
+        mock_http_client.get.return_value = HTTP_ERROR_ENVELOPE
+
+        result = await get_cpu_usage(
+            server_id='550e8400-e29b-41d4-a716-446655440001', workspace='testworkspace'
+        )
+
+        assert result['status'] == 'error'
+        assert result['status_code'] == 404
+        assert result['message'] == 'Not found'
 
     @pytest.mark.asyncio
     async def test_cpu_usage_no_token(self, mock_http_client, mock_token_manager):
@@ -389,6 +408,27 @@ class TestGetNetworkTraffic:
         assert 'No token found' in result['message']
 
 
+class TestGetDiskIo:
+    """Test get_disk_io function."""
+
+    @pytest.mark.asyncio
+    async def test_disk_io_http_error_envelope(
+        self, mock_http_client, mock_token_manager
+    ):
+        """Test disk I/O returns error when http_client returns an error envelope."""
+        from tools.metrics_tools import get_disk_io
+
+        mock_http_client.get.return_value = HTTP_ERROR_ENVELOPE
+
+        result = await get_disk_io(
+            server_id='550e8400-e29b-41d4-a716-446655440001', workspace='testworkspace'
+        )
+
+        assert result['status'] == 'error'
+        assert result['status_code'] == 404
+        assert result['message'] == 'Not found'
+
+
 class TestGetTopServers:
     """Test get_top_servers function."""
 
@@ -572,6 +612,21 @@ class TestGetAlertRules:
         # Verify no server filter was applied
         call_args = mock_http_client.get.call_args
         assert call_args[1]['params'] == {}
+
+    @pytest.mark.asyncio
+    async def test_alert_rules_http_error_envelope(
+        self, mock_http_client, mock_token_manager
+    ):
+        """Test alert rules returns error when http_client returns an error envelope."""
+        from tools.metrics_tools import get_alert_rules
+
+        mock_http_client.get.return_value = HTTP_ERROR_ENVELOPE
+
+        result = await get_alert_rules(workspace='testworkspace')
+
+        assert result['status'] == 'error'
+        assert result['status_code'] == 404
+        assert result['message'] == 'Not found'
 
     @pytest.mark.asyncio
     async def test_alert_rules_no_token(self, mock_http_client, mock_token_manager):

--- a/tests/test_metrics_tools.py
+++ b/tests/test_metrics_tools.py
@@ -299,6 +299,25 @@ class TestGetDiskUsage:
         assert mock_http_client.get.call_count == 2
 
     @pytest.mark.asyncio
+    async def test_disk_usage_device_discovery_http_error(
+        self, mock_http_client, mock_token_manager
+    ):
+        """Device-discovery 4xx/5xx must surface as an error, not 'no devices'."""
+        from tools.metrics_tools import get_disk_usage
+
+        mock_http_client.get.return_value = HTTP_ERROR_ENVELOPE
+
+        result = await get_disk_usage(
+            server_id='550e8400-e29b-41d4-a716-446655440001', workspace='testworkspace'
+        )
+
+        assert result['status'] == 'error'
+        assert result['status_code'] == 404
+        assert 'No disk devices found' not in result['message']
+        # The metrics call must be skipped once discovery fails.
+        assert mock_http_client.get.call_count == 1
+
+    @pytest.mark.asyncio
     async def test_disk_usage_no_token(self, mock_http_client, mock_token_manager):
         """Test disk usage when no token is available."""
         from tools.metrics_tools import get_disk_usage
@@ -497,6 +516,22 @@ class TestGetTopServers:
 
         # Multiple metrics - returns combined data
         assert 'data' in result
+
+    @pytest.mark.asyncio
+    async def test_top_servers_single_metric_http_error(
+        self, mock_http_client, mock_token_manager
+    ):
+        """A single-metric error envelope must not be wrapped as success."""
+        from tools.metrics_tools import get_top_servers
+
+        mock_http_client.get.return_value = HTTP_ERROR_ENVELOPE
+
+        result = await get_top_servers(
+            workspace='testworkspace', metric_types='cpu', region='ap1'
+        )
+
+        assert result['status'] == 'error'
+        assert result['status_code'] == 404
 
     @pytest.mark.asyncio
     async def test_top_servers_invalid_metric(

--- a/tests/test_package_tools.py
+++ b/tests/test_package_tools.py
@@ -4,6 +4,7 @@ from unittest.mock import AsyncMock, patch
 
 import pytest
 
+from tests.conftest import HTTP_ERROR_ENVELOPE
 from tools.package_tools import (
     install_python_package,
     install_system_package,
@@ -161,6 +162,37 @@ class TestSystemPackages:
             token='test-token',
         )
 
+    @pytest.mark.asyncio
+    async def test_list_system_package_entries_error(
+        self, mock_http_client, mock_token_manager
+    ):
+        """Test system package entries listing surfaces an HTTP error."""
+        mock_http_client.get.return_value = HTTP_ERROR_ENVELOPE
+
+        result = await list_system_package_entries(
+            server_id=SERVER_ID, workspace='testworkspace', region='ap1'
+        )
+
+        assert result['status'] == 'error'
+        assert result['status_code'] == 404
+
+    @pytest.mark.asyncio
+    async def test_install_system_package_error(
+        self, mock_http_client, mock_token_manager
+    ):
+        """Test system package installation surfaces an HTTP error."""
+        mock_http_client.post.return_value = HTTP_ERROR_ENVELOPE
+
+        result = await install_system_package(
+            server_id=SERVER_ID,
+            package_name='htop',
+            workspace='testworkspace',
+            region='ap1',
+        )
+
+        assert result['status'] == 'error'
+        assert result['status_code'] == 404
+
 
 class TestPythonPackages:
     """Test Python package tools."""
@@ -262,3 +294,17 @@ class TestPythonPackages:
             endpoint='/api/packages/python/entries/py-1/',
             token='test-token',
         )
+
+    @pytest.mark.asyncio
+    async def test_remove_python_package_error(
+        self, mock_http_client, mock_token_manager
+    ):
+        """Test Python package removal surfaces an HTTP error."""
+        mock_http_client.delete.return_value = HTTP_ERROR_ENVELOPE
+
+        result = await remove_python_package(
+            entry_id='py-1', workspace='testworkspace', region='ap1'
+        )
+
+        assert result['status'] == 'error'
+        assert result['status_code'] == 404

--- a/tests/test_security_tools.py
+++ b/tests/test_security_tools.py
@@ -4,6 +4,7 @@ from unittest.mock import AsyncMock, patch
 
 import pytest
 
+from tests.conftest import HTTP_ERROR_ENVELOPE
 from tools.security_tools import (
     bulk_server_acl,
     create_command_acl,
@@ -205,6 +206,21 @@ class TestCreateCommandAcl:
 
         assert result['status'] == 'error'
         mock_http_client.post.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_create_http_error_returns_error(
+        self, mock_http_client, mock_token_manager
+    ):
+        mock_http_client.post.return_value = HTTP_ERROR_ENVELOPE
+
+        result = await create_command_acl(
+            workspace='testworkspace',
+            command='docker *',
+            api_token_id='token-uuid',
+            region='ap1',
+        )
+
+        assert result['status'] == 'error'
 
 
 class TestUpdateCommandAcl:
@@ -578,6 +594,20 @@ class TestDeleteServerAcl:
             token='test-token',
         )
 
+    @pytest.mark.asyncio
+    async def test_delete_http_error_returns_error(
+        self, mock_http_client, mock_token_manager
+    ):
+        mock_http_client.delete.return_value = HTTP_ERROR_ENVELOPE
+
+        result = await delete_server_acl(
+            acl_id='acl-1',
+            workspace='testworkspace',
+            region='ap1',
+        )
+
+        assert result['status'] == 'error'
+
 
 class TestBulkServerAcl:
     @pytest.mark.asyncio
@@ -764,6 +794,16 @@ class TestListFileAcls:
             token='test-token',
             params={},
         )
+
+    @pytest.mark.asyncio
+    async def test_list_http_error_returns_error(
+        self, mock_http_client, mock_token_manager
+    ):
+        mock_http_client.get.return_value = HTTP_ERROR_ENVELOPE
+
+        result = await list_file_acls(workspace='testworkspace', region='ap1')
+
+        assert result['status'] == 'error'
 
     @pytest.mark.asyncio
     async def test_list_filter_by_api_token(self, mock_http_client, mock_token_manager):

--- a/tests/test_system_info_tools.py
+++ b/tests/test_system_info_tools.py
@@ -9,6 +9,8 @@ from unittest.mock import AsyncMock, patch
 
 import pytest
 
+from tests.conftest import HTTP_ERROR_ENVELOPE
+
 
 @pytest.fixture
 def mock_http_client():
@@ -98,6 +100,29 @@ class TestGetSystemInfo:
 
         assert result['status'] == 'error'
         assert 'Failed in get_system_info' in result['message']
+
+    @pytest.mark.asyncio
+    async def test_system_info_error_envelope(
+        self, mock_http_client, mock_token_manager
+    ):
+        """Test that an http_client error envelope returns an error response."""
+        from tools.system_info_tools import get_system_info
+
+        mock_http_client.get.return_value = HTTP_ERROR_ENVELOPE
+
+        result = await get_system_info(
+            server_id='550e8400-e29b-41d4-a716-446655440001',
+            workspace='testworkspace',
+            region='ap1',
+        )
+
+        assert result['status'] == 'error'
+        assert result['message'] == 'Not found'
+        assert result['status_code'] == 404
+        assert result['server_id'] == '550e8400-e29b-41d4-a716-446655440001'
+        assert result['region'] == 'ap1'
+        assert result['workspace'] == 'testworkspace'
+        assert 'data' not in result
 
 
 class TestGetOsVersion:
@@ -261,6 +286,27 @@ class TestListSystemUsers:
 
         assert result['status'] == 'error'
         assert 'No token found' in result['message']
+
+    @pytest.mark.asyncio
+    async def test_list_users_error_envelope(
+        self, mock_http_client, mock_token_manager
+    ):
+        """Test that an http_client error envelope returns an error response."""
+        from tools.system_info_tools import list_system_users
+
+        mock_http_client.get.return_value = HTTP_ERROR_ENVELOPE
+
+        result = await list_system_users(
+            server_id='550e8400-e29b-41d4-a716-446655440001',
+            workspace='testworkspace',
+            region='ap1',
+        )
+
+        assert result['status'] == 'error'
+        assert result['message'] == 'Not found'
+        assert result['status_code'] == 404
+        assert result['server_id'] == '550e8400-e29b-41d4-a716-446655440001'
+        assert 'data' not in result
 
 
 class TestListSystemGroups:
@@ -513,6 +559,27 @@ class TestGetNetworkInterfaces:
 
         assert result['status'] == 'error'
         assert 'No token found' in result['message']
+
+    @pytest.mark.asyncio
+    async def test_network_interfaces_error_envelope(
+        self, mock_http_client, mock_token_manager
+    ):
+        """Test that an http_client error envelope returns an error response."""
+        from tools.system_info_tools import get_network_interfaces
+
+        mock_http_client.get.return_value = HTTP_ERROR_ENVELOPE
+
+        result = await get_network_interfaces(
+            server_id='550e8400-e29b-41d4-a716-446655440001',
+            workspace='testworkspace',
+            region='ap1',
+        )
+
+        assert result['status'] == 'error'
+        assert result['message'] == 'Not found'
+        assert result['status_code'] == 404
+        assert result['server_id'] == '550e8400-e29b-41d4-a716-446655440001'
+        assert 'data' not in result
 
 
 class TestGetDiskInfo:

--- a/tools/alert_tools.py
+++ b/tools/alert_tools.py
@@ -2,7 +2,7 @@
 
 from typing import Any
 
-from utils.common import error_response, success_response
+from utils.common import error_response, success_response, unwrap_http_result
 from utils.decorators import mcp_tool_handler
 from utils.http_client import http_client
 from utils.tool_annotations import ADDITIVE, DESTRUCTIVE, IDEMPOTENT_WRITE, READ_ONLY
@@ -62,6 +62,16 @@ async def list_alerts(
         params=params,
     )
 
+    err = unwrap_http_result(
+        result,
+        default_message='Failed to list alerts',
+        server_id=server_id,
+        region=region,
+        workspace=workspace,
+    )
+    if err:
+        return err
+
     return success_response(
         data=result, server_id=server_id, region=region, workspace=workspace
     )
@@ -93,6 +103,16 @@ async def get_alert(
         endpoint=f'/api/alerts/{alert_id}/',
         token=token,
     )
+
+    err = unwrap_http_result(
+        result,
+        default_message='Failed to get alert',
+        alert_id=alert_id,
+        region=region,
+        workspace=workspace,
+    )
+    if err:
+        return err
 
     return success_response(
         data=result, alert_id=alert_id, region=region, workspace=workspace
@@ -135,6 +155,16 @@ async def mute_alert(
         token=token,
         data=mute_data,
     )
+
+    err = unwrap_http_result(
+        result,
+        default_message='Failed to mute alert',
+        alert_id=alert_id,
+        region=region,
+        workspace=workspace,
+    )
+    if err:
+        return err
 
     return success_response(
         data=result, alert_id=alert_id, region=region, workspace=workspace
@@ -208,6 +238,15 @@ async def create_alert_rule(
         data=rule_data,
     )
 
+    err = unwrap_http_result(
+        result,
+        default_message='Failed to create alert rule',
+        region=region,
+        workspace=workspace,
+    )
+    if err:
+        return err
+
     return success_response(data=result, region=region, workspace=workspace)
 
 
@@ -279,6 +318,16 @@ async def update_alert_rule(
         data=update_data,
     )
 
+    err = unwrap_http_result(
+        result,
+        default_message='Failed to update alert rule',
+        rule_id=rule_id,
+        region=region,
+        workspace=workspace,
+    )
+    if err:
+        return err
+
     return success_response(
         data=result, rule_id=rule_id, region=region, workspace=workspace
     )
@@ -310,6 +359,16 @@ async def delete_alert_rule(
         endpoint=f'/api/metrics/alert-rules/{rule_id}/',
         token=token,
     )
+
+    err = unwrap_http_result(
+        result,
+        default_message='Failed to delete alert rule',
+        rule_id=rule_id,
+        region=region,
+        workspace=workspace,
+    )
+    if err:
+        return err
 
     return success_response(
         data=result, rule_id=rule_id, region=region, workspace=workspace

--- a/tools/approval_tools.py
+++ b/tools/approval_tools.py
@@ -11,7 +11,11 @@ who approves out-of-band (Alpacon web console or Slack).
 
 from typing import Any
 
-from utils.common import pending_approval_response, success_response
+from utils.common import (
+    pending_approval_response,
+    success_response,
+    unwrap_http_result,
+)
 from utils.decorators import mcp_tool_handler
 from utils.http_client import http_client
 from utils.tool_annotations import ADDITIVE, READ_ONLY
@@ -64,6 +68,15 @@ async def list_approval_requests(
         params=params,
     )
 
+    err = unwrap_http_result(
+        result,
+        default_message='Failed to list approval requests',
+        region=region,
+        workspace=workspace,
+    )
+    if err:
+        return err
+
     return success_response(data=result, region=region, workspace=workspace)
 
 
@@ -93,6 +106,16 @@ async def get_approval_request(
         endpoint=f'/api/approvals/approvals/{request_id}/',
         token=token,
     )
+
+    err = unwrap_http_result(
+        result,
+        default_message='Failed to get approval request',
+        request_id=request_id,
+        region=region,
+        workspace=workspace,
+    )
+    if err:
+        return err
 
     return success_response(
         data=result, request_id=request_id, region=region, workspace=workspace
@@ -196,6 +219,15 @@ async def list_sudo_policies(
         params=params,
     )
 
+    err = unwrap_http_result(
+        result,
+        default_message='Failed to list sudo policies',
+        region=region,
+        workspace=workspace,
+    )
+    if err:
+        return err
+
     return success_response(data=result, region=region, workspace=workspace)
 
 
@@ -260,5 +292,14 @@ async def create_sudo_policy(
         token=token,
         data=policy_data,
     )
+
+    err = unwrap_http_result(
+        result,
+        default_message='Failed to create sudo policy',
+        region=region,
+        workspace=workspace,
+    )
+    if err:
+        return err
 
     return success_response(data=result, region=region, workspace=workspace)

--- a/tools/audit_tools.py
+++ b/tools/audit_tools.py
@@ -2,7 +2,7 @@
 
 from typing import Any
 
-from utils.common import success_response
+from utils.common import success_response, unwrap_http_result
 from utils.decorators import mcp_tool_handler
 from utils.http_client import http_client
 from utils.tool_annotations import READ_ONLY
@@ -51,6 +51,15 @@ async def list_activity_logs(
         params=params,
     )
 
+    err = unwrap_http_result(
+        result,
+        default_message='Failed to list activity logs',
+        region=region,
+        workspace=workspace,
+    )
+    if err:
+        return err
+
     return success_response(data=result, region=region, workspace=workspace)
 
 
@@ -80,6 +89,16 @@ async def get_activity_log(
         endpoint=f'/api/audit/activity/{log_id}/',
         token=token,
     )
+
+    err = unwrap_http_result(
+        result,
+        default_message='Failed to get activity log details',
+        log_id=log_id,
+        region=region,
+        workspace=workspace,
+    )
+    if err:
+        return err
 
     return success_response(
         data=result, log_id=log_id, region=region, workspace=workspace
@@ -134,6 +153,16 @@ async def list_server_logs(
         params=params,
     )
 
+    err = unwrap_http_result(
+        result,
+        default_message='Failed to list server logs',
+        server_id=server_id,
+        region=region,
+        workspace=workspace,
+    )
+    if err:
+        return err
+
     return success_response(
         data=result, server_id=server_id, region=region, workspace=workspace
     )
@@ -181,6 +210,16 @@ async def list_webftp_logs(
         token=token,
         params=params,
     )
+
+    err = unwrap_http_result(
+        result,
+        default_message='Failed to list WebFTP logs',
+        server_id=server_id,
+        region=region,
+        workspace=workspace,
+    )
+    if err:
+        return err
 
     return success_response(
         data=result, server_id=server_id, region=region, workspace=workspace
@@ -243,6 +282,16 @@ async def list_session_analyses(
         params=params,
     )
 
+    err = unwrap_http_result(
+        result,
+        default_message='Failed to list session analyses',
+        server_id=server_id,
+        region=region,
+        workspace=workspace,
+    )
+    if err:
+        return err
+
     return success_response(
         data=result, server_id=server_id, region=region, workspace=workspace
     )
@@ -277,6 +326,16 @@ async def get_session_analysis_detail(
         endpoint=f'/api/history/session-analyses/{analysis_id}/',
         token=token,
     )
+
+    err = unwrap_http_result(
+        result,
+        default_message='Failed to get session analysis details',
+        analysis_id=analysis_id,
+        region=region,
+        workspace=workspace,
+    )
+    if err:
+        return err
 
     return success_response(
         data=result, analysis_id=analysis_id, region=region, workspace=workspace

--- a/tools/cert_tools.py
+++ b/tools/cert_tools.py
@@ -2,7 +2,7 @@
 
 from typing import Any
 
-from utils.common import error_response, success_response
+from utils.common import error_response, success_response, unwrap_http_result
 from utils.decorators import mcp_tool_handler
 from utils.http_client import http_client
 from utils.tool_annotations import ADDITIVE, DESTRUCTIVE, IDEMPOTENT_WRITE, READ_ONLY
@@ -50,6 +50,15 @@ async def list_certificate_authorities(
         token=token,
         params=params,
     )
+
+    err = unwrap_http_result(
+        result,
+        default_message='Failed to list certificate authorities',
+        region=region,
+        workspace=workspace,
+    )
+    if err:
+        return err
 
     return success_response(data=result, region=region, workspace=workspace)
 
@@ -126,6 +135,15 @@ async def create_certificate_authority(
         data=ca_data,
     )
 
+    err = unwrap_http_result(
+        result,
+        default_message='Failed to create certificate authority',
+        region=region,
+        workspace=workspace,
+    )
+    if err:
+        return err
+
     return success_response(data=result, region=region, workspace=workspace)
 
 
@@ -158,6 +176,16 @@ async def get_certificate_authority(
         endpoint=f'/api/cert/authorities/{ca_id}/',
         token=token,
     )
+
+    err = unwrap_http_result(
+        result,
+        default_message='Failed to get certificate authority details',
+        ca_id=ca_id,
+        region=region,
+        workspace=workspace,
+    )
+    if err:
+        return err
 
     return success_response(
         data=result, ca_id=ca_id, region=region, workspace=workspace
@@ -212,6 +240,16 @@ async def update_certificate_authority(
         data=patch_data,
     )
 
+    err = unwrap_http_result(
+        result,
+        default_message='Failed to update certificate authority',
+        ca_id=ca_id,
+        region=region,
+        workspace=workspace,
+    )
+    if err:
+        return err
+
     return success_response(
         data=result, ca_id=ca_id, region=region, workspace=workspace
     )
@@ -246,6 +284,16 @@ async def delete_certificate_authority(
         endpoint=f'/api/cert/authorities/{ca_id}/',
         token=token,
     )
+
+    err = unwrap_http_result(
+        result,
+        default_message='Failed to delete certificate authority',
+        ca_id=ca_id,
+        region=region,
+        workspace=workspace,
+    )
+    if err:
+        return err
 
     return success_response(
         data=result, ca_id=ca_id, region=region, workspace=workspace
@@ -295,6 +343,15 @@ async def list_sign_requests(
         token=token,
         params=params,
     )
+
+    err = unwrap_http_result(
+        result,
+        default_message='Failed to list certificate signing requests',
+        region=region,
+        workspace=workspace,
+    )
+    if err:
+        return err
 
     return success_response(data=result, region=region, workspace=workspace)
 
@@ -349,6 +406,15 @@ async def create_sign_request(
         data=csr_data,
     )
 
+    err = unwrap_http_result(
+        result,
+        default_message='Failed to create certificate signing request',
+        region=region,
+        workspace=workspace,
+    )
+    if err:
+        return err
+
     return success_response(data=result, region=region, workspace=workspace)
 
 
@@ -381,6 +447,16 @@ async def get_sign_request(
         endpoint=f'/api/cert/sign-requests/{csr_id}/',
         token=token,
     )
+
+    err = unwrap_http_result(
+        result,
+        default_message='Failed to get certificate signing request details',
+        csr_id=csr_id,
+        region=region,
+        workspace=workspace,
+    )
+    if err:
+        return err
 
     return success_response(
         data=result, csr_id=csr_id, region=region, workspace=workspace
@@ -416,6 +492,16 @@ async def delete_sign_request(
         endpoint=f'/api/cert/sign-requests/{csr_id}/',
         token=token,
     )
+
+    err = unwrap_http_result(
+        result,
+        default_message='Failed to cancel certificate signing request',
+        csr_id=csr_id,
+        region=region,
+        workspace=workspace,
+    )
+    if err:
+        return err
 
     return success_response(
         data=result, csr_id=csr_id, region=region, workspace=workspace
@@ -453,6 +539,16 @@ async def approve_sign_request(
         data={},
     )
 
+    err = unwrap_http_result(
+        result,
+        default_message='Failed to approve certificate signing request',
+        csr_id=csr_id,
+        region=region,
+        workspace=workspace,
+    )
+    if err:
+        return err
+
     return success_response(
         data=result, csr_id=csr_id, region=region, workspace=workspace
     )
@@ -488,6 +584,16 @@ async def deny_sign_request(
         token=token,
         data={},
     )
+
+    err = unwrap_http_result(
+        result,
+        default_message='Failed to deny certificate signing request',
+        csr_id=csr_id,
+        region=region,
+        workspace=workspace,
+    )
+    if err:
+        return err
 
     return success_response(
         data=result, csr_id=csr_id, region=region, workspace=workspace
@@ -526,6 +632,16 @@ async def retry_sign_request(
         token=token,
         data={},
     )
+
+    err = unwrap_http_result(
+        result,
+        default_message='Failed to retry certificate signing request',
+        csr_id=csr_id,
+        region=region,
+        workspace=workspace,
+    )
+    if err:
+        return err
 
     return success_response(
         data=result, csr_id=csr_id, region=region, workspace=workspace
@@ -580,6 +696,15 @@ async def list_certificates(
         params=params,
     )
 
+    err = unwrap_http_result(
+        result,
+        default_message='Failed to list certificates',
+        region=region,
+        workspace=workspace,
+    )
+    if err:
+        return err
+
     return success_response(data=result, region=region, workspace=workspace)
 
 
@@ -612,6 +737,16 @@ async def get_certificate(
         endpoint=f'/api/cert/certificates/{certificate_id}/',
         token=token,
     )
+
+    err = unwrap_http_result(
+        result,
+        default_message='Failed to get certificate details',
+        certificate_id=certificate_id,
+        region=region,
+        workspace=workspace,
+    )
+    if err:
+        return err
 
     return success_response(
         data=result,
@@ -668,6 +803,16 @@ async def revoke_certificate(
         data=data,
     )
 
+    err = unwrap_http_result(
+        result,
+        default_message='Failed to revoke certificate',
+        certificate_id=certificate_id,
+        region=region,
+        workspace=workspace,
+    )
+    if err:
+        return err
+
     return success_response(
         data=result,
         certificate_id=certificate_id,
@@ -720,6 +865,15 @@ async def list_revoke_requests(
         params=params,
     )
 
+    err = unwrap_http_result(
+        result,
+        default_message='Failed to list certificate revocation requests',
+        region=region,
+        workspace=workspace,
+    )
+    if err:
+        return err
+
     return success_response(data=result, region=region, workspace=workspace)
 
 
@@ -752,6 +906,16 @@ async def get_revoke_request(
         endpoint=f'/api/cert/revoke-requests/{revoke_id}/',
         token=token,
     )
+
+    err = unwrap_http_result(
+        result,
+        default_message='Failed to get certificate revocation request details',
+        revoke_id=revoke_id,
+        region=region,
+        workspace=workspace,
+    )
+    if err:
+        return err
 
     return success_response(
         data=result, revoke_id=revoke_id, region=region, workspace=workspace
@@ -789,6 +953,16 @@ async def approve_revoke_request(
         data={},
     )
 
+    err = unwrap_http_result(
+        result,
+        default_message='Failed to approve certificate revocation request',
+        revoke_id=revoke_id,
+        region=region,
+        workspace=workspace,
+    )
+    if err:
+        return err
+
     return success_response(
         data=result, revoke_id=revoke_id, region=region, workspace=workspace
     )
@@ -824,6 +998,16 @@ async def deny_revoke_request(
         token=token,
         data={},
     )
+
+    err = unwrap_http_result(
+        result,
+        default_message='Failed to deny certificate revocation request',
+        revoke_id=revoke_id,
+        region=region,
+        workspace=workspace,
+    )
+    if err:
+        return err
 
     return success_response(
         data=result, revoke_id=revoke_id, region=region, workspace=workspace
@@ -863,6 +1047,16 @@ async def retry_revoke_request(
         data={},
     )
 
+    err = unwrap_http_result(
+        result,
+        default_message='Failed to retry certificate revocation request',
+        revoke_id=revoke_id,
+        region=region,
+        workspace=workspace,
+    )
+    if err:
+        return err
+
     return success_response(
         data=result, revoke_id=revoke_id, region=region, workspace=workspace
     )
@@ -897,6 +1091,16 @@ async def cancel_revoke_request(
         endpoint=f'/api/cert/revoke-requests/{revoke_id}/',
         token=token,
     )
+
+    err = unwrap_http_result(
+        result,
+        default_message='Failed to cancel certificate revocation request',
+        revoke_id=revoke_id,
+        region=region,
+        workspace=workspace,
+    )
+    if err:
+        return err
 
     return success_response(
         data=result, revoke_id=revoke_id, region=region, workspace=workspace

--- a/tools/events_tools.py
+++ b/tools/events_tools.py
@@ -2,7 +2,7 @@
 
 from typing import Any
 
-from utils.common import success_response
+from utils.common import success_response, unwrap_http_result
 from utils.decorators import mcp_tool_handler
 from utils.http_client import http_client
 from utils.tool_annotations import READ_ONLY
@@ -39,6 +39,18 @@ async def list_events(
         params=params,
     )
 
+    err = unwrap_http_result(
+        result,
+        default_message='Failed to list events',
+        server_id=server_id,
+        reporter=reporter,
+        limit=limit,
+        region=region,
+        workspace=workspace,
+    )
+    if err:
+        return err
+
     return success_response(
         data=result,
         server_id=server_id,
@@ -66,6 +78,16 @@ async def get_event(
         endpoint=f'/api/events/events/{event_id}/',
         token=token,
     )
+
+    err = unwrap_http_result(
+        result,
+        default_message='Failed to get event',
+        event_id=event_id,
+        region=region,
+        workspace=workspace,
+    )
+    if err:
+        return err
 
     return success_response(
         data=result, event_id=event_id, region=region, workspace=workspace
@@ -100,6 +122,18 @@ async def search_events(
         token=token,
         params=params,
     )
+
+    err = unwrap_http_result(
+        result,
+        default_message='Failed to search events',
+        search_query=search_query,
+        server_id=server_id,
+        limit=limit,
+        region=region,
+        workspace=workspace,
+    )
+    if err:
+        return err
 
     return success_response(
         data=result,

--- a/tools/iam_tools.py
+++ b/tools/iam_tools.py
@@ -4,7 +4,7 @@ import re
 from typing import Any
 
 from server import mcp
-from utils.common import error_response, success_response
+from utils.common import error_response, success_response, unwrap_http_result
 from utils.decorators import mcp_tool_handler
 from utils.error_handler import format_validation_error, validate_server_id_format
 from utils.http_client import http_client
@@ -69,6 +69,15 @@ async def list_iam_users(
         params=params,
     )
 
+    err = unwrap_http_result(
+        result,
+        default_message='Failed to list IAM users',
+        region=region,
+        workspace=workspace,
+    )
+    if err:
+        return err
+
     return success_response(data=result, region=region, workspace=workspace)
 
 
@@ -106,6 +115,16 @@ async def get_iam_user(
         endpoint=f'/api/iam/users/{user_id}/',
         token=token,
     )
+
+    err = unwrap_http_result(
+        result,
+        default_message='Failed to get IAM user',
+        user_id=user_id,
+        region=region,
+        workspace=workspace,
+    )
+    if err:
+        return err
 
     return success_response(
         data=result, user_id=user_id, region=region, workspace=workspace
@@ -160,6 +179,16 @@ async def create_iam_user(
         token=token,
         data=user_data,
     )
+
+    err = unwrap_http_result(
+        result,
+        default_message='Failed to create IAM user',
+        username=username,
+        region=region,
+        workspace=workspace,
+    )
+    if err:
+        return err
 
     return success_response(
         data=result, username=username, region=region, workspace=workspace
@@ -225,6 +254,16 @@ async def update_iam_user(
         data=update_data,
     )
 
+    err = unwrap_http_result(
+        result,
+        default_message='Failed to update IAM user',
+        user_id=user_id,
+        region=region,
+        workspace=workspace,
+    )
+    if err:
+        return err
+
     return success_response(
         data=result, user_id=user_id, region=region, workspace=workspace
     )
@@ -260,6 +299,16 @@ async def delete_iam_user(
         endpoint=f'/api/iam/users/{user_id}/',
         token=token,
     )
+
+    err = unwrap_http_result(
+        result,
+        default_message='Failed to delete IAM user',
+        user_id=user_id,
+        region=region,
+        workspace=workspace,
+    )
+    if err:
+        return err
 
     return success_response(
         data=result, user_id=user_id, region=region, workspace=workspace
@@ -309,6 +358,15 @@ async def list_iam_groups(
         token=token,
         params=params,
     )
+
+    err = unwrap_http_result(
+        result,
+        default_message='Failed to list IAM groups',
+        region=region,
+        workspace=workspace,
+    )
+    if err:
+        return err
 
     return success_response(data=result, region=region, workspace=workspace)
 
@@ -361,6 +419,16 @@ async def create_iam_group(
         token=token,
         data=group_data,
     )
+
+    err = unwrap_http_result(
+        result,
+        default_message='Failed to create IAM group',
+        group_name=name,
+        region=region,
+        workspace=workspace,
+    )
+    if err:
+        return err
 
     return success_response(
         data=result, group_name=name, region=region, workspace=workspace
@@ -460,6 +528,15 @@ async def get_iam_group(
         endpoint=f'/api/iam/groups/{group_id}/',
         token=token,
     )
+    err = unwrap_http_result(
+        result,
+        default_message='Failed to get IAM group',
+        group_id=group_id,
+        region=region,
+        workspace=workspace,
+    )
+    if err:
+        return err
     return success_response(
         data=result, group_id=group_id, region=region, workspace=workspace
     )
@@ -515,6 +592,15 @@ async def update_iam_group(
         token=token,
         data=update_data,
     )
+    err = unwrap_http_result(
+        result,
+        default_message='Failed to update IAM group',
+        group_id=group_id,
+        region=region,
+        workspace=workspace,
+    )
+    if err:
+        return err
     return success_response(
         data=result, group_id=group_id, region=region, workspace=workspace
     )
@@ -552,6 +638,15 @@ async def delete_iam_group(
         endpoint=f'/api/iam/groups/{group_id}/',
         token=token,
     )
+    err = unwrap_http_result(
+        result,
+        default_message='Failed to delete IAM group',
+        group_id=group_id,
+        region=region,
+        workspace=workspace,
+    )
+    if err:
+        return err
     return success_response(
         data=result, group_id=group_id, region=region, workspace=workspace
     )
@@ -609,6 +704,14 @@ async def list_iam_memberships(
         token=token,
         params=params,
     )
+    err = unwrap_http_result(
+        result,
+        default_message='Failed to list IAM memberships',
+        region=region,
+        workspace=workspace,
+    )
+    if err:
+        return err
     return success_response(data=result, region=region, workspace=workspace)
 
 
@@ -653,6 +756,16 @@ async def add_iam_member(
         token=token,
         data={'group': group_id, 'user': user_id, 'role': role},
     )
+    err = unwrap_http_result(
+        result,
+        default_message='Failed to add IAM member',
+        group_id=group_id,
+        user_id=user_id,
+        region=region,
+        workspace=workspace,
+    )
+    if err:
+        return err
     return success_response(
         data=result,
         group_id=group_id,
@@ -694,6 +807,15 @@ async def remove_iam_member(
         endpoint=f'/api/iam/memberships/{membership_id}/',
         token=token,
     )
+    err = unwrap_http_result(
+        result,
+        default_message='Failed to remove IAM member',
+        membership_id=membership_id,
+        region=region,
+        workspace=workspace,
+    )
+    if err:
+        return err
     return success_response(
         data=result,
         membership_id=membership_id,
@@ -739,6 +861,15 @@ async def invite_workspace_user(
         token=token,
         data={'email': email},
     )
+    err = unwrap_http_result(
+        result,
+        default_message='Failed to invite workspace user',
+        email=email,
+        region=region,
+        workspace=workspace,
+    )
+    if err:
+        return err
     return success_response(
         data=result, email=email, region=region, workspace=workspace
     )
@@ -787,6 +918,14 @@ async def list_iam_applications(
         token=token,
         params=params,
     )
+    err = unwrap_http_result(
+        result,
+        default_message='Failed to list IAM applications',
+        region=region,
+        workspace=workspace,
+    )
+    if err:
+        return err
     return success_response(data=result, region=region, workspace=workspace)
 
 
@@ -838,6 +977,15 @@ async def create_iam_application(
         token=token,
         data=app_data,
     )
+    err = unwrap_http_result(
+        result,
+        default_message='Failed to create IAM application',
+        app_name=name,
+        region=region,
+        workspace=workspace,
+    )
+    if err:
+        return err
     return success_response(
         data=result, app_name=name, region=region, workspace=workspace
     )
@@ -875,6 +1023,15 @@ async def get_iam_application(
         endpoint=f'/api/iam/applications/{app_id}/',
         token=token,
     )
+    err = unwrap_http_result(
+        result,
+        default_message='Failed to get IAM application',
+        app_id=app_id,
+        region=region,
+        workspace=workspace,
+    )
+    if err:
+        return err
     return success_response(
         data=result, app_id=app_id, region=region, workspace=workspace
     )
@@ -927,6 +1084,15 @@ async def update_iam_application(
         token=token,
         data=update_data,
     )
+    err = unwrap_http_result(
+        result,
+        default_message='Failed to update IAM application',
+        app_id=app_id,
+        region=region,
+        workspace=workspace,
+    )
+    if err:
+        return err
     return success_response(
         data=result, app_id=app_id, region=region, workspace=workspace
     )
@@ -964,6 +1130,15 @@ async def delete_iam_application(
         endpoint=f'/api/iam/applications/{app_id}/',
         token=token,
     )
+    err = unwrap_http_result(
+        result,
+        default_message='Failed to delete IAM application',
+        app_id=app_id,
+        region=region,
+        workspace=workspace,
+    )
+    if err:
+        return err
     return success_response(
         data=result, app_id=app_id, region=region, workspace=workspace
     )
@@ -1016,6 +1191,15 @@ async def assign_application_system_users(
         token=token,
         data={'system_user_ids': system_user_ids},
     )
+    err = unwrap_http_result(
+        result,
+        default_message='Failed to assign system users to IAM application',
+        app_id=app_id,
+        region=region,
+        workspace=workspace,
+    )
+    if err:
+        return err
     return success_response(
         data=result, app_id=app_id, region=region, workspace=workspace
     )
@@ -1068,6 +1252,15 @@ async def unassign_application_system_users(
         token=token,
         data={'system_user_ids': system_user_ids},
     )
+    err = unwrap_http_result(
+        result,
+        default_message='Failed to unassign system users from IAM application',
+        app_id=app_id,
+        region=region,
+        workspace=workspace,
+    )
+    if err:
+        return err
     return success_response(
         data=result, app_id=app_id, region=region, workspace=workspace
     )

--- a/tools/metrics_tools.py
+++ b/tools/metrics_tools.py
@@ -795,7 +795,12 @@ async def get_top_servers(
                 raise result  # Re-raise CancelledError, KeyboardInterrupt, etc.
             combined_data[metric] = {'error': str(result), 'available': False}
         else:
-            combined_data[metric] = result
+            err = unwrap_http_result(
+                result, default_message=f'Failed to fetch {metric} metrics'
+            )
+            combined_data[metric] = (
+                {'error': err['message'], 'available': False} if err else result
+            )
 
     return success_response(
         data=combined_data,

--- a/tools/metrics_tools.py
+++ b/tools/metrics_tools.py
@@ -4,7 +4,7 @@ import asyncio
 from datetime import UTC, datetime, timedelta
 from typing import Any
 
-from utils.common import error_response, success_response
+from utils.common import error_response, success_response, unwrap_http_result
 from utils.decorators import mcp_tool_handler
 from utils.error_handler import UpstreamAuthError
 from utils.http_client import http_client
@@ -117,6 +117,16 @@ async def get_cpu_usage(
         token=token,
         params=params,
     )
+
+    err = unwrap_http_result(
+        result,
+        default_message='Failed to get CPU usage metrics',
+        server_id=server_id,
+        region=region,
+        workspace=workspace,
+    )
+    if err:
+        return err
 
     # Parse metrics for better readability
     parsed_data = {
@@ -237,6 +247,16 @@ async def get_memory_usage(
         token=token,
         params=params,
     )
+
+    err = unwrap_http_result(
+        result,
+        default_message='Failed to get memory usage metrics',
+        server_id=server_id,
+        region=region,
+        workspace=workspace,
+    )
+    if err:
+        return err
 
     # Parse metrics for better readability
     parsed_data = {
@@ -398,6 +418,16 @@ async def get_disk_usage(
         params=params,
     )
 
+    err = unwrap_http_result(
+        result,
+        default_message='Failed to get disk usage metrics',
+        server_id=server_id,
+        region=region,
+        workspace=workspace,
+    )
+    if err:
+        return err
+
     # Parse metrics for better readability
     parsed_data = {
         'server_id': server_id,
@@ -556,6 +586,16 @@ async def get_disk_io(
         params=params,
     )
 
+    err = unwrap_http_result(
+        result,
+        default_message='Failed to get disk I/O metrics',
+        server_id=server_id,
+        region=region,
+        workspace=workspace,
+    )
+    if err:
+        return err
+
     return success_response(
         data=result,
         server_id=server_id,
@@ -616,6 +656,16 @@ async def get_network_traffic(
         token=token,
         params=params,
     )
+
+    err = unwrap_http_result(
+        result,
+        default_message='Failed to get network traffic metrics',
+        server_id=server_id,
+        region=region,
+        workspace=workspace,
+    )
+    if err:
+        return err
 
     # Parse metrics for better readability
     parsed_data = {
@@ -769,6 +819,16 @@ async def get_alert_rules(
         token=token,
         params=params,
     )
+
+    err = unwrap_http_result(
+        result,
+        default_message='Failed to get alert rules',
+        server_id=server_id,
+        region=region,
+        workspace=workspace,
+    )
+    if err:
+        return err
 
     return success_response(
         data=result, server_id=server_id, region=region, workspace=workspace

--- a/tools/metrics_tools.py
+++ b/tools/metrics_tools.py
@@ -368,6 +368,18 @@ async def get_disk_usage(
                 params={'server': server_id},
             )
 
+            # A 4xx/5xx here must surface as the real error, not be masked as
+            # "no devices found" by the empty-list fallback below.
+            err = unwrap_http_result(
+                devices_result,
+                default_message='Failed to fetch disk devices',
+                server_id=server_id,
+                region=region,
+                workspace=workspace,
+            )
+            if err:
+                return err
+
             # Extract device list from response
             available_devices = (
                 devices_result.get('devices', [])
@@ -761,6 +773,15 @@ async def get_top_servers(
                 region=region,
                 workspace=workspace,
             )
+
+        err = unwrap_http_result(
+            result,
+            default_message=f'Failed to fetch {metric} metrics',
+            region=region,
+            workspace=workspace,
+        )
+        if err:
+            return err
 
         return success_response(
             data=result, metric_type=f'{metric}_top', region=region, workspace=workspace

--- a/tools/package_tools.py
+++ b/tools/package_tools.py
@@ -2,7 +2,7 @@
 
 from typing import Any
 
-from utils.common import success_response
+from utils.common import success_response, unwrap_http_result
 from utils.decorators import mcp_tool_handler
 from utils.http_client import http_client
 from utils.tool_annotations import ADDITIVE, DESTRUCTIVE, READ_ONLY
@@ -53,6 +53,16 @@ async def list_system_package_entries(
         params=params,
     )
 
+    err = unwrap_http_result(
+        result,
+        default_message='Failed to list system package entries',
+        server_id=server_id,
+        region=region,
+        workspace=workspace,
+    )
+    if err:
+        return err
+
     return success_response(
         data=result, server_id=server_id, region=region, workspace=workspace
     )
@@ -101,6 +111,16 @@ async def install_system_package(
         data=package_data,
     )
 
+    err = unwrap_http_result(
+        result,
+        default_message='Failed to install system package',
+        server_id=server_id,
+        region=region,
+        workspace=workspace,
+    )
+    if err:
+        return err
+
     return success_response(
         data=result, server_id=server_id, region=region, workspace=workspace
     )
@@ -132,6 +152,16 @@ async def remove_system_package(
         endpoint=f'/api/packages/system/entries/{entry_id}/',
         token=token,
     )
+
+    err = unwrap_http_result(
+        result,
+        default_message='Failed to remove system package',
+        entry_id=entry_id,
+        region=region,
+        workspace=workspace,
+    )
+    if err:
+        return err
 
     return success_response(
         data=result, entry_id=entry_id, region=region, workspace=workspace
@@ -184,6 +214,16 @@ async def list_python_packages(
         params=params,
     )
 
+    err = unwrap_http_result(
+        result,
+        default_message='Failed to list Python packages',
+        server_id=server_id,
+        region=region,
+        workspace=workspace,
+    )
+    if err:
+        return err
+
     return success_response(
         data=result, server_id=server_id, region=region, workspace=workspace
     )
@@ -232,6 +272,16 @@ async def install_python_package(
         data=package_data,
     )
 
+    err = unwrap_http_result(
+        result,
+        default_message='Failed to install Python package',
+        server_id=server_id,
+        region=region,
+        workspace=workspace,
+    )
+    if err:
+        return err
+
     return success_response(
         data=result, server_id=server_id, region=region, workspace=workspace
     )
@@ -263,6 +313,16 @@ async def remove_python_package(
         endpoint=f'/api/packages/python/entries/{entry_id}/',
         token=token,
     )
+
+    err = unwrap_http_result(
+        result,
+        default_message='Failed to remove Python package',
+        entry_id=entry_id,
+        region=region,
+        workspace=workspace,
+    )
+    if err:
+        return err
 
     return success_response(
         data=result, entry_id=entry_id, region=region, workspace=workspace

--- a/tools/security_tools.py
+++ b/tools/security_tools.py
@@ -2,7 +2,7 @@
 
 from typing import Any
 
-from utils.common import error_response, success_response
+from utils.common import error_response, success_response, unwrap_http_result
 from utils.decorators import mcp_tool_handler
 from utils.http_client import http_client
 from utils.tool_annotations import ADDITIVE, DESTRUCTIVE, IDEMPOTENT_WRITE, READ_ONLY
@@ -75,6 +75,15 @@ async def list_command_acls(
         params=params,
     )
 
+    err = unwrap_http_result(
+        result,
+        default_message='Failed to list command ACLs',
+        region=region,
+        workspace=workspace,
+    )
+    if err:
+        return err
+
     return success_response(data=result, region=region, workspace=workspace)
 
 
@@ -134,6 +143,15 @@ async def create_command_acl(
         data=acl_data,
     )
 
+    err = unwrap_http_result(
+        result,
+        default_message='Failed to create command ACL',
+        region=region,
+        workspace=workspace,
+    )
+    if err:
+        return err
+
     return success_response(data=result, region=region, workspace=workspace)
 
 
@@ -187,6 +205,16 @@ async def update_command_acl(
         data=update_data,
     )
 
+    err = unwrap_http_result(
+        result,
+        default_message='Failed to update command ACL',
+        acl_id=acl_id,
+        region=region,
+        workspace=workspace,
+    )
+    if err:
+        return err
+
     return success_response(
         data=result, acl_id=acl_id, region=region, workspace=workspace
     )
@@ -218,6 +246,16 @@ async def delete_command_acl(
         endpoint=f'{_API_COMMAND_ACL}{acl_id}/',
         token=token,
     )
+
+    err = unwrap_http_result(
+        result,
+        default_message='Failed to delete command ACL',
+        acl_id=acl_id,
+        region=region,
+        workspace=workspace,
+    )
+    if err:
+        return err
 
     return success_response(
         data=result, acl_id=acl_id, region=region, workspace=workspace
@@ -274,6 +312,15 @@ async def list_server_acls(
         params=params,
     )
 
+    err = unwrap_http_result(
+        result,
+        default_message='Failed to list server ACLs',
+        region=region,
+        workspace=workspace,
+    )
+    if err:
+        return err
+
     return success_response(data=result, region=region, workspace=workspace)
 
 
@@ -325,6 +372,15 @@ async def create_server_acl(
         token=token,
         data=acl_data,
     )
+
+    err = unwrap_http_result(
+        result,
+        default_message='Failed to create server ACL',
+        region=region,
+        workspace=workspace,
+    )
+    if err:
+        return err
 
     return success_response(data=result, region=region, workspace=workspace)
 
@@ -386,6 +442,16 @@ async def update_server_acl(
         data=update_data,
     )
 
+    err = unwrap_http_result(
+        result,
+        default_message='Failed to update server ACL',
+        acl_id=acl_id,
+        region=region,
+        workspace=workspace,
+    )
+    if err:
+        return err
+
     return success_response(
         data=result, acl_id=acl_id, region=region, workspace=workspace
     )
@@ -417,6 +483,16 @@ async def delete_server_acl(
         endpoint=f'{_API_SERVER_ACL}{acl_id}/',
         token=token,
     )
+
+    err = unwrap_http_result(
+        result,
+        default_message='Failed to delete server ACL',
+        acl_id=acl_id,
+        region=region,
+        workspace=workspace,
+    )
+    if err:
+        return err
 
     return success_response(
         data=result, acl_id=acl_id, region=region, workspace=workspace
@@ -486,6 +562,16 @@ async def bulk_server_acl(
         data=body,
     )
 
+    err = unwrap_http_result(
+        result,
+        default_message='Failed to bulk update server ACLs',
+        action=action,
+        region=region,
+        workspace=workspace,
+    )
+    if err:
+        return err
+
     return success_response(
         data=result, action=action, region=region, workspace=workspace
     )
@@ -540,6 +626,15 @@ async def list_file_acls(
         token=token,
         params=params,
     )
+
+    err = unwrap_http_result(
+        result,
+        default_message='Failed to list file ACLs',
+        region=region,
+        workspace=workspace,
+    )
+    if err:
+        return err
 
     return success_response(data=result, region=region, workspace=workspace)
 
@@ -609,6 +704,15 @@ async def create_file_acl(
         data=acl_data,
     )
 
+    err = unwrap_http_result(
+        result,
+        default_message='Failed to create file ACL',
+        region=region,
+        workspace=workspace,
+    )
+    if err:
+        return err
+
     return success_response(data=result, region=region, workspace=workspace)
 
 
@@ -671,6 +775,16 @@ async def update_file_acl(
         data=update_data,
     )
 
+    err = unwrap_http_result(
+        result,
+        default_message='Failed to update file ACL',
+        acl_id=acl_id,
+        region=region,
+        workspace=workspace,
+    )
+    if err:
+        return err
+
     return success_response(
         data=result, acl_id=acl_id, region=region, workspace=workspace
     )
@@ -702,6 +816,16 @@ async def delete_file_acl(
         endpoint=f'{_API_FILE_ACL}{acl_id}/',
         token=token,
     )
+
+    err = unwrap_http_result(
+        result,
+        default_message='Failed to delete file ACL',
+        acl_id=acl_id,
+        region=region,
+        workspace=workspace,
+    )
+    if err:
+        return err
 
     return success_response(
         data=result, acl_id=acl_id, region=region, workspace=workspace

--- a/tools/system_info_tools.py
+++ b/tools/system_info_tools.py
@@ -3,7 +3,7 @@
 import asyncio
 from typing import Any
 
-from utils.common import success_response
+from utils.common import success_response, unwrap_http_result
 from utils.decorators import mcp_tool_handler
 from utils.http_client import http_client
 from utils.tool_annotations import READ_ONLY
@@ -38,6 +38,16 @@ async def get_system_info(
         params={'server': server_id},
     )
 
+    err = unwrap_http_result(
+        result,
+        default_message='Failed to get system info',
+        server_id=server_id,
+        region=region,
+        workspace=workspace,
+    )
+    if err:
+        return err
+
     return success_response(
         data=result, server_id=server_id, region=region, workspace=workspace
     )
@@ -71,6 +81,16 @@ async def get_os_version(
         token=token,
         params={'server': server_id},
     )
+
+    err = unwrap_http_result(
+        result,
+        default_message='Failed to get OS version',
+        server_id=server_id,
+        region=region,
+        workspace=workspace,
+    )
+    if err:
+        return err
 
     return success_response(
         data=result, server_id=server_id, region=region, workspace=workspace
@@ -120,6 +140,16 @@ async def list_system_users(
         params=params,
     )
 
+    err = unwrap_http_result(
+        result,
+        default_message='Failed to list system users',
+        server_id=server_id,
+        region=region,
+        workspace=workspace,
+    )
+    if err:
+        return err
+
     return success_response(
         data=result,
         server_id=server_id,
@@ -168,6 +198,16 @@ async def list_system_groups(
         token=token,
         params=params,
     )
+
+    err = unwrap_http_result(
+        result,
+        default_message='Failed to list system groups',
+        server_id=server_id,
+        region=region,
+        workspace=workspace,
+    )
+    if err:
+        return err
 
     return success_response(
         data=result,
@@ -223,6 +263,16 @@ async def list_system_packages(
         params=params,
     )
 
+    err = unwrap_http_result(
+        result,
+        default_message='Failed to list system packages',
+        server_id=server_id,
+        region=region,
+        workspace=workspace,
+    )
+    if err:
+        return err
+
     return success_response(
         data=result,
         server_id=server_id,
@@ -262,6 +312,16 @@ async def get_network_interfaces(
         token=token,
         params={'server': server_id},
     )
+
+    err = unwrap_http_result(
+        result,
+        default_message='Failed to get network interfaces',
+        server_id=server_id,
+        region=region,
+        workspace=workspace,
+    )
+    if err:
+        return err
 
     return success_response(
         data=result, server_id=server_id, region=region, workspace=workspace
@@ -360,6 +420,16 @@ async def get_system_time(
         token=token,
         params={'server': server_id},
     )
+
+    err = unwrap_http_result(
+        result,
+        default_message='Failed to get system time',
+        server_id=server_id,
+        region=region,
+        workspace=workspace,
+    )
+    if err:
+        return err
 
     return success_response(
         data=result, server_id=server_id, region=region, workspace=workspace


### PR DESCRIPTION
### Background

`utils/http_client` does not raise on 4xx/5xx; it returns an error envelope dict (`{'error', 'status_code', 'message'}`). Many tools wrapped that return value in `success_response(data=result)` without checking, so an upstream error masqueraded as `status: "success"`. Callers then mistake auth expiry, 404, or permission errors for a normal response.

### Changes

**1. Standardize single-call tools** — `add1c82`

Added an `unwrap_http_result` guard across the single-call paths of 10 modules: alert, approval, audit, cert, events, iam, metrics, package, security, system_info.

```python
err = unwrap_http_result(result, default_message='...', region=region, workspace=workspace)
if err:
    return err
```

If the value is an error envelope it becomes an error_response that preserves `status_code`; otherwise it passes through and is wrapped normally.

**2. Tests and shared fixture** — `ef39de8`

- Added an error-path test per module, collapsed to one parametrized case per module.
- Hoisted the shared `HTTP_ERROR_ENVELOPE` constant into `tests/conftest.py`.
- Removed duplicated inline envelope literals and unused constants.

**3. Two aggregation-path false successes** — `82ae550`

- `get_disk_usage`: a 4xx/5xx on the device-discovery call fell through to the empty-list fallback and returned "No disk devices found", masking the real error. It now surfaces the real status code and skips the follow-up metrics call.
- `get_top_servers`: the single-metric path passed a gathered error envelope straight to `success_response`. Now guarded.

Reviewed but intentionally unchanged, since they are not false successes: `get_server_metrics_summary`, `get_server_overview`, `get_disk_info`. They already represent errors per metric or per key, so no error data is lost.

### Tests

```
818 passed, ruff All checks passed!
```

The two failing tests `test_import_main` and `test_main_entry_point` are an environment artifact: the working directory is named `main/`, so `import main` resolves to the package instead of `main.py`. They are unrelated to this change and pass in CI where the directory is `alpacon-mcp/`.

### Impact

Read-only error-handling improvement. No change to success response shape or behavior. No security, data-loss, or race risk.
