### PR TITLE
feat: add MCP prompts (workflow guides)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -477,6 +477,15 @@ Read-only data exposed as `alpacon://` resources (one per read tool). URI conven
 
 Resources are generated from a registry table in `tools/resources.py`.
 
+### MCP prompts
+
+Workflow guides that teach an agent the Alpacon operating discipline (Work Session as the single primitive, human-gated approval, structured-denial self-correction). Defined in `tools/prompts.py` and aligned to the handbook's ACCESS→EXECUTION→AUDIT model.
+
+- `work_session_workflow`: ACCESS—how to scope and open a Work Session (minimal scope, agent-only `command`/`webftp`, handle `pending_approval`) before any infrastructure action
+- `guarded_execution`: EXECUTION—run commands and transfers inside an approved session, handling HITL approval and structured denials
+- `incident_response`: Scenario—read-only triage first, then bounded remediation inside a scoped Work Session
+- `security_audit`: AUDIT—pick the right one of Alpacon's five audit lenses (session forensic, event forensic, decision, mutation, AI/MITRE) for the question
+
 ## Dependencies
 
 **Runtime dependencies** (from `pyproject.toml`):

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -481,7 +481,7 @@ Resources are generated from a registry table in `tools/resources.py`.
 
 Workflow guides that teach an agent the Alpacon operating discipline (Work Session as the single primitive, human-gated approval, structured-denial self-correction). Defined in `tools/prompts.py` and aligned to the handbook's ACCESS→EXECUTION→AUDIT model.
 
-- `work_session_workflow`: ACCESS—how to scope and open a Work Session (minimal scope, agent-only `command`/`webftp`, handle `pending_approval`) before any infrastructure action
+- `work_session_workflow`: ACCESS—how to scope and open a Work Session (minimal scope, agent-requestable `command`/`webftp`/`tunnel`, handle `pending_approval`) before any infrastructure action
 - `guarded_execution`: EXECUTION—run commands and transfers inside an approved session, handling HITL approval and structured denials
 - `incident_response`: Scenario—read-only triage first, then bounded remediation inside a scoped Work Session
 - `security_audit`: AUDIT—pick the right one of Alpacon's five audit lenses (session forensic, event forensic, decision, mutation, AI/MITRE) for the question

--- a/server.py
+++ b/server.py
@@ -278,6 +278,7 @@ def run(
     import tools.iam_tools  # noqa: F401
     import tools.metrics_tools  # noqa: F401
     import tools.package_tools  # noqa: F401
+    import tools.prompts  # noqa: F401
     import tools.resources  # noqa: F401
     import tools.security_tools  # noqa: F401
     import tools.server_tools  # noqa: F401

--- a/tests/test_prompts.py
+++ b/tests/test_prompts.py
@@ -27,3 +27,13 @@ async def test_prompt_renders_nonempty_text(name, args):
     assert text.strip()
     for arg_value in args.values():
         assert arg_value in text  # argument is interpolated into the guidance
+
+
+@pytest.mark.asyncio
+async def test_work_session_workflow_renders_servers():
+    result = await mcp.get_prompt(
+        'work_session_workflow',
+        {'intent': 'restart nginx', 'servers': 'uuid-a, uuid-b'},
+    )
+    text = result.messages[0].content.text
+    assert 'Target servers (UUIDs): uuid-a, uuid-b' in text

--- a/tests/test_prompts.py
+++ b/tests/test_prompts.py
@@ -1,0 +1,29 @@
+"""Tests for MCP prompts (agent workflow guides)."""
+
+import pytest
+
+import tools.prompts  # noqa: F401  (registers prompts on import)
+from server import mcp
+
+EXPECTED = {
+    'work_session_workflow': {'intent': 'restart nginx'},
+    'guarded_execution': {'work_session_id': 'sess-123'},
+    'incident_response': {'server_id': 'srv-1'},
+    'security_audit': {'work_session_id': 'sess-9'},
+}
+
+
+@pytest.mark.asyncio
+async def test_all_four_prompts_registered():
+    names = {p.name for p in await mcp.list_prompts()}
+    assert set(EXPECTED) <= names
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize('name, args', EXPECTED.items())
+async def test_prompt_renders_nonempty_text(name, args):
+    result = await mcp.get_prompt(name, args)
+    text = result.messages[0].content.text
+    assert text.strip()
+    for arg_value in args.values():
+        assert arg_value in text  # argument is interpolated into the guidance

--- a/tools/prompts.py
+++ b/tools/prompts.py
@@ -21,10 +21,11 @@ In Alpacon there is NO out-of-session path: every command, file transfer, or con
 must belong to an approved Work Session. Follow this order.
 
 1. Declare intent and minimal scope, then call `work_session_create`.
-   - Pass the goal above as the session intent.
-   - As an agent (MCP channel) you can scope `command` and `webftp`/`cp` directly; `sudo`
-     is available but every sudo invocation routes to human approval (HITL). `websh` and
-     `editor` require human presence (MFA) and are NOT available to you.
+   - Pass the goal above as the session `description` (the API has no `intent` field).
+   - Valid scopes are `command`, `webftp`, `tunnel`, and `sudo`. As an agent (MCP channel)
+     you can request `command`/`webftp`/`tunnel` directly; `sudo` is available but every
+     sudo invocation routes to human approval (HITL). Interactive `websh`/`editor` access
+     requires human presence (MFA) and is NOT available to you.
    - Scope to the specific target servers only — do not request workspace-wide access.
 
 2. Handle the result by status:
@@ -57,9 +58,12 @@ here is judged in real time and recorded. Follow this discipline.
    tool-call result, always `success` on a good call). Any other state (`pending`,
    `approved`, `rejected`, `expired`, `revoked`, `completed`) means stop — do not execute.
 
-2. Run actions through the session:
+2. Run actions through the session. Pass `work_session_id` on every call (it falls back to
+   the `ALPACON_WORK_SESSION` env var if omitted; without either the server rejects the
+   scoped action):
    - Commands: `execute_command` (single host) or `execute_command_multi_server` (fleet).
-   - File transfers: `webftp_upload_file` / `webftp_download_file`.
+   - File transfers: `webftp_download_file`. `webftp_upload_file` is local-mode only — in
+     remote/OAuth mode it returns `remote_mode_unsupported`.
 
 3. Expect risk verdicts. Each action is scored; a HIGH-risk command or any `sudo`
    invocation routes to human-in-the-loop. You cannot self-approve (an agent has no

--- a/tools/prompts.py
+++ b/tools/prompts.py
@@ -21,6 +21,8 @@ In Alpacon there is NO out-of-session path: every command, file transfer, or con
 must belong to an approved Work Session. Follow this order.
 
 1. Declare intent and minimal scope, then call `work_session_create`.
+   - Required arguments: `workspace`, `scopes` (list), `servers` (list of UUIDs),
+     `expires_at` (ISO 8601), and `description` — fill them all or the call is rejected.
    - Pass the goal above as the session `description` (the API has no `intent` field).
    - Valid scopes are `command`, `webftp`, `tunnel`, and `sudo`. As an agent (MCP channel)
      you can request `command`/`webftp`/`tunnel` directly; `sudo` is available but every
@@ -32,7 +34,8 @@ must belong to an approved Work Session. Follow this order.
    - `pending_approval`: you cannot approve your own work — an agent has no presence (MFA),
      so the session routes to a human approver. Surface the request to a human and WAIT.
      Do not retry-spam.
-     Use `explain_approval_decision` to relay why a human must act out-of-band.
+     Use `explain_approval_decision` (pass `workspace`) to relay why a human must
+     act out-of-band.
    - `error` with a gate `code` (`work_session_required`, `work_session_scope_not_allowed`,
      `work_session_server_not_allowed`, `work_session_expired`, ...): read `next_action`,
      narrow the scope or server set, and retry deliberately — never brute-force.

--- a/tools/prompts.py
+++ b/tools/prompts.py
@@ -1,0 +1,117 @@
+"""MCP prompts — workflow guides that teach an agent the Alpacon operating discipline.
+
+Unlike tools (which act) and resources (which expose data), these prompts inject the
+*rules* an MCP agent must follow: every infrastructure action is wrapped in a Work
+Session, approval gates route to a human (an agent can never self-approve), and denials
+are structured so the agent self-corrects instead of brute-forcing. Grounded in the
+alpacon-handbook product model (ACCESS -> EXECUTION -> AUDIT, Work Session as the single
+primitive). Each prompt returns static guidance text; arguments only scope the context.
+"""
+
+from server import mcp
+
+
+@mcp.prompt()
+def work_session_workflow(intent: str, servers: str = '') -> str:
+    """ACCESS: how to scope and open a Work Session before any infrastructure action."""
+    target = f'\nTarget servers (UUIDs): {servers}' if servers else ''
+    return f"""You are operating Alpacon as an AI agent over MCP. Goal: {intent}{target}
+
+In Alpacon there is NO out-of-session path: every command, file transfer, or connection
+must belong to an approved Work Session. Follow this order.
+
+1. Declare intent and minimal scope, then call `work_session_create`.
+   - Pass the goal above as the session intent.
+   - As an agent (MCP channel) you can scope `command` and `webftp`/`cp` directly; `sudo`
+     is available but every sudo invocation routes to human approval (HITL). `websh` and
+     `editor` require human presence (MFA) and are NOT available to you.
+   - Scope to the specific target servers only — do not request workspace-wide access.
+
+2. Handle the result by status:
+   - `pending_approval`: you cannot approve your own work — an agent has no presence (MFA),
+     so the session routes to a human approver. Surface the request to a human and WAIT.
+     Do not retry-spam.
+     Use `explain_approval_decision` to relay why a human must act out-of-band.
+   - `error` with a gate `code` (`work_session_required`, `work_session_scope_not_allowed`,
+     `work_session_server_not_allowed`, `work_session_expired`, ...): read `next_action`,
+     narrow the scope or server set, and retry deliberately — never brute-force.
+
+3. Once the session is `active` (confirm with `work_session_get`), proceed to execution.
+   Follow the `guarded_execution` workflow for the running commands.
+
+Read-only context needs no session: `alpacon://servers/{{region}}/{{workspace}}` lists
+servers and their UUIDs for the calls above.
+"""
+
+
+@mcp.prompt()
+def guarded_execution(work_session_id: str) -> str:
+    """EXECUTION: run commands and transfers inside an approved session, handling HITL."""
+    return f"""You are executing work inside Work Session `{work_session_id}`. Every action
+here is judged in real time and recorded. Follow this discipline.
+
+1. Confirm the session is `active` with `work_session_get` before any action. Any other
+   state (`pending`, `approved`, `rejected`, `expired`, `revoked`, `completed`) means
+   stop — do not execute.
+
+2. Run actions through the session:
+   - Commands: `execute_command` (single host) or `execute_command_multi_server` (fleet).
+   - File transfers: `webftp_upload_file` / `webftp_download_file`.
+
+3. Expect risk verdicts. Each action is scored; a HIGH-risk command or any `sudo`
+   invocation routes to human-in-the-loop. You cannot self-approve (an agent has no
+   presence/MFA). When a result is `pending_approval`, surface it to a human and wait.
+
+4. On a denial, read the structured `code` and `next_action` and self-correct — adjust
+   the command, narrow the target, or escalate to a human. Never re-run the identical
+   denied command in a loop.
+
+5. When the work is done, call `work_session_close` to mark it completed and trigger the
+   AI security analysis over the session.
+"""
+
+
+@mcp.prompt()
+def incident_response(server_id: str = '', workspace: str = '') -> str:
+    """Scenario: triage read-only first, then bounded remediation inside a Work Session."""
+    scope = server_id or workspace or 'the affected scope'
+    return f"""Respond to an incident on {scope}. Triage before you touch anything.
+
+1. Triage (no Work Session needed — read-only):
+   - Active alerts: `alpacon://alerts/active/{{region}}/{{workspace}}` or `list_alerts`.
+   - Server state: `get_server_overview`, `get_cpu_usage`, `get_memory_usage`.
+   - Recent events: `list_events`. Identify the likely cause before acting.
+
+2. If remediation requires running commands, do NOT execute directly. Open a Work Session
+   via the `work_session_workflow`: scope it to the affected server(s) only, with the
+   `command` scope, and wait for human approval.
+
+3. Execute remediation under the `guarded_execution` workflow. Risky remediation
+   (restarts, sudo, destructive commands) will route to human-in-the-loop — surface it
+   and wait; you cannot self-approve.
+
+4. After the incident is resolved, `work_session_close` the session to mark it complete
+   and trigger AI security analysis for the audit trail.
+"""
+
+
+@mcp.prompt()
+def security_audit(work_session_id: str = '', server_id: str = '') -> str:
+    """AUDIT: pick the right one of Alpacon's five audit lenses for the question."""
+    anchor = work_session_id or server_id or 'the workspace'
+    return f"""Audit privileged activity for {anchor}. Choose the lens that fits the question.
+
+- Lens 1 — Session forensic ("what happened in this session?"):
+  `work_session_timeline` for the unified command/transfer/risk timeline.
+- Lens 2 — Event forensic, cross-session ("every sudo / every `rm -rf` / every transfer
+  of /etc/*"): `list_server_logs`, `list_webftp_logs`, `search_events`.
+- Lens 3 — Decision audit ("why was access granted, who approved, when revoked?"):
+  `list_approval_requests`, `get_approval_request`.
+- Lens 4 — Mutation audit ("what changed in workspace state — roles, tokens, policy?"):
+  `list_activity_logs`, `get_activity_log`.
+- Lens 5 — AI-derived analysis (attack patterns, MITRE ATT&CK mapping, kill-chain):
+  `list_session_analyses`, then `get_session_analysis_detail` for a specific session.
+
+Start from the anchor above, then link findings back to the Work Session that contains
+each event — the session is the primary primitive for the audit story.
+"""

--- a/tools/prompts.py
+++ b/tools/prompts.py
@@ -36,8 +36,10 @@ must belong to an approved Work Session. Follow this order.
      `work_session_server_not_allowed`, `work_session_expired`, ...): read `next_action`,
      narrow the scope or server set, and retry deliberately — never brute-force.
 
-3. Once the session is `active` (confirm with `work_session_get`), proceed to execution.
-   Follow the `guarded_execution` workflow for the running commands.
+3. Once the session is `active`, proceed to execution. Confirm with `work_session_get`
+   and read the session state from `data.status` (the top-level `status` is just the
+   tool-call result, always `success` on a good call). Follow the `guarded_execution`
+   workflow for the running commands.
 
 Read-only context needs no session: `alpacon://servers/{{region}}/{{workspace}}` lists
 servers and their UUIDs for the calls above.
@@ -50,9 +52,10 @@ def guarded_execution(work_session_id: str) -> str:
     return f"""You are executing work inside Work Session `{work_session_id}`. Every action
 here is judged in real time and recorded. Follow this discipline.
 
-1. Confirm the session is `active` with `work_session_get` before any action. Any other
-   state (`pending`, `approved`, `rejected`, `expired`, `revoked`, `completed`) means
-   stop — do not execute.
+1. Confirm the session is `active` with `work_session_get` before any action. Read the
+   session state from `data.status`, not the top-level `status` (that is just the
+   tool-call result, always `success` on a good call). Any other state (`pending`,
+   `approved`, `rejected`, `expired`, `revoked`, `completed`) means stop — do not execute.
 
 2. Run actions through the session:
    - Commands: `execute_command` (single host) or `execute_command_multi_server` (fleet).

--- a/tools/prompts.py
+++ b/tools/prompts.py
@@ -56,7 +56,8 @@ here is judged in real time and recorded. Follow this discipline.
 1. Confirm the session is `active` with `work_session_get` before any action. Read the
    session state from `data.status`, not the top-level `status` (that is just the
    tool-call result, always `success` on a good call). Any other state (`pending`,
-   `approved`, `rejected`, `expired`, `revoked`, `completed`) means stop — do not execute.
+   `approved`, `rejected`, `cancelled`, `expired`, `revoked`, `completed`) means stop —
+   do not execute.
 
 2. Run actions through the session. Pass `work_session_id` on every call (it falls back to
    the `ALPACON_WORK_SESSION` env var if omitted; without either the server rejects the


### PR DESCRIPTION
## Overview

Adds four MCP prompts that guide an agent through the procedures to follow when operating Alpacon. Unlike tools and resources, they neither act nor return data; they only return guidance text.

Closes #60 (the Resource part was merged in #124; this PR adds the Prompt definitions)

## Prompts added

Four prompts aligned to the handbook model (ACCESS → EXECUTION → AUDIT):

| Prompt | Role |
|---|---|
| work_session_workflow | Open a Work Session with minimal scope before any action and handle pending_approval |
| guarded_execution | Run commands and transfers inside an approved session, handling HITL approval and denial codes |
| incident_response | Read-only triage first, then remediation inside a scope-narrowed session |
| security_audit | Choose among the five audit lenses (session/event/decision/mutation/AI·MITRE) |

Arguments are used only to scope context. Prompts are registered via the import in server.run(), and a test verifies registration and argument interpolation.

## Handbook reconciliation

Aligned with the scope table in design/02-work-session-model.md.

- Agent-allowed scopes: command/webftp/tunnel, and sudo (routed through HITL). websh/editor are not available.
- Reworded the pending_approval explanation around "no self-approval" (ADR 0015).
- Generalized the execution-block condition to every state other than active (pending/approved/rejected/expired/revoked/completed).

The prompt examples in issue #60 did not match the actual behavior, so they were not used; the prompts were written against the handbook instead.

## Tests

tests/test_prompts.py 5 passed

## Files changed

- tools/prompts.py (new, +128)
- tests/test_prompts.py (new, +29)
- server.py (+1, registration import)
- CLAUDE.md (+9, docs)

