### PR TITLE
docs: document hosted remote MCP server (streamable-http)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,14 @@ All notable changes to the Alpacon MCP Server project will be documented in this
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Documentation
+- Documented the hosted remote MCP server (`https://mcp.alpacon.io/mcp`, streamable-http transport)
+  - Added a "Remote MCP server (hosted, no install)" section to `README.md` with per-client setup for Claude Code, Claude Desktop, Cursor, and VS Code
+  - Explained browser-based OAuth authentication (no API token, no `token.json`) and prompt-driven workspace selection
+  - Added a streamable-http transport mode entry to `docs/configuration.md`
+
 ## [0.4.3] - 2025-10-24
 
 ### Improved

--- a/README.md
+++ b/README.md
@@ -120,7 +120,7 @@ Don't want to run anything locally? Alpacon hosts a managed MCP server at **`htt
 
 The first time your client connects, it opens a browser window for you to log in to Alpacon (Auth0). After you sign in, the client receives a short-lived token and uses it for every request—the same identity, RBAC, and audit trail as the Alpacon web console. If your session needs multi-factor re-verification (for example after an MFA timeout), the client automatically reopens the browser to complete it.
 
-Because access is granted per login, you **do not** set `region`, `workspace`, or any API token in your client config. Region is resolved automatically from your authorized workspaces; you only name the **workspace** in your prompt when you have access to more than one.
+Because access is granted per login, you **do not** set `region`, `workspace`, or any API token in your client config. Instead, you name the **workspace** in your prompt (e.g. *"in the `production` workspace"*)—tools require it, and the AI passes it along. The **region** is resolved automatically from your authorized workspaces, so you rarely need to mention it.
 
 ### Add it to your AI client
 

--- a/README.md
+++ b/README.md
@@ -104,6 +104,81 @@ After setup completes, add the configuration to your MCP client:
 
 ---
 
+## 🌐 Remote MCP server (hosted, no install)
+
+Don't want to run anything locally? Alpacon hosts a managed MCP server at **`https://mcp.alpacon.io/mcp`** using the streamable-http transport. Just point your AI client at the URL and sign in through your browser.
+
+### Why use the hosted server?
+
+- **No install**: No `uvx`, no Python, no local process to keep running
+- **No API token**: You authenticate through your browser (OAuth), not by pasting a token into a config file
+- **No `token.json`**: Nothing to create, store, or rotate on your machine
+- **No region/workspace config**: The workspaces you can access come from your login—you just say which one to use in your prompt (e.g. *"list servers in the `production` workspace"*)
+- **Always up to date**: Run the latest tools without upgrading anything
+
+### How authentication works
+
+The first time your client connects, it opens a browser window for you to log in to Alpacon (Auth0). After you sign in, the client receives a short-lived token and uses it for every request—the same identity, RBAC, and audit trail as the Alpacon web console. If your session needs multi-factor re-verification (for example after an MFA timeout), the client automatically reopens the browser to complete it.
+
+Because access is granted per login, you **do not** set `region`, `workspace`, or any API token in your client config. Region is resolved automatically from your authorized workspaces; you only name the **workspace** in your prompt when you have access to more than one.
+
+### Add it to your AI client
+
+**Claude Code** (CLI):
+```bash
+claude mcp add --transport http alpacon https://mcp.alpacon.io/mcp
+```
+On first use, Claude Code opens your browser to sign in. Verify with `claude mcp list`.
+
+**Claude Desktop**—add a custom connector (Settings → Connectors → Add custom connector) with the URL `https://mcp.alpacon.io/mcp`, or use the `mcp-remote` bridge in `claude_desktop_config.json`:
+```json
+{
+  "mcpServers": {
+    "alpacon": {
+      "command": "npx",
+      "args": ["-y", "mcp-remote", "https://mcp.alpacon.io/mcp"]
+    }
+  }
+}
+```
+
+**Cursor**—add to `.cursor/mcp.json`:
+```json
+{
+  "mcpServers": {
+    "alpacon": {
+      "url": "https://mcp.alpacon.io/mcp"
+    }
+  }
+}
+```
+
+**VS Code** (native MCP)—add to `.vscode/mcp.json`:
+```json
+{
+  "servers": {
+    "alpacon": {
+      "type": "http",
+      "url": "https://mcp.alpacon.io/mcp"
+    }
+  }
+}
+```
+
+> **Tip**: Any MCP client that supports remote/streamable-http servers can connect—just give it the URL `https://mcp.alpacon.io/mcp`. Clients that only support local (stdio) servers should use the `mcp-remote` bridge shown above for Claude Desktop.
+
+### Hosted vs. local—which should I use?
+
+| | Hosted (remote MCP) | Local (`uvx alpacon-mcp`) |
+|---|---|---|
+| Setup | Add a URL, sign in via browser | Install + configure token |
+| Authentication | Browser OAuth (Auth0) | API token in `token.json`/env |
+| Region/workspace | Resolved from login; named in prompt | Configured per token |
+| Maintenance | None (managed) | Self-managed upgrades |
+| Best for | Quick start, most users | Air-gapped/custom deployments, self-hosting |
+
+---
+
 ## 📋 CLI commands reference
 
 ```bash
@@ -168,6 +243,8 @@ python main.py
 ---
 
 ## 🔌 Connect to other AI tools
+
+> Prefer not to install anything? Skip this section and use the [hosted remote MCP server](#-remote-mcp-server-hosted-no-install) instead—just point your client at `https://mcp.alpacon.io/mcp` and sign in via browser.
 
 ### Cursor IDE
 

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -215,7 +215,7 @@ python main_sse.py
 #### Streamable-HTTP mode (remote deployment)
 - HTTP-based transport for hosting a remote MCP server
 - Authenticates clients with Auth0 JWT (browser OAuth)—no `token.json` or API token on the client
-- Requires `AUTH0_DOMAIN` and `AUTH0_CLIENT_ID` environment variables (see `main_http.py`)
+- `main_http.py` validates `AUTH0_DOMAIN` and `AUTH0_CLIENT_ID` at startup; the OAuth proxy endpoints additionally require `AUTH0_CLIENT_SECRET`, and accept an optional `AUTH0_AUDIENCE` (default `https://alpacon.io/access/`)
 - Alpacon operates a managed instance at `https://mcp.alpacon.io/mcp`
 
 ```bash

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -212,6 +212,18 @@ python main.py
 python main_sse.py
 ```
 
+#### Streamable-HTTP mode (remote deployment)
+- HTTP-based transport for hosting a remote MCP server
+- Authenticates clients with Auth0 JWT (browser OAuth)—no `token.json` or API token on the client
+- Requires `AUTH0_DOMAIN` and `AUTH0_CLIENT_ID` environment variables (see `main_http.py`)
+- Alpacon operates a managed instance at `https://mcp.alpacon.io/mcp`
+
+```bash
+python main_http.py
+```
+
+To connect a client to a remote streamable-http server, point it at the server URL instead of a local command. See the [hosted remote MCP guide in the README](../README.md#-remote-mcp-server-hosted-no-install) for per-client examples.
+
 ### Environment configuration
 
 #### Environment variables


### PR DESCRIPTION
## Summary
Documents Alpacon's managed remote MCP server at `https://mcp.alpacon.io/mcp` (streamable-http transport), which was already implemented in `main_http.py` but undocumented. Users can now connect an AI client by URL and sign in via browser—no local install, no API token, and no `token.json`. Region is resolved from the OAuth login and the workspace is named in the prompt.

## Pipeline Results
- Tests: PASS (848 tests, 0 auto-fixes)
- Review: APPROVED (0 critical, 0 warnings, 2 informational)
- Auto-fix: SKIPPED (no auto-fixable items; the one em-dash style nit was fixed manually)
- Config drift: not applicable (documentation-only change)

## Changes
- `README.md`: new "Remote MCP server (hosted, no install)" section—why-to-use, how OAuth auth works (incl. MFA re-verification), per-client setup (Claude Code, Claude Desktop, Cursor, VS Code), and a hosted-vs-local comparison table. Added a cross-reference from "Connect to other AI tools".
- `docs/configuration.md`: added a streamable-http transport mode entry under "Transport modes" with a pointer to the README guide.
- `CHANGELOG.md`: added an `[Unreleased]` / `Documentation` entry.

## Accuracy
All technical claims were verified against the source during review:
- Started by `main_http.py` → `run('streamable-http')` with Auth0 JWT auth (`server.py`).
- Remote mode uses the JWT from the auth context only and never falls back to `token.json` (`utils/decorators.py`).
- Region auto-resolved from the JWT's authorized workspaces; `workspace` remains required.
- Client endpoint `…/mcp` is FastMCP's default `streamable_http_path`, distinct from the OAuth resource identifier `https://mcp.alpacon.io`.

## Testing
- [x] All tests pass (848 passed)
- [x] No source code changed (markdown-only)
- [ ] Manual rendering check on GitHub