### PR TITLE
fix(tools): stop wrapping HTTP failures as success responses

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -17,6 +17,14 @@ HTTP_ERROR_ENVELOPE = {
 }
 
 
+@pytest.fixture
+def mock_token_manager():
+    """Mock token manager so tests never read a real ~/.alpacon-mcp/token.json."""
+    with patch('utils.common.token_manager') as mock_manager:
+        mock_manager.get_token.return_value = 'test-token'
+        yield mock_manager
+
+
 @pytest.fixture(autouse=True)
 def mock_region_auto_detect():
     """Prevent _resolve_region from accessing real token.json in all tests.

--- a/tests/test_agent_actions.py
+++ b/tests/test_agent_actions.py
@@ -4,6 +4,7 @@ from unittest.mock import AsyncMock, patch
 
 import pytest
 
+from tests.conftest import HTTP_ERROR_ENVELOPE
 from tools.server_tools import (
     reboot_system,
     restart_agent,
@@ -23,15 +24,42 @@ def mock_http_client():
         yield mock_client
 
 
-@pytest.fixture
-def mock_token_manager():
-    """Mock token manager for testing."""
-    with patch('utils.common.token_manager') as mock_manager:
-        mock_manager.get_token.return_value = 'test-token'
-        yield mock_manager
-
-
 SERVER_ID = '550e8400-e29b-41d4-a716-446655440123'
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    ('tool', 'action'),
+    [
+        (restart_agent, 'restart_agent'),
+        (shutdown_agent, 'shutdown_agent'),
+        (upgrade_agent, 'upgrade_agent'),
+        (update_information, 'update_information'),
+        (upgrade_system, 'upgrade_system'),
+        (reboot_system, 'reboot_system'),
+        (shutdown_system, 'shutdown_system'),
+    ],
+)
+async def test_agent_action_http_error_envelope_returns_error(
+    tool, action, mock_http_client, mock_token_manager
+):
+    mock_http_client.post.return_value = HTTP_ERROR_ENVELOPE
+
+    result = await tool(server_id=SERVER_ID, workspace='testworkspace', region='ap1')
+
+    assert result['status'] == 'error'
+    assert result['message'] == HTTP_ERROR_ENVELOPE['message']
+    assert result['status_code'] == HTTP_ERROR_ENVELOPE['status_code']
+    assert result['server_id'] == SERVER_ID
+    assert result['region'] == 'ap1'
+    assert result['workspace'] == 'testworkspace'
+    mock_http_client.post.assert_called_once_with(
+        region='ap1',
+        workspace='testworkspace',
+        endpoint=f'/api/servers/servers/{SERVER_ID}/actions/',
+        token='test-token',
+        data={'action': action},
+    )
 
 
 class TestRestartAgent:

--- a/tests/test_server_tools.py
+++ b/tests/test_server_tools.py
@@ -8,6 +8,7 @@ from unittest.mock import AsyncMock, patch
 
 import pytest
 
+from tests.conftest import HTTP_ERROR_ENVELOPE
 from tools.server_tools import (
     create_registration_token,
     create_server_note,
@@ -35,14 +36,6 @@ def mock_http_client():
         mock_client.patch = AsyncMock()
         mock_client.delete = AsyncMock()
         yield mock_client
-
-
-@pytest.fixture
-def mock_token_manager():
-    """Mock token manager for testing."""
-    with patch('utils.common.token_manager') as mock_manager:
-        mock_manager.get_token.return_value = 'test-token'
-        yield mock_manager
 
 
 @pytest.fixture
@@ -288,6 +281,25 @@ class TestServerNotes:
         )
 
     @pytest.mark.asyncio
+    async def test_list_server_notes_http_error_envelope(
+        self, mock_http_client, mock_token_manager
+    ):
+        mock_http_client.get.return_value = HTTP_ERROR_ENVELOPE
+
+        result = await list_server_notes(
+            server_id='550e8400-e29b-41d4-a716-446655440123',
+            workspace='testworkspace',
+            region='ap1',
+        )
+
+        assert result['status'] == 'error'
+        assert result['message'] == HTTP_ERROR_ENVELOPE['message']
+        assert result['status_code'] == HTTP_ERROR_ENVELOPE['status_code']
+        assert result['server_id'] == '550e8400-e29b-41d4-a716-446655440123'
+        assert result['region'] == 'ap1'
+        assert result['workspace'] == 'testworkspace'
+
+    @pytest.mark.asyncio
     async def test_list_server_notes_no_token(
         self, mock_http_client, mock_token_manager
     ):
@@ -340,6 +352,27 @@ class TestServerNotes:
             token='test-token',
             data=expected_data,
         )
+
+    @pytest.mark.asyncio
+    async def test_create_server_note_http_error_envelope(
+        self, mock_http_client, mock_token_manager
+    ):
+        mock_http_client.post.return_value = HTTP_ERROR_ENVELOPE
+
+        result = await create_server_note(
+            server_id='550e8400-e29b-41d4-a716-446655440123',
+            title='',
+            content='This is a new note about the server',
+            workspace='testworkspace',
+            region='ap1',
+        )
+
+        assert result['status'] == 'error'
+        assert result['message'] == HTTP_ERROR_ENVELOPE['message']
+        assert result['status_code'] == HTTP_ERROR_ENVELOPE['status_code']
+        assert result['server_id'] == '550e8400-e29b-41d4-a716-446655440123'
+        assert result['region'] == 'ap1'
+        assert result['workspace'] == 'testworkspace'
 
     @pytest.mark.asyncio
     async def test_create_server_note_no_token(

--- a/tests/test_system_info_tools.py
+++ b/tests/test_system_info_tools.py
@@ -644,10 +644,10 @@ class TestGetDiskInfo:
         assert mock_http_client.get.call_count == 2
 
     @pytest.mark.asyncio
-    async def test_disk_info_partial_failure(
+    async def test_disk_info_sub_call_exception_fails(
         self, mock_http_client, mock_token_manager
     ):
-        """Test disk info with partial failure."""
+        """A raised exception in one sub-call fails the whole call, not partial success."""
         from tools.system_info_tools import get_disk_info
 
         disks_data = {'disks': [{'device': '/dev/sda'}]}
@@ -667,10 +667,30 @@ class TestGetDiskInfo:
             server_id='550e8400-e29b-41d4-a716-446655440001', workspace='testworkspace'
         )
 
-        assert result['status'] == 'success'
-        assert result['data']['disks'] == disks_data
-        assert 'error' in result['data']['partitions']
-        assert 'Partitions service unavailable' in result['data']['partitions']['error']
+        assert result['status'] == 'error'
+        assert 'Partitions service unavailable' in result['message']
+
+    @pytest.mark.asyncio
+    async def test_disk_info_error_envelope(self, mock_http_client, mock_token_manager):
+        """An http error envelope in a sub-call is not wrapped as success."""
+        from tools.system_info_tools import get_disk_info
+
+        disks_data = {'disks': [{'device': '/dev/sda'}]}
+
+        def mock_get_side_effect(*args, **kwargs):
+            endpoint = kwargs.get('endpoint', '')
+            if 'partitions' in endpoint:
+                return HTTP_ERROR_ENVELOPE
+            return disks_data
+
+        mock_http_client.get.side_effect = mock_get_side_effect
+
+        result = await get_disk_info(
+            server_id='550e8400-e29b-41d4-a716-446655440001', workspace='testworkspace'
+        )
+
+        assert result['status'] == 'error'
+        assert result['status_code'] == HTTP_ERROR_ENVELOPE['status_code']
 
     @pytest.mark.asyncio
     async def test_disk_info_no_token(self, mock_http_client, mock_token_manager):

--- a/tests/test_system_tools.py
+++ b/tests/test_system_tools.py
@@ -388,11 +388,9 @@ class TestGetDiskInfoEdgeCases:
             server_id='550e8400-e29b-41d4-a716-446655440001', workspace='testworkspace'
         )
 
-        # get_disk_info uses asyncio.gather with return_exceptions=True
-        # so it returns success with error info in the data
-        assert result['status'] == 'success'
-        assert 'error' in result['data']['disks']
-        assert 'error' in result['data']['partitions']
+        # A failed sub-call must surface as an error, not a wrapped success.
+        assert result['status'] == 'error'
+        assert 'Disk service unavailable' in result['message']
 
 
 class TestCrossFunctionScenarios:

--- a/tests/test_webhook_tools.py
+++ b/tests/test_webhook_tools.py
@@ -4,6 +4,7 @@ from unittest.mock import AsyncMock, patch
 
 import pytest
 
+from tests.conftest import HTTP_ERROR_ENVELOPE
 from tools.webhook_tools import (
     create_event_subscription,
     create_webhook,
@@ -27,12 +28,111 @@ def mock_http_client():
         yield mock_client
 
 
-@pytest.fixture
-def mock_token_manager():
-    """Mock token manager for testing."""
-    with patch('utils.common.token_manager') as mock_manager:
-        mock_manager.get_token.return_value = 'test-token'
-        yield mock_manager
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    ('tool', 'tool_kwargs', 'method_name', 'expected_context'),
+    [
+        pytest.param(
+            list_event_subscriptions,
+            {'workspace': 'testworkspace', 'region': 'ap1'},
+            'get',
+            {},
+            id='list_event_subscriptions',
+        ),
+        pytest.param(
+            create_event_subscription,
+            {
+                'workspace': 'testworkspace',
+                'channel': 'ch-1',
+                'event_type': 'command_fin',
+                'target_id': 'server-1',
+                'region': 'ap1',
+            },
+            'post',
+            {},
+            id='create_event_subscription',
+        ),
+        pytest.param(
+            delete_event_subscription,
+            {
+                'subscription_id': 'sub-1',
+                'workspace': 'testworkspace',
+                'region': 'ap1',
+            },
+            'delete',
+            {'subscription_id': 'sub-1'},
+            id='delete_event_subscription',
+        ),
+        pytest.param(
+            list_webhooks,
+            {'workspace': 'testworkspace', 'region': 'ap1'},
+            'get',
+            {},
+            id='list_webhooks',
+        ),
+        pytest.param(
+            get_webhook,
+            {'webhook_id': 'wh-1', 'workspace': 'testworkspace', 'region': 'ap1'},
+            'get',
+            {'webhook_id': 'wh-1'},
+            id='get_webhook',
+        ),
+        pytest.param(
+            create_webhook,
+            {
+                'workspace': 'testworkspace',
+                'name': 'alerts',
+                'url': 'https://example.com/webhook',
+                'region': 'ap1',
+            },
+            'post',
+            {},
+            id='create_webhook',
+        ),
+        pytest.param(
+            update_webhook,
+            {
+                'webhook_id': 'wh-1',
+                'workspace': 'testworkspace',
+                'name': 'updated-alerts',
+                'region': 'ap1',
+            },
+            'patch',
+            {'webhook_id': 'wh-1'},
+            id='update_webhook',
+        ),
+        pytest.param(
+            delete_webhook,
+            {
+                'webhook_id': 'wh-1',
+                'workspace': 'testworkspace',
+                'region': 'ap1',
+            },
+            'delete',
+            {'webhook_id': 'wh-1'},
+            id='delete_webhook',
+        ),
+    ],
+)
+async def test_webhook_http_error_envelope_returns_error(
+    tool,
+    tool_kwargs,
+    method_name,
+    expected_context,
+    mock_http_client,
+    mock_token_manager,
+):
+    getattr(mock_http_client, method_name).return_value = HTTP_ERROR_ENVELOPE
+
+    result = await tool(**tool_kwargs)
+
+    assert result['status'] == 'error'
+    assert result['message'] == HTTP_ERROR_ENVELOPE['message']
+    assert result['status_code'] == HTTP_ERROR_ENVELOPE['status_code']
+    assert result['region'] == 'ap1'
+    assert result['workspace'] == 'testworkspace'
+    for key, value in expected_context.items():
+        assert result[key] == value
 
 
 class TestEventSubscriptions:

--- a/tools/server_tools.py
+++ b/tools/server_tools.py
@@ -158,6 +158,16 @@ async def list_server_notes(
         token=token,
     )
 
+    err = unwrap_http_result(
+        result,
+        default_message='Failed to list server notes',
+        server_id=server_id,
+        region=region,
+        workspace=workspace,
+    )
+    if err:
+        return err
+
     return success_response(
         data=result, server_id=server_id, region=region, workspace=workspace
     )
@@ -206,6 +216,17 @@ async def create_server_note(
         token=token,
         data=note_data,
     )
+
+    err = unwrap_http_result(
+        result,
+        default_message='Failed to create server note',
+        server_id=server_id,
+        note_title=title,
+        region=region,
+        workspace=workspace,
+    )
+    if err:
+        return err
 
     return success_response(
         data=result,
@@ -375,6 +396,38 @@ async def delete_server_note(
     )
 
 
+async def _server_action(
+    *,
+    server_id: str,
+    workspace: str,
+    region: str,
+    action: str,
+    default_message: str,
+    token: str | None,
+) -> dict[str, Any]:
+    result = await http_client.post(
+        region=region,
+        workspace=workspace,
+        endpoint=f'/api/servers/servers/{server_id}/actions/',
+        token=token,
+        data={'action': action},
+    )
+
+    err = unwrap_http_result(
+        result,
+        default_message=default_message,
+        server_id=server_id,
+        region=region,
+        workspace=workspace,
+    )
+    if err:
+        return err
+
+    return success_response(
+        data=result, server_id=server_id, region=region, workspace=workspace
+    )
+
+
 @mcp_tool_handler(
     description=(
         'Restart the Alpacon agent process on a server. The agent will briefly go offline during restart. '
@@ -399,16 +452,13 @@ async def restart_agent(
     """
     token = kwargs.get('token')
 
-    result = await http_client.post(
-        region=region,
+    return await _server_action(
+        server_id=server_id,
         workspace=workspace,
-        endpoint=f'/api/servers/servers/{server_id}/actions/',
+        region=region,
+        action='restart_agent',
+        default_message='Failed to restart agent',
         token=token,
-        data={'action': 'restart_agent'},
-    )
-
-    return success_response(
-        data=result, server_id=server_id, region=region, workspace=workspace
     )
 
 
@@ -436,16 +486,13 @@ async def shutdown_agent(
     """
     token = kwargs.get('token')
 
-    result = await http_client.post(
-        region=region,
+    return await _server_action(
+        server_id=server_id,
         workspace=workspace,
-        endpoint=f'/api/servers/servers/{server_id}/actions/',
+        region=region,
+        action='shutdown_agent',
+        default_message='Failed to shutdown agent',
         token=token,
-        data={'action': 'shutdown_agent'},
-    )
-
-    return success_response(
-        data=result, server_id=server_id, region=region, workspace=workspace
     )
 
 
@@ -473,16 +520,13 @@ async def upgrade_agent(
     """
     token = kwargs.get('token')
 
-    result = await http_client.post(
-        region=region,
+    return await _server_action(
+        server_id=server_id,
         workspace=workspace,
-        endpoint=f'/api/servers/servers/{server_id}/actions/',
+        region=region,
+        action='upgrade_agent',
+        default_message='Failed to upgrade agent',
         token=token,
-        data={'action': 'upgrade_agent'},
-    )
-
-    return success_response(
-        data=result, server_id=server_id, region=region, workspace=workspace
     )
 
 
@@ -510,16 +554,13 @@ async def update_information(
     """
     token = kwargs.get('token')
 
-    result = await http_client.post(
-        region=region,
+    return await _server_action(
+        server_id=server_id,
         workspace=workspace,
-        endpoint=f'/api/servers/servers/{server_id}/actions/',
+        region=region,
+        action='update_information',
+        default_message='Failed to update server information',
         token=token,
-        data={'action': 'update_information'},
-    )
-
-    return success_response(
-        data=result, server_id=server_id, region=region, workspace=workspace
     )
 
 
@@ -548,16 +589,13 @@ async def upgrade_system(
     """
     token = kwargs.get('token')
 
-    result = await http_client.post(
-        region=region,
+    return await _server_action(
+        server_id=server_id,
         workspace=workspace,
-        endpoint=f'/api/servers/servers/{server_id}/actions/',
+        region=region,
+        action='upgrade_system',
+        default_message='Failed to upgrade system',
         token=token,
-        data={'action': 'upgrade_system'},
-    )
-
-    return success_response(
-        data=result, server_id=server_id, region=region, workspace=workspace
     )
 
 
@@ -585,16 +623,13 @@ async def reboot_system(
     """
     token = kwargs.get('token')
 
-    result = await http_client.post(
-        region=region,
+    return await _server_action(
+        server_id=server_id,
         workspace=workspace,
-        endpoint=f'/api/servers/servers/{server_id}/actions/',
+        region=region,
+        action='reboot_system',
+        default_message='Failed to reboot system',
         token=token,
-        data={'action': 'reboot_system'},
-    )
-
-    return success_response(
-        data=result, server_id=server_id, region=region, workspace=workspace
     )
 
 
@@ -623,16 +658,13 @@ async def shutdown_system(
     """
     token = kwargs.get('token')
 
-    result = await http_client.post(
-        region=region,
+    return await _server_action(
+        server_id=server_id,
         workspace=workspace,
-        endpoint=f'/api/servers/servers/{server_id}/actions/',
+        region=region,
+        action='shutdown_system',
+        default_message='Failed to shutdown system',
         token=token,
-        data={'action': 'shutdown_system'},
-    )
-
-    return success_response(
-        data=result, server_id=server_id, region=region, workspace=workspace
     )
 
 

--- a/tools/system_info_tools.py
+++ b/tools/system_info_tools.py
@@ -395,6 +395,10 @@ async def get_disk_info(
             workspace=workspace,
         )
         if err:
+            # Work Session gate responses already carry a specific message; only
+            # plain upstream errors need the disks-vs-partitions label restored.
+            if err.get('status') == 'error' and 'code' not in err:
+                err['message'] = f'{default_message}: {err["message"]}'
             return err
 
     disk_info = {

--- a/tools/system_info_tools.py
+++ b/tools/system_info_tools.py
@@ -3,7 +3,7 @@
 import asyncio
 from typing import Any
 
-from utils.common import success_response, unwrap_http_result
+from utils.common import error_response, success_response, unwrap_http_result
 from utils.decorators import mcp_tool_handler
 from utils.http_client import http_client
 from utils.tool_annotations import READ_ONLY
@@ -376,15 +376,31 @@ async def get_disk_info(
         if isinstance(r, BaseException) and not isinstance(r, Exception):
             raise r
 
-    # Prepare response
+    for result, default_message in (
+        (disks_result, 'Failed to get disk info'),
+        (partitions_result, 'Failed to get partition info'),
+    ):
+        if isinstance(result, Exception):
+            return error_response(
+                f'{default_message}: {result}',
+                server_id=server_id,
+                region=region,
+                workspace=workspace,
+            )
+        err = unwrap_http_result(
+            result,
+            default_message=default_message,
+            server_id=server_id,
+            region=region,
+            workspace=workspace,
+        )
+        if err:
+            return err
+
     disk_info = {
         'server_id': server_id,
-        'disks': disks_result
-        if not isinstance(disks_result, Exception)
-        else {'error': str(disks_result)},
-        'partitions': partitions_result
-        if not isinstance(partitions_result, Exception)
-        else {'error': str(partitions_result)},
+        'disks': disks_result,
+        'partitions': partitions_result,
         'region': region,
         'workspace': workspace,
     }

--- a/tools/webhook_tools.py
+++ b/tools/webhook_tools.py
@@ -51,6 +51,15 @@ async def list_event_subscriptions(
         params=params,
     )
 
+    err = unwrap_http_result(
+        result,
+        default_message='Failed to list event subscriptions',
+        region=region,
+        workspace=workspace,
+    )
+    if err:
+        return err
+
     return success_response(data=result, region=region, workspace=workspace)
 
 
@@ -97,6 +106,15 @@ async def create_event_subscription(
         data=subscription_data,
     )
 
+    err = unwrap_http_result(
+        result,
+        default_message='Failed to create event subscription',
+        region=region,
+        workspace=workspace,
+    )
+    if err:
+        return err
+
     return success_response(data=result, region=region, workspace=workspace)
 
 
@@ -126,6 +144,16 @@ async def delete_event_subscription(
         endpoint=f'/api/events/subscriptions/{subscription_id}/',
         token=token,
     )
+
+    err = unwrap_http_result(
+        result,
+        default_message='Failed to delete event subscription',
+        subscription_id=subscription_id,
+        region=region,
+        workspace=workspace,
+    )
+    if err:
+        return err
 
     return success_response(
         data=result,
@@ -178,6 +206,15 @@ async def list_webhooks(
         token=token,
         params=params,
     )
+
+    err = unwrap_http_result(
+        result,
+        default_message='Failed to list webhooks',
+        region=region,
+        workspace=workspace,
+    )
+    if err:
+        return err
 
     return success_response(data=result, region=region, workspace=workspace)
 
@@ -273,6 +310,15 @@ async def create_webhook(
         data=webhook_data,
     )
 
+    err = unwrap_http_result(
+        result,
+        default_message='Failed to create webhook',
+        region=region,
+        workspace=workspace,
+    )
+    if err:
+        return err
+
     return success_response(data=result, region=region, workspace=workspace)
 
 
@@ -328,6 +374,16 @@ async def update_webhook(
         data=update_data,
     )
 
+    err = unwrap_http_result(
+        result,
+        default_message='Failed to update webhook',
+        webhook_id=webhook_id,
+        region=region,
+        workspace=workspace,
+    )
+    if err:
+        return err
+
     return success_response(
         data=result, webhook_id=webhook_id, region=region, workspace=workspace
     )
@@ -359,6 +415,16 @@ async def delete_webhook(
         endpoint=f'/api/notifications/webhooks/{webhook_id}/',
         token=token,
     )
+
+    err = unwrap_http_result(
+        result,
+        default_message='Failed to delete webhook',
+        webhook_id=webhook_id,
+        region=region,
+        workspace=workspace,
+    )
+    if err:
+        return err
 
     return success_response(
         data=result, webhook_id=webhook_id, region=region, workspace=workspace


### PR DESCRIPTION
## Background

`utils/http_client` does not raise on upstream 4xx/5xx. Instead it returns an error envelope dict shaped like `{'error':..., 'status_code':..., 'message':...}`. Several tools passed that return value straight into `success_response(data=result, ...)` without inspecting it, so a failed upstream call surfaced to the MCP client as `status="success"`. This also masked WorkSession gate denials (403), hiding cases that actually need out-of-band human approval behind a fake success.

Most tools in the repo already route their result through `unwrap_http_result()` (which converts an error envelope into an `error_response`, or a WorkSession gate response, and otherwise returns `None`). Only a few tools were missing that guard; this PR closes those gaps.

## Changes

Add the missing `unwrap_http_result()` check to the server, webhook, and system-info tools so HTTP failures are no longer wrapped as success.

- `tools/server_tools.py`: guard `list_server_notes`, `create_server_note`, and the seven agent/system actions (`restart_agent`, `shutdown_agent`, `upgrade_agent`, `update_information`, `upgrade_system`, `reboot_system`, `shutdown_system`). The seven actions shared an identical `POST /actions/` call plus unwrap, so they were factored into a `_server_action()` private helper.
- `tools/webhook_tools.py`: guard the eight event-subscription and webhook tools (`list/create/delete_event_subscription`, `list/create/update/delete_webhook`).
- `tools/system_info_tools.py`: `get_disk_info` fetches `/proc/disks` and `/proc/partitions` concurrently via `asyncio.gather` and previously only checked for raised exceptions. Each result now hard-fails when it is an exception (`error_response`) or an error envelope (`unwrap_http_result`). Disks and partitions come from the same server and token, so a half-populated payload is not a useful partial success.

## Safety

This change improves authz visibility. Previously a WorkSession gate denial (403 with `work_session_required` and similar codes) also returned `status="success"`, making a denial look like a success. Those gate codes now route through `work_session_gate_response`, matching the gating semantics already used by the other tools. `unwrap_http_result` only forwards `message`, `status_code`, and the fixed strings for recognized gate codes, never the raw upstream response body, so surfacing the failure does not leak sensitive upstream data. Tokens are sent via the `Authorization` header and never appear in error messages.

## Tests

- Add regression tests asserting the error envelope is not wrapped as success for each tool (`test_agent_actions.py`, `test_server_tools.py`, `test_webhook_tools.py`, `test_system_info_tools.py`).
- For `get_disk_info`, assert that both the raised-exception path and the error-envelope path return `status="error"`, and that the envelope path preserves `status_code`. Two existing tests that pinned the old partial-success behavior (`test_system_info_tools.py`, `test_system_tools.py`) were updated to the new behavior.
- Centralize the repeated error envelope and token-manager mock into shared `tests/conftest.py` helpers (`HTTP_ERROR_ENVELOPE`, `mock_token_manager`).
- Full suite: 882 passed.

## Checklist

- [x] Every http_client call site checks for an error envelope before `success_response` (audited across all tools modules; this branch handles the last gap, `get_disk_info`)
- [x] Passed a six-stage review loop (correctness, performance, security, clean code, over-engineering, AlpacaX conventions)
- [x] Regression tests added; full suite green

Closes #127
