### PR TITLE
feat: expose read-only tools as alpacon:// MCP resources (#60)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -461,6 +461,20 @@ Alternative endpoints available in the server:
 - `/api/workspaces/preferences/` (workspaces app)
 - `/api/auth0/users/` (auth0 app)
 
+### 🧩 MCP resources
+
+Read-only data exposed as `alpacon://` resources (one per read tool). URI convention: `alpacon://<domain>[/<sub>]/{region}/{workspace}[/{id}]`. Optional filters use tool defaults (no filter params in the URI).
+
+- `alpacon://servers/{region}/{workspace}`: server list (also `/{server_id}`, `/{server_id}/overview`, `/{server_id}/notes`)
+- `alpacon://alerts/{region}/{workspace}` and `alpacon://alerts/active/{region}/{workspace}`: all / active (unacknowledged) alerts
+- `alpacon://metrics/{region}/{workspace}/{server_id}/{cpu|memory|disk|disk-io|network|summary}`: server metrics
+- `alpacon://system/{region}/{workspace}/{server_id}/{info|users|groups|packages|...}`: system information
+- `alpacon://iam/{users|groups|applications}/{region}/{workspace}`: IAM
+- `alpacon://certs/...`, `alpacon://audit/...`, `alpacon://tokens/...`, `alpacon://webhooks/...`, `alpacon://acls/...`, `alpacon://webftp/...`, `alpacon://approvals/...`, `alpacon://events/...`, `alpacon://commands/...`, `alpacon://work-sessions/...`
+- `alpacon://workspaces/{region}`, `alpacon://current-user/{region}/{workspace}`
+
+Resources are generated from a registry table in `tools/resources.py`.
+
 ## Dependencies
 
 **Runtime dependencies** (from `pyproject.toml`):

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -471,7 +471,7 @@ Read-only data exposed as `alpacon://` resources (one per read tool). URI conven
 - `alpacon://system/{region}/{workspace}/{server_id}/{info|users|groups|packages|...}`: system information
 - `alpacon://iam/{users|groups|applications}/{region}/{workspace}`: IAM
 - `alpacon://certs/...`, `alpacon://audit/...`, `alpacon://tokens/...`, `alpacon://webhooks/...`, `alpacon://acls/...`, `alpacon://webftp/...`, `alpacon://approvals/...`, `alpacon://events/...`, `alpacon://commands/...`, `alpacon://work-sessions/...`
-- `alpacon://workspaces/{region}`, `alpacon://current-user/{region}/{workspace}`
+- `alpacon://workspaces` (all regions) and `alpacon://workspaces/{region}`, `alpacon://current-user/{region}/{workspace}`
 
 Resources are generated from a registry table in `tools/resources.py`.
 

--- a/server.py
+++ b/server.py
@@ -278,6 +278,7 @@ def run(
     import tools.iam_tools  # noqa: F401
     import tools.metrics_tools  # noqa: F401
     import tools.package_tools  # noqa: F401
+    import tools.resources  # noqa: F401
     import tools.security_tools  # noqa: F401
     import tools.server_tools  # noqa: F401
     import tools.system_info_tools  # noqa: F401

--- a/tests/test_alert_tools.py
+++ b/tests/test_alert_tools.py
@@ -68,6 +68,24 @@ class TestListAlerts:
             params={'acknowledged': False},
         )
 
+    @pytest.mark.asyncio
+    async def test_list_dismissed_filter(self, mock_http_client, mock_token_manager):
+        """dismissed=False must forward as a param, not be dropped by a truthy check."""
+        mock_http_client.get.return_value = {'results': [], 'count': 0}
+
+        result = await list_alerts(
+            workspace='testworkspace', region='ap1', dismissed=False
+        )
+
+        assert result['status'] == 'success'
+        mock_http_client.get.assert_called_once_with(
+            region='ap1',
+            workspace='testworkspace',
+            endpoint='/api/alerts/',
+            token='test-token',
+            params={'dismissed': False},
+        )
+
 
 class TestGetAlert:
     @pytest.mark.asyncio

--- a/tests/test_alert_tools.py
+++ b/tests/test_alert_tools.py
@@ -51,6 +51,23 @@ class TestListAlerts:
             params={},
         )
 
+    @pytest.mark.asyncio
+    async def test_list_active_filter(self, mock_http_client, mock_token_manager):
+        mock_http_client.get.return_value = {'results': [], 'count': 0}
+
+        result = await list_alerts(
+            workspace='testworkspace', region='ap1', acknowledged=False
+        )
+
+        assert result['status'] == 'success'
+        mock_http_client.get.assert_called_once_with(
+            region='ap1',
+            workspace='testworkspace',
+            endpoint='/api/alerts/',
+            token='test-token',
+            params={'acknowledged': False},
+        )
+
 
 class TestGetAlert:
     @pytest.mark.asyncio

--- a/tests/test_resources.py
+++ b/tests/test_resources.py
@@ -97,6 +97,23 @@ class TestResourceRegistration:
         )
         assert 'acknowledged=False' in active.description
 
+    def test_wrapper_named_after_resource(self):
+        """The exec'd wrapper must adopt the resource name, not stay '_wrapper',
+        so stack traces and name-based diagnostics stay legible."""
+        import tools.resources as res
+
+        async def fake_fn(region, workspace):
+            return {'ok': True}
+
+        res.register_resource(
+            'alpacon://test-named/{region}/{workspace}', fake_fn, 'named_probe'
+        )
+        fn = mcp._resource_manager._templates[
+            'alpacon://test-named/{region}/{workspace}'
+        ].fn
+        assert fn.__name__ == 'named_probe'
+        assert fn.__qualname__ == 'named_probe'
+
     def test_uri_params_match_function_signatures(self):
         """Every URI {param} and extra kwarg must be a real parameter of its
         backing function — a typo breaks at read time, not import; catch it here."""

--- a/tests/test_resources.py
+++ b/tests/test_resources.py
@@ -1,0 +1,85 @@
+"""Tests for alpacon:// MCP resources."""
+
+import pytest
+
+from server import mcp
+
+
+async def _template_uris():
+    return {t.uriTemplate for t in await mcp.list_resource_templates()}
+
+
+class TestResourceRegistration:
+    @pytest.mark.asyncio
+    async def test_helper_registers_and_reads(self):
+        """register_resource builds a real-signature wrapper that reads through."""
+        import tools.resources as res
+
+        captured = {}
+
+        async def fake_fn(region, workspace, alert_id):
+            captured['args'] = (region, workspace, alert_id)
+            return {'ok': True}
+
+        res.register_resource(
+            'alpacon://test/{region}/{workspace}/{alert_id}', fake_fn, 'test_probe'
+        )
+
+        contents = await mcp.read_resource('alpacon://test/ap1/ws/abc')
+        assert captured['args'] == ('ap1', 'ws', 'abc')
+        assert contents  # non-empty content list
+
+    @pytest.mark.asyncio
+    async def test_helper_passes_extra_kwargs(self):
+        """extra kwargs are forwarded to the backing function."""
+        import tools.resources as res
+
+        captured = {}
+
+        async def fake_fn(region, workspace, acknowledged=None):
+            captured['ack'] = acknowledged
+            return {'ok': True}
+
+        res.register_resource(
+            'alpacon://test-extra/{region}/{workspace}',
+            fake_fn,
+            'test_extra_probe',
+            {'acknowledged': False},
+        )
+
+        await mcp.read_resource('alpacon://test-extra/ap1/ws')
+        assert captured['ack'] is False
+
+    @pytest.mark.asyncio
+    async def test_all_resources_registered(self):
+        """Every RESOURCES entry is registered, no dup, no legacy scheme."""
+        import tools.resources as res
+
+        uris = await _template_uris()
+        table_uris = {uri for _n, _f, uri in res.RESOURCES}
+
+        assert table_uris <= uris
+        assert 'alpacon://alerts/active/{region}/{workspace}' in uris  # extra-kwarg one
+        assert not any(u.startswith(('webftp://', 'iam://')) for u in uris)
+        assert 'alpacon://webftp/sessions/{region}/{workspace}' in uris
+        assert 'alpacon://iam/users/{region}/{workspace}' in uris
+        assert len(table_uris) == len(res.RESOURCES)
+        assert len(res.RESOURCES) == 70
+
+    @pytest.mark.asyncio
+    async def test_literal_subresources_not_shadowed(self):
+        """A literal sub-path (e.g. /active/) must not be captured by a sibling
+        {id} wildcard — resolve to the right tool, not the detail route."""
+        import tools.resources  # noqa: F401  # registers resources on import
+
+        mgr = mcp._resource_manager
+        cases = {
+            'alpacon://alerts/active/ap1/ws': 'alerts_active',
+            'alpacon://certs/revoke-requests/ap1/ws': 'cert_revoke_requests_list',
+            'alpacon://tokens/scopes/ap1/ws': 'token_scopes',
+            'alpacon://tokens/presets/ap1/ws': 'token_presets',
+            'alpacon://alerts/ap1/ws/some-id': 'alert_detail',  # detail still works
+        }
+        for uri, want in cases.items():
+            resource = await mgr.get_resource(uri)
+            assert resource.name == want, f'{uri} -> {resource.name}, want {want}'

--- a/tests/test_resources.py
+++ b/tests/test_resources.py
@@ -115,8 +115,7 @@ class TestResourceRegistration:
         assert fn.__name__ == 'named_probe'
         assert fn.__qualname__ == 'named_probe'
         assert fn.__module__ == 'tools.resources'
-        # FastMCP wraps fn with pydantic validate_call; co_filename lives on the
-        # underlying exec'd wrapper, reached through __wrapped__.
+        # co_filename lives on the exec'd wrapper, under validate_call's wrapping.
         while hasattr(fn, '__wrapped__'):
             fn = fn.__wrapped__
         assert fn.__code__.co_filename == res.__file__

--- a/tests/test_resources.py
+++ b/tests/test_resources.py
@@ -98,8 +98,9 @@ class TestResourceRegistration:
         assert 'acknowledged=False' in active.description
 
     def test_wrapper_named_after_resource(self):
-        """The exec'd wrapper must adopt the resource name, not stay '_wrapper',
-        so stack traces and name-based diagnostics stay legible."""
+        """The exec'd wrapper must adopt the resource name and this module's
+        identity, not stay '_wrapper' with a '<string>' traceback frame, so
+        stack traces and name-based diagnostics stay legible."""
         import tools.resources as res
 
         async def fake_fn(region, workspace):
@@ -113,6 +114,12 @@ class TestResourceRegistration:
         ].fn
         assert fn.__name__ == 'named_probe'
         assert fn.__qualname__ == 'named_probe'
+        assert fn.__module__ == 'tools.resources'
+        # FastMCP wraps fn with pydantic validate_call; co_filename lives on the
+        # underlying exec'd wrapper, reached through __wrapped__.
+        while hasattr(fn, '__wrapped__'):
+            fn = fn.__wrapped__
+        assert fn.__code__.co_filename == res.__file__
 
     def test_uri_params_match_function_signatures(self):
         """Every URI {param} and extra kwarg must be a real parameter of its

--- a/tests/test_resources.py
+++ b/tests/test_resources.py
@@ -86,6 +86,25 @@ class TestResourceRegistration:
         assert 'alpacon://iam/users/{region}/{workspace}' in uris
         assert len(table_uris) == len(res.RESOURCES)
 
+    def test_uri_params_match_function_signatures(self):
+        """Every URI {param} and extra kwarg must be a real parameter of its
+        backing function — a typo breaks at read time, not import; catch it here."""
+        import inspect
+        import re
+
+        import tools.resources as res
+
+        for name, fn, uri, extra in res._REGISTRATIONS:
+            wanted = set(re.findall(r'\{(\w+)\}', uri)) | set(extra or {})
+            sig = inspect.signature(fn).parameters
+            accepted = {
+                p
+                for p, v in sig.items()
+                if v.kind not in (v.VAR_KEYWORD, v.VAR_POSITIONAL)
+            }
+            missing = wanted - accepted
+            assert not missing, f'{name}: {missing} not accepted by {fn.__name__}'
+
     @pytest.mark.asyncio
     async def test_literal_subresources_not_shadowed(self):
         """A literal sub-path (e.g. /active/) must not be captured by a sibling

--- a/tests/test_resources.py
+++ b/tests/test_resources.py
@@ -85,7 +85,6 @@ class TestResourceRegistration:
         assert 'alpacon://webftp/sessions/{region}/{workspace}' in uris
         assert 'alpacon://iam/users/{region}/{workspace}' in uris
         assert len(table_uris) == len(res.RESOURCES)
-        assert len(res.RESOURCES) == 71
 
     @pytest.mark.asyncio
     async def test_literal_subresources_not_shadowed(self):

--- a/tests/test_resources.py
+++ b/tests/test_resources.py
@@ -5,8 +5,11 @@ import pytest
 from server import mcp
 
 
-async def _template_uris():
-    return {t.uriTemplate for t in await mcp.list_resource_templates()}
+async def _registered_uris():
+    """All registered alpacon:// URIs — templated (with {params}) and static."""
+    templates = {t.uriTemplate for t in await mcp.list_resource_templates()}
+    static = {str(r.uri) for r in await mcp.list_resources()}
+    return templates | static
 
 
 class TestResourceRegistration:
@@ -51,11 +54,29 @@ class TestResourceRegistration:
         assert captured['ack'] is False
 
     @pytest.mark.asyncio
+    async def test_extra_kwargs_without_path_params(self):
+        """No path params + extra must not emit a leading-comma SyntaxError."""
+        import tools.resources as res
+
+        captured = {}
+
+        async def fake_fn(flag=None):
+            captured['flag'] = flag
+            return {'ok': True}
+
+        res.register_resource(
+            'alpacon://test-noparam', fake_fn, 'test_noparam_probe', {'flag': True}
+        )
+
+        await mcp.read_resource('alpacon://test-noparam')
+        assert captured['flag'] is True
+
+    @pytest.mark.asyncio
     async def test_all_resources_registered(self):
         """Every RESOURCES entry is registered, no dup, no legacy scheme."""
         import tools.resources as res
 
-        uris = await _template_uris()
+        uris = await _registered_uris()
         table_uris = {uri for _n, _f, uri in res.RESOURCES}
 
         assert table_uris <= uris
@@ -64,7 +85,7 @@ class TestResourceRegistration:
         assert 'alpacon://webftp/sessions/{region}/{workspace}' in uris
         assert 'alpacon://iam/users/{region}/{workspace}' in uris
         assert len(table_uris) == len(res.RESOURCES)
-        assert len(res.RESOURCES) == 70
+        assert len(res.RESOURCES) == 71
 
     @pytest.mark.asyncio
     async def test_literal_subresources_not_shadowed(self):

--- a/tests/test_resources.py
+++ b/tests/test_resources.py
@@ -139,20 +139,35 @@ class TestResourceRegistration:
             missing = wanted - accepted
             assert not missing, f'{name}: {missing} not accepted by {fn.__name__}'
 
+            # Inverse: every required (no-default) param must be filled by the URI
+            # or an extra kwarg, else the read fails at runtime, not import.
+            required = {
+                p
+                for p, v in sig.items()
+                if v.default is v.empty
+                and v.kind not in (v.VAR_KEYWORD, v.VAR_POSITIONAL)
+            }
+            unfilled = required - wanted
+            assert not unfilled, f'{name}: {unfilled} required but not in URI/extra'
+
     @pytest.mark.asyncio
-    async def test_literal_subresources_not_shadowed(self):
-        """A literal sub-path (e.g. /active/) must not be captured by a sibling
-        {id} wildcard — resolve to the right tool, not the detail route."""
-        import tools.resources  # noqa: F401  # registers resources on import
+    async def test_no_resource_is_shadowed(self):
+        """Every registered template, filled with concrete values, must resolve to
+        its own handler — a general guard so a future literal/{id} sibling pair
+        can't silently shadow one another. Subsumes the specific /active/, /scopes/,
+        etc. cases without hard-coding them."""
+        import re
+
+        import tools.resources as res
 
         mgr = mcp._resource_manager
-        cases = {
-            'alpacon://alerts/active/ap1/ws': 'alerts_active',
-            'alpacon://certs/revoke-requests/ap1/ws': 'cert_revoke_requests_list',
-            'alpacon://tokens/scopes/ap1/ws': 'token_scopes',
-            'alpacon://tokens/presets/ap1/ws': 'token_presets',
-            'alpacon://alerts/ap1/ws/some-id': 'alert_detail',  # detail still works
-        }
-        for uri, want in cases.items():
-            resource = await mgr.get_resource(uri)
-            assert resource.name == want, f'{uri} -> {resource.name}, want {want}'
+
+        def concrete(uri: str) -> str:
+            # Sentinel placeholders never collide with a literal segment.
+            return re.sub(r'\{(\w+)\}', lambda m: f'_{m.group(1)}_', uri)
+
+        for name, _fn, uri, _extra in res._REGISTRATIONS:
+            resolved = await mgr.get_resource(concrete(uri))
+            assert resolved.name == name, (
+                f'{uri} -> {resolved.name}, want {name} (shadowed)'
+            )

--- a/tests/test_resources.py
+++ b/tests/test_resources.py
@@ -86,6 +86,17 @@ class TestResourceRegistration:
         assert 'alpacon://iam/users/{region}/{workspace}' in uris
         assert len(table_uris) == len(res.RESOURCES)
 
+    @pytest.mark.asyncio
+    async def test_filtered_resource_describes_its_pin(self):
+        """A resource registered with extra kwargs must surface the pinned
+        filter in its description, not just inherit the tool docstring."""
+        active = next(
+            t
+            for t in await mcp.list_resource_templates()
+            if t.uriTemplate == 'alpacon://alerts/active/{region}/{workspace}'
+        )
+        assert 'acknowledged=False' in active.description
+
     def test_uri_params_match_function_signatures(self):
         """Every URI {param} and extra kwarg must be a real parameter of its
         backing function — a typo breaks at read time, not import; catch it here."""

--- a/tools/alert_tools.py
+++ b/tools/alert_tools.py
@@ -27,6 +27,8 @@ async def list_alerts(
     region: str = '',
     page: int | None = None,
     page_size: int | None = None,
+    acknowledged: bool | None = None,
+    dismissed: bool | None = None,
     **kwargs,
 ) -> dict[str, Any]:
     """List alerts.
@@ -38,6 +40,8 @@ async def list_alerts(
         region: Region (ap1, us1, eu1). Auto-detected if not provided
         page: Page number for pagination (optional)
         page_size: Number of items per page (optional)
+        acknowledged: Filter by acknowledgement state (False = active/unacknowledged)
+        dismissed: Filter by dismissed state
 
     Returns:
         Alerts list response
@@ -53,6 +57,10 @@ async def list_alerts(
         params['page'] = page
     if page_size is not None:
         params['page_size'] = page_size
+    if acknowledged is not None:
+        params['acknowledged'] = acknowledged
+    if dismissed is not None:
+        params['dismissed'] = dismissed
 
     result = await http_client.get(
         region=region,

--- a/tools/iam_tools.py
+++ b/tools/iam_tools.py
@@ -3,7 +3,6 @@
 import re
 from typing import Any
 
-from server import mcp
 from utils.common import error_response, success_response, unwrap_http_result
 from utils.decorators import mcp_tool_handler
 from utils.error_handler import format_validation_error, validate_server_id_format
@@ -441,54 +440,6 @@ async def create_iam_group(
 # - ROLE MANAGEMENT TOOLS (list_iam_roles, assign_iam_user_role)
 # - PERMISSION MANAGEMENT TOOLS (list_iam_permissions, get_iam_user_permissions)
 # ===============================
-
-
-# ===============================
-# RESOURCE MANAGEMENT
-# ===============================
-
-
-@mcp.resource(
-    uri='iam://users/{region}/{workspace}',
-    name='IAM Users List',
-    description='Get list of IAM users',
-    mime_type='application/json',
-)
-async def iam_users_resource(region: str, workspace: str) -> dict[str, Any]:
-    """Get IAM users as a resource.
-
-    Args:
-        region: Region (ap1, us1, eu1, etc.)
-        workspace: Workspace name
-
-    Returns:
-        IAM users information
-    """
-    users_data = await list_iam_users(region=region, workspace=workspace)
-    return {'content': users_data}
-
-
-@mcp.resource(
-    uri='iam://groups/{region}/{workspace}',
-    name='IAM Groups List',
-    description='Get list of IAM groups',
-    mime_type='application/json',
-)
-async def iam_groups_resource(region: str, workspace: str) -> dict[str, Any]:
-    """Get IAM groups as a resource.
-
-    Args:
-        region: Region (ap1, us1, eu1, etc.)
-        workspace: Workspace name
-
-    Returns:
-        IAM groups information
-    """
-    groups_data = await list_iam_groups(region=region, workspace=workspace)
-    return {'content': groups_data}
-
-
-# NOTE: IAM roles resource removed - endpoint not implemented in server
 
 
 # ===============================

--- a/tools/resources.py
+++ b/tools/resources.py
@@ -116,6 +116,9 @@ def register_resource(
     ns: dict = {'_fn': fn}
     exec(src, ns)  # noqa: S102
     wrapper = ns['_wrapper']
+    # Every wrapper is born '_wrapper'; rename it so stack traces and any
+    # function-name-based diagnostics identify the resource, not the factory.
+    wrapper.__name__ = wrapper.__qualname__ = name
     doc = inspect.getdoc(fn) or name
     if extra:
         # The wrapper inherits the tool docstring verbatim; without this note a

--- a/tools/resources.py
+++ b/tools/resources.py
@@ -3,7 +3,7 @@
 Resources are generated from the RESOURCES registry table to avoid ~70 copies
 of identical boilerplate. Each wrapper is built via exec with real named
 parameters because FastMCP matches URI template params to the function
-signature by name (server.py:603).
+signature by name; a **kwargs wrapper fails its func_metadata check.
 """
 
 import inspect
@@ -106,9 +106,10 @@ def register_resource(
     """
     path_params = re.findall(r'\{(\w+)\}', uri)
     sig = ', '.join(f'{p}: str' for p in path_params)
-    call = ', '.join(f'{p}={p}' for p in path_params)
+    parts = [f'{p}={p}' for p in path_params]
     if extra:
-        call += ''.join(f', {k}={v!r}' for k, v in extra.items())
+        parts += [f'{k}={v!r}' for k, v in extra.items()]
+    call = ', '.join(parts)
     # exec: FastMCP requires a real named signature matching the URI template;
     # a **kwargs wrapper with a synthetic __signature__ fails func_metadata.
     src = f"async def _wrapper({sig}):\n    return {{'content': await _fn({call})}}\n"
@@ -390,6 +391,7 @@ RESOURCES: list[tuple[str, Callable, str]] = [
         work_session_get,
         'alpacon://work-sessions/{region}/{workspace}/{session_id}',
     ),
+    ('workspaces_all', list_workspaces, 'alpacon://workspaces'),
     ('workspaces_list', list_workspaces, 'alpacon://workspaces/{region}'),
     ('current_user', get_current_user, 'alpacon://current-user/{region}/{workspace}'),
 ]

--- a/tools/resources.py
+++ b/tools/resources.py
@@ -113,8 +113,10 @@ def register_resource(
     # exec: FastMCP requires a real named signature matching the URI template;
     # a **kwargs wrapper with a synthetic __signature__ fails func_metadata.
     src = f"async def _wrapper({sig}):\n    return {{'content': await _fn({call})}}\n"
-    ns: dict = {'_fn': fn}
-    exec(src, ns)  # noqa: S102
+    # Compile against this module's file/name so the wrapper reports
+    # tools/resources.py (not '<string>') in tracebacks and a real __module__.
+    ns: dict = {'_fn': fn, '__name__': __name__}
+    exec(compile(src, __file__, 'exec'), ns)  # noqa: S102
     wrapper = ns['_wrapper']
     # Every wrapper is born '_wrapper'; rename it so stack traces and any
     # function-name-based diagnostics identify the resource, not the factory.

--- a/tools/resources.py
+++ b/tools/resources.py
@@ -110,21 +110,16 @@ def register_resource(
     if extra:
         parts += [f'{k}={v!r}' for k, v in extra.items()]
     call = ', '.join(parts)
-    # exec: FastMCP requires a real named signature matching the URI template;
-    # a **kwargs wrapper with a synthetic __signature__ fails func_metadata.
+    # FastMCP needs a real named signature; a **kwargs wrapper fails func_metadata.
     src = f"async def _wrapper({sig}):\n    return {{'content': await _fn({call})}}\n"
-    # Compile against this module's file/name so the wrapper reports
-    # tools/resources.py (not '<string>') in tracebacks and a real __module__.
+    # __name__/__file__ give the wrapper a real __module__ and traceback frame.
     ns: dict = {'_fn': fn, '__name__': __name__}
     exec(compile(src, __file__, 'exec'), ns)  # noqa: S102
     wrapper = ns['_wrapper']
-    # Every wrapper is born '_wrapper'; rename it so stack traces and any
-    # function-name-based diagnostics identify the resource, not the factory.
     wrapper.__name__ = wrapper.__qualname__ = name
     doc = inspect.getdoc(fn) or name
     if extra:
-        # The wrapper inherits the tool docstring verbatim; without this note a
-        # filtered resource looks identical to the unfiltered one to clients.
+        # Surface the pinned filter so a filtered resource isn't mistaken for the bare one.
         pinned = ', '.join(f'{k}={v!r}' for k, v in extra.items())
         doc = f'{doc}\n\nThis resource pins: {pinned}.'
     wrapper.__doc__ = doc
@@ -416,9 +411,7 @@ _REGISTRATIONS = [(n, f, u, None) for n, f, u in RESOURCES] + [
 ]
 
 
-# Register most-specific first: a literal path segment (e.g. /active/) must win
-# over a sibling {id} wildcard that would otherwise shadow it — FastMCP returns
-# the first registered template that matches. Fewer {placeholders} = more
-# literal segments (colliding templates share a segment count), so sort ascending.
+# Fewer placeholders first so a literal segment (/active/) wins over a sibling
+# {id} wildcard — FastMCP matches the first registered template.
 for _name, _fn, _uri, _extra in sorted(_REGISTRATIONS, key=lambda r: r[2].count('{')):
     register_resource(_uri, _fn, _name, _extra)

--- a/tools/resources.py
+++ b/tools/resources.py
@@ -116,10 +116,14 @@ def register_resource(
     ns: dict = {'_fn': fn}
     exec(src, ns)  # noqa: S102
     wrapper = ns['_wrapper']
-    wrapper.__doc__ = inspect.getdoc(fn) or name
-    mcp.resource(
-        uri, name=name, description=wrapper.__doc__, mime_type='application/json'
-    )(wrapper)
+    doc = inspect.getdoc(fn) or name
+    if extra:
+        # The wrapper inherits the tool docstring verbatim; without this note a
+        # filtered resource looks identical to the unfiltered one to clients.
+        pinned = ', '.join(f'{k}={v!r}' for k, v in extra.items())
+        doc = f'{doc}\n\nThis resource pins: {pinned}.'
+    wrapper.__doc__ = doc
+    mcp.resource(uri, name=name, description=doc, mime_type='application/json')(wrapper)
 
 
 RESOURCES: list[tuple[str, Callable, str]] = [

--- a/tools/resources.py
+++ b/tools/resources.py
@@ -1,0 +1,413 @@
+"""alpacon:// MCP resources — thin read-only wrappers over list_/get_ tools.
+
+Resources are generated from the RESOURCES registry table to avoid ~70 copies
+of identical boilerplate. Each wrapper is built via exec with real named
+parameters because FastMCP matches URI template params to the function
+signature by name (server.py:603).
+"""
+
+import inspect
+import re
+from collections.abc import Callable
+
+from server import mcp
+from tools.alert_tools import get_alert, list_alerts
+from tools.approval_tools import (
+    get_approval_request,
+    list_approval_requests,
+    list_sudo_policies,
+)
+from tools.audit_tools import (
+    get_activity_log,
+    get_session_analysis_detail,
+    list_activity_logs,
+    list_server_logs,
+    list_session_analyses,
+    list_webftp_logs,
+)
+from tools.cert_tools import (
+    get_certificate,
+    get_certificate_authority,
+    get_revoke_request,
+    get_sign_request,
+    list_certificate_authorities,
+    list_certificates,
+    list_revoke_requests,
+    list_sign_requests,
+)
+from tools.command_tools import list_commands
+from tools.events_tools import get_event, list_events
+from tools.iam_tools import (
+    get_iam_application,
+    get_iam_group,
+    get_iam_user,
+    list_iam_applications,
+    list_iam_groups,
+    list_iam_memberships,
+    list_iam_users,
+)
+from tools.metrics_tools import (
+    get_alert_rules,
+    get_cpu_usage,
+    get_disk_io,
+    get_disk_usage,
+    get_memory_usage,
+    get_network_traffic,
+    get_server_metrics_summary,
+    get_top_servers,
+)
+from tools.package_tools import list_python_packages, list_system_package_entries
+from tools.security_tools import (
+    list_command_acls,
+    list_file_acls,
+    list_server_acls,
+)
+from tools.server_tools import (
+    get_server,
+    get_server_note,
+    list_registration_tokens,
+    list_server_notes,
+    list_servers,
+)
+from tools.system_info_tools import (
+    get_disk_info,
+    get_network_interfaces,
+    get_os_version,
+    get_server_overview,
+    get_system_info,
+    get_system_time,
+    list_system_groups,
+    list_system_packages,
+    list_system_users,
+)
+from tools.token_tools import (
+    get_api_token,
+    list_api_token_presets,
+    list_api_token_scopes,
+    list_api_tokens,
+)
+from tools.webftp_tools import (
+    webftp_downloads_list,
+    webftp_sessions_list,
+    webftp_uploads_list,
+)
+from tools.webhook_tools import get_webhook, list_event_subscriptions, list_webhooks
+from tools.work_session_tools import work_session_get, work_session_list
+from tools.workspace_tools import get_current_user, list_workspaces
+
+
+def register_resource(
+    uri: str, fn: Callable, name: str, extra: dict | None = None
+) -> None:
+    """Register an alpacon:// resource that proxies a read-only tool.
+
+    Path params in `uri` (e.g. {region}) become the wrapper's named arguments;
+    `extra` injects fixed keyword args (e.g. acknowledged=False) into the call.
+    """
+    path_params = re.findall(r'\{(\w+)\}', uri)
+    sig = ', '.join(f'{p}: str' for p in path_params)
+    call = ', '.join(f'{p}={p}' for p in path_params)
+    if extra:
+        call += ''.join(f', {k}={v!r}' for k, v in extra.items())
+    # exec: FastMCP requires a real named signature matching the URI template;
+    # a **kwargs wrapper with a synthetic __signature__ fails func_metadata.
+    src = f"async def _wrapper({sig}):\n    return {{'content': await _fn({call})}}\n"
+    ns: dict = {'_fn': fn}
+    exec(src, ns)  # noqa: S102
+    wrapper = ns['_wrapper']
+    wrapper.__doc__ = inspect.getdoc(fn) or name
+    mcp.resource(
+        uri, name=name, description=wrapper.__doc__, mime_type='application/json'
+    )(wrapper)
+
+
+RESOURCES: list[tuple[str, Callable, str]] = [
+    ('servers_list', list_servers, 'alpacon://servers/{region}/{workspace}'),
+    ('server_detail', get_server, 'alpacon://servers/{region}/{workspace}/{server_id}'),
+    (
+        'server_notes_list',
+        list_server_notes,
+        'alpacon://servers/{region}/{workspace}/{server_id}/notes',
+    ),
+    (
+        'server_overview',
+        get_server_overview,
+        'alpacon://servers/{region}/{workspace}/{server_id}/overview',
+    ),
+    (
+        'server_note_detail',
+        get_server_note,
+        'alpacon://server-notes/{region}/{workspace}/{note_id}',
+    ),
+    (
+        'registration_tokens_list',
+        list_registration_tokens,
+        'alpacon://registration-tokens/{region}/{workspace}',
+    ),
+    (
+        'system_info',
+        get_system_info,
+        'alpacon://system/{region}/{workspace}/{server_id}/info',
+    ),
+    (
+        'system_os_version',
+        get_os_version,
+        'alpacon://system/{region}/{workspace}/{server_id}/os-version',
+    ),
+    (
+        'system_users',
+        list_system_users,
+        'alpacon://system/{region}/{workspace}/{server_id}/users',
+    ),
+    (
+        'system_groups',
+        list_system_groups,
+        'alpacon://system/{region}/{workspace}/{server_id}/groups',
+    ),
+    (
+        'system_packages',
+        list_system_packages,
+        'alpacon://system/{region}/{workspace}/{server_id}/packages',
+    ),
+    (
+        'system_network_interfaces',
+        get_network_interfaces,
+        'alpacon://system/{region}/{workspace}/{server_id}/network-interfaces',
+    ),
+    (
+        'system_disk_info',
+        get_disk_info,
+        'alpacon://system/{region}/{workspace}/{server_id}/disk-info',
+    ),
+    (
+        'system_time',
+        get_system_time,
+        'alpacon://system/{region}/{workspace}/{server_id}/time',
+    ),
+    (
+        'metrics_cpu',
+        get_cpu_usage,
+        'alpacon://metrics/{region}/{workspace}/{server_id}/cpu',
+    ),
+    (
+        'metrics_memory',
+        get_memory_usage,
+        'alpacon://metrics/{region}/{workspace}/{server_id}/memory',
+    ),
+    (
+        'metrics_disk',
+        get_disk_usage,
+        'alpacon://metrics/{region}/{workspace}/{server_id}/disk',
+    ),
+    (
+        'metrics_disk_io',
+        get_disk_io,
+        'alpacon://metrics/{region}/{workspace}/{server_id}/disk-io',
+    ),
+    (
+        'metrics_network',
+        get_network_traffic,
+        'alpacon://metrics/{region}/{workspace}/{server_id}/network',
+    ),
+    (
+        'metrics_summary',
+        get_server_metrics_summary,
+        'alpacon://metrics/{region}/{workspace}/{server_id}/summary',
+    ),
+    ('metrics_top', get_top_servers, 'alpacon://metrics/{region}/{workspace}/top'),
+    ('alert_rules', get_alert_rules, 'alpacon://alert-rules/{region}/{workspace}'),
+    ('alerts_list', list_alerts, 'alpacon://alerts/{region}/{workspace}'),
+    ('alert_detail', get_alert, 'alpacon://alerts/{region}/{workspace}/{alert_id}'),
+    (
+        'approvals_list',
+        list_approval_requests,
+        'alpacon://approvals/{region}/{workspace}',
+    ),
+    (
+        'approval_detail',
+        get_approval_request,
+        'alpacon://approvals/{region}/{workspace}/{request_id}',
+    ),
+    (
+        'sudo_policies_list',
+        list_sudo_policies,
+        'alpacon://sudo-policies/{region}/{workspace}',
+    ),
+    (
+        'audit_activity_list',
+        list_activity_logs,
+        'alpacon://audit/activity/{region}/{workspace}',
+    ),
+    (
+        'audit_activity_detail',
+        get_activity_log,
+        'alpacon://audit/activity/{region}/{workspace}/{log_id}',
+    ),
+    (
+        'audit_server_logs',
+        list_server_logs,
+        'alpacon://audit/server-logs/{region}/{workspace}',
+    ),
+    (
+        'audit_webftp_logs',
+        list_webftp_logs,
+        'alpacon://audit/webftp-logs/{region}/{workspace}',
+    ),
+    (
+        'audit_session_analyses',
+        list_session_analyses,
+        'alpacon://audit/session-analyses/{region}/{workspace}',
+    ),
+    (
+        'audit_session_analysis_detail',
+        get_session_analysis_detail,
+        'alpacon://audit/session-analyses/{region}/{workspace}/{analysis_id}',
+    ),
+    (
+        'cert_authorities_list',
+        list_certificate_authorities,
+        'alpacon://certs/authorities/{region}/{workspace}',
+    ),
+    (
+        'cert_authority_detail',
+        get_certificate_authority,
+        'alpacon://certs/authorities/{region}/{workspace}/{ca_id}',
+    ),
+    (
+        'cert_sign_requests_list',
+        list_sign_requests,
+        'alpacon://certs/sign-requests/{region}/{workspace}',
+    ),
+    (
+        'cert_sign_request_detail',
+        get_sign_request,
+        'alpacon://certs/sign-requests/{region}/{workspace}/{csr_id}',
+    ),
+    ('certs_list', list_certificates, 'alpacon://certs/{region}/{workspace}'),
+    (
+        'cert_detail',
+        get_certificate,
+        'alpacon://certs/{region}/{workspace}/{certificate_id}',
+    ),
+    (
+        'cert_revoke_requests_list',
+        list_revoke_requests,
+        'alpacon://certs/revoke-requests/{region}/{workspace}',
+    ),
+    (
+        'cert_revoke_request_detail',
+        get_revoke_request,
+        'alpacon://certs/revoke-requests/{region}/{workspace}/{revoke_id}',
+    ),
+    ('commands_list', list_commands, 'alpacon://commands/{region}/{workspace}'),
+    ('events_list', list_events, 'alpacon://events/{region}/{workspace}'),
+    ('event_detail', get_event, 'alpacon://events/{region}/{workspace}/{event_id}'),
+    ('iam_users_list', list_iam_users, 'alpacon://iam/users/{region}/{workspace}'),
+    (
+        'iam_user_detail',
+        get_iam_user,
+        'alpacon://iam/users/{region}/{workspace}/{user_id}',
+    ),
+    ('iam_groups_list', list_iam_groups, 'alpacon://iam/groups/{region}/{workspace}'),
+    (
+        'iam_group_detail',
+        get_iam_group,
+        'alpacon://iam/groups/{region}/{workspace}/{group_id}',
+    ),
+    (
+        'iam_memberships_list',
+        list_iam_memberships,
+        'alpacon://iam/memberships/{region}/{workspace}',
+    ),
+    (
+        'iam_applications_list',
+        list_iam_applications,
+        'alpacon://iam/applications/{region}/{workspace}',
+    ),
+    (
+        'iam_application_detail',
+        get_iam_application,
+        'alpacon://iam/applications/{region}/{workspace}/{app_id}',
+    ),
+    (
+        'packages_system',
+        list_system_package_entries,
+        'alpacon://packages/system/{region}/{workspace}/{server_id}',
+    ),
+    (
+        'packages_python',
+        list_python_packages,
+        'alpacon://packages/python/{region}/{workspace}/{server_id}',
+    ),
+    ('acls_command', list_command_acls, 'alpacon://acls/command/{region}/{workspace}'),
+    ('acls_server', list_server_acls, 'alpacon://acls/server/{region}/{workspace}'),
+    ('acls_file', list_file_acls, 'alpacon://acls/file/{region}/{workspace}'),
+    ('tokens_list', list_api_tokens, 'alpacon://tokens/{region}/{workspace}'),
+    ('token_detail', get_api_token, 'alpacon://tokens/{region}/{workspace}/{token_id}'),
+    (
+        'token_scopes',
+        list_api_token_scopes,
+        'alpacon://tokens/scopes/{region}/{workspace}',
+    ),
+    (
+        'token_presets',
+        list_api_token_presets,
+        'alpacon://tokens/presets/{region}/{workspace}',
+    ),
+    (
+        'event_subscriptions_list',
+        list_event_subscriptions,
+        'alpacon://event-subscriptions/{region}/{workspace}',
+    ),
+    ('webhooks_list', list_webhooks, 'alpacon://webhooks/{region}/{workspace}'),
+    (
+        'webhook_detail',
+        get_webhook,
+        'alpacon://webhooks/{region}/{workspace}/{webhook_id}',
+    ),
+    (
+        'webftp_sessions',
+        webftp_sessions_list,
+        'alpacon://webftp/sessions/{region}/{workspace}',
+    ),
+    (
+        'webftp_downloads',
+        webftp_downloads_list,
+        'alpacon://webftp/downloads/{region}/{workspace}',
+    ),
+    (
+        'webftp_uploads',
+        webftp_uploads_list,
+        'alpacon://webftp/uploads/{region}/{workspace}',
+    ),
+    (
+        'work_sessions_list',
+        work_session_list,
+        'alpacon://work-sessions/{region}/{workspace}',
+    ),
+    (
+        'work_session_detail',
+        work_session_get,
+        'alpacon://work-sessions/{region}/{workspace}/{session_id}',
+    ),
+    ('workspaces_list', list_workspaces, 'alpacon://workspaces/{region}'),
+    ('current_user', get_current_user, 'alpacon://current-user/{region}/{workspace}'),
+]
+
+# (name, fn, uri, extra) — extra pins fixed kwargs for the few filtered resources.
+_REGISTRATIONS = [(n, f, u, None) for n, f, u in RESOURCES] + [
+    (
+        'alerts_active',
+        list_alerts,
+        'alpacon://alerts/active/{region}/{workspace}',
+        {'acknowledged': False},
+    ),
+]
+
+
+# Register most-specific first: a literal path segment (e.g. /active/) must win
+# over a sibling {id} wildcard that would otherwise shadow it — FastMCP returns
+# the first registered template that matches. Fewer {placeholders} = more
+# literal segments (colliding templates share a segment count), so sort ascending.
+for _name, _fn, _uri, _extra in sorted(_REGISTRATIONS, key=lambda r: r[2].count('{')):
+    register_resource(_uri, _fn, _name, _extra)

--- a/tools/webftp_tools.py
+++ b/tools/webftp_tools.py
@@ -11,7 +11,6 @@ from typing import Any, cast
 
 import httpx
 
-from server import mcp
 from utils.common import error_response, success_response, unwrap_http_result
 from utils.decorators import _is_auth_enabled, mcp_tool_handler
 from utils.error_handler import format_validation_error, validate_file_path
@@ -1043,27 +1042,3 @@ async def webftp_check_status(
         region=region,
         workspace=workspace,
     )
-
-
-@mcp.resource(
-    uri='webftp://sessions/{region}/{workspace}',
-    name='WebFTP Sessions List',
-    description='Get list of WebFTP sessions',
-    mime_type='application/json',
-)
-async def webftp_sessions_resource(region: str, workspace: str) -> dict[str, Any]:
-    """Get WebFTP sessions as a resource."""
-    sessions_data = await webftp_sessions_list(region=region, workspace=workspace)
-    return {'content': sessions_data}
-
-
-@mcp.resource(
-    uri='webftp://downloads/{region}/{workspace}',
-    name='WebFTP Downloads List',
-    description='Get list of WebFTP download history for a workspace',
-    mime_type='application/json',
-)
-async def webftp_downloads_resource(region: str, workspace: str) -> dict[str, Any]:
-    """Get WebFTP downloads as a resource."""
-    downloads_data = await webftp_downloads_list(region=region, workspace=workspace)
-    return {'content': downloads_data}


### PR DESCRIPTION
## Overview

Expose read-only MCP tools as MCP resources under the unified `alpacon://` URI scheme (#60). MCP clients can read infrastructure state via resource reads instead of tool calls. Legacy `webftp://` / `iam://` schemes are removed in favor of a single `alpacon://` scheme.

## Changes

- Generate 71 read-only resources from a registry table (`tools/resources.py`). URI convention: `alpacon://<domain>[/<sub>]/{region}/{workspace}[/{id}]`. Covers servers, metrics, system, iam, certs, audit, tokens, webhooks, acls, webftp, approvals, events, commands, and work-sessions; each domain exposes a list + detail pair.
- Add `acknowledged` / `dismissed` filter arguments to `list_alerts`, used by the `alpacon://alerts/active/...` resource to expose only unacknowledged alerts.
- Remove legacy `iam://` / `webftp://` resource wrappers (`iam_tools.py`, `webftp_tools.py`).

## Implementation notes

- Table-driven registration: a `RESOURCES` registry plus a `register_resource()` factory avoids ~70 near-identical wrapper copies.
- exec-based wrappers: FastMCP matches URI template params to the function signature by name, so wrappers need real named parameters. A `**kwargs` wrapper fails `func_metadata`.
- URI-template shadowing fix: templates are registered most-specific-first (sorted by placeholder count) so literal sub-paths like `/active/`, `/scopes/`, `/presets/`, `/revoke-requests/` are not captured by a sibling `{id}` wildcard.
- Resource wrappers call the decorated backing tools, so they go through `with_token_validation` (token check, workspace required, format checks, MFA) identically to the equivalent tools.

## Tests

- `tests/test_resources.py`: registration, helper, and routing regression tests (including shadowing).
- `tests/test_alert_tools.py`: `acknowledged` / `dismissed` filter forwarding.
- All passing, ruff clean.

## Intentionally excluded

- `get_registration_guide`: requires free-form args (e.g. `platform`), so it does not fit a URI template.
- `search_events`: a query-based search action, not a good fit for a resource.
- `work_session_timeline`: a supplementary view of detail, optional.

