### PR TITLE
chore(release): bump version to 0.6.2

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "alpacon-mcp"
-version = "0.6.1"
+version = "0.6.2"
 description = "AI-Powered Server Management - Connect Claude, Cursor, and other AI tools directly to your Alpacon infrastructure"
 readme = "README.md"
 license = { text = "MIT" }

--- a/uv.lock
+++ b/uv.lock
@@ -4,7 +4,7 @@ requires-python = ">=3.12"
 
 [[package]]
 name = "alpacon-mcp"
-version = "0.6.1"
+version = "0.6.2"
 source = { editable = "." }
 dependencies = [
     { name = "httpx" },


### PR DESCRIPTION
## Background
The `Publish to PyPI` workflow (0.6.2 release) failed with a 400 error. The version in `pyproject.toml` was still `0.6.1`, so the build produced `alpacon_mcp-0.6.1` artifacts, and twine tried to upload them to the already-existing 0.6.1 release—blocked by PyPI's "cannot add new files to releases older than 14 days" policy.

## Changes
Bumped the version in `pyproject.toml` to `0.6.2` and synced `uv.lock`. The build now produces `alpacon_mcp-0.6.2` artifacts that upload cleanly as a new release.

This is a temporary fix for the immediate failure, not a root-cause solution. The structural issue—manually keeping the release tag and source version in sync every time—will be addressed in a separate PR.

## Testing
Verified lockfile update via `uv lock`.