### PR TITLE
build: derive package version from git tags via hatch-vcs

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -23,6 +23,11 @@ jobs:
       - uses: actions/checkout@v6
         with:
           ref: ${{ github.event.workflow_run.head_sha || github.ref }}
+          fetch-depth: 0  # hatch-vcs derives the version from git tags
+
+      - name: Resolve package version
+        id: version
+        run: echo "value=$(pipx run hatch version)" >> "$GITHUB_OUTPUT"
 
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v4
@@ -49,9 +54,9 @@ jobs:
           context: .
           push: true
           platforms: linux/amd64
-          # Dev builds (workflow_run) have no release tag, so fall back to a placeholder version
+          # Build context excludes .git, so the version is resolved on the runner and passed in
           build-args: |
-            VERSION=${{ github.event_name == 'push' && github.ref_name || '0.0.0' }}
+            VERSION=${{ steps.version.outputs.value }}
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}
           cache-from: type=gha

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -25,9 +25,17 @@ jobs:
           ref: ${{ github.event.workflow_run.head_sha || github.ref }}
           fetch-depth: 0  # hatch-vcs derives the version from git tags
 
+      - name: Set up Python
+        uses: actions/setup-python@v6
+        with:
+          python-version: "3.12"
+
       - name: Resolve package version
         id: version
-        run: echo "value=$(pipx run hatch version)" >> "$GITHUB_OUTPUT"
+        # Install hatch-vcs explicitly so the vcs version source resolves without relying on runtime bootstrap
+        run: |
+          pip install hatchling hatch-vcs
+          echo "value=$(hatchling version)" >> "$GITHUB_OUTPUT"
 
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v4

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -49,6 +49,7 @@ jobs:
           context: .
           push: true
           platforms: linux/amd64
+          # Dev builds (workflow_run) have no release tag, so fall back to a placeholder version
           build-args: |
             VERSION=${{ github.event_name == 'push' && github.ref_name || '0.0.0' }}
           tags: ${{ steps.meta.outputs.tags }}

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -49,6 +49,8 @@ jobs:
           context: .
           push: true
           platforms: linux/amd64
+          build-args: |
+            VERSION=${{ github.event_name == 'push' && github.ref_name || '0.0.0' }}
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}
           cache-from: type=gha

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -35,7 +35,14 @@ jobs:
         # Install hatch-vcs explicitly so the vcs version source resolves without relying on runtime bootstrap
         run: |
           pip install hatchling hatch-vcs
-          echo "value=$(hatchling version)" >> "$GITHUB_OUTPUT"
+          # Assign first so a hatchling failure trips `set -e` here with its own
+          # error, instead of leaking an empty version into a cryptic Docker build failure
+          version="$(hatchling version)"
+          if [ -z "$version" ] || [ "$version" = "0.0.0" ]; then
+            echo "::error::Failed to resolve package version from git tags" >&2
+            exit 1
+          fi
+          echo "value=$version" >> "$GITHUB_OUTPUT"
 
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v4

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -13,6 +13,8 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v6
+      with:
+        fetch-depth: 0  # hatch-vcs derives the version from git tags
 
     - name: Set up Python
       uses: actions/setup-python@v6

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -23,6 +23,8 @@ jobs:
 
     steps:
     - uses: actions/checkout@v6
+      with:
+        fetch-depth: 0  # hatch-vcs derives the version from git tags
 
     - name: Set up Python ${{ matrix.python-version }}
       uses: actions/setup-python@v6

--- a/Dockerfile
+++ b/Dockerfile
@@ -8,7 +8,9 @@ WORKDIR /app
 
 # Copy full source and install (hatchling needs source for metadata)
 COPY . .
-RUN pip install --no-cache-dir . && \
+# Build context excludes .git, so hatch-vcs cannot derive the version; CI passes the release tag
+ARG VERSION=0.0.0
+RUN SETUPTOOLS_SCM_PRETEND_VERSION="${VERSION#v}" pip install --no-cache-dir . && \
     rm -rf /root/.cache
 
 # Default port (MCAR - MCP Alpacon Remote)

--- a/Dockerfile
+++ b/Dockerfile
@@ -8,7 +8,7 @@ WORKDIR /app
 
 # Copy full source and install (hatchling needs source for metadata)
 COPY . .
-# Build context excludes .git; CI passes the tag as VERSION (hatch-vcs reads it via setuptools-scm's PRETEND_VERSION)
+# Build context excludes .git; CI resolves the version and passes it as VERSION (fed to setuptools-scm's PRETEND_VERSION)
 ARG VERSION=0.0.0
 RUN SETUPTOOLS_SCM_PRETEND_VERSION="${VERSION#v}" pip install --no-cache-dir . && \
     rm -rf /root/.cache

--- a/Dockerfile
+++ b/Dockerfile
@@ -8,7 +8,7 @@ WORKDIR /app
 
 # Copy full source and install (hatchling needs source for metadata)
 COPY . .
-# Build context excludes .git, so hatch-vcs cannot derive the version; CI passes the release tag
+# Build context excludes .git; CI passes the tag as VERSION (hatch-vcs reads it via setuptools-scm's PRETEND_VERSION)
 ARG VERSION=0.0.0
 RUN SETUPTOOLS_SCM_PRETEND_VERSION="${VERSION#v}" pip install --no-cache-dir . && \
     rm -rf /root/.cache

--- a/Dockerfile
+++ b/Dockerfile
@@ -8,10 +8,12 @@ WORKDIR /app
 
 # Copy full source and install (hatchling needs source for metadata)
 COPY . .
-# Build context excludes .git; CI resolves the version and passes it as VERSION (fed to setuptools-scm's PRETEND_VERSION)
+# CI resolves the version and passes it as VERSION (.git is excluded from the build context)
 ARG VERSION=0.0.0
-RUN SETUPTOOLS_SCM_PRETEND_VERSION="${VERSION#v}" pip install --no-cache-dir . && \
-    rm -rf /root/.cache
+# Scope the global pretend-version to our own wheel build so it can't leak into a dependency's sdist build
+RUN SETUPTOOLS_SCM_PRETEND_VERSION="${VERSION#v}" pip wheel --no-cache-dir --no-deps --wheel-dir /tmp/wheels . && \
+    pip install --no-cache-dir /tmp/wheels/*.whl && \
+    rm -rf /tmp/wheels /root/.cache
 
 # Default port (MCAR - MCP Alpacon Remote)
 EXPOSE 8237

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,10 +1,10 @@
 [build-system]
-requires = ["hatchling"]
+requires = ["hatchling", "hatch-vcs"]
 build-backend = "hatchling.build"
 
 [project]
 name = "alpacon-mcp"
-version = "0.6.2"
+dynamic = ["version"]
 description = "AI-Powered Server Management - Connect Claude, Cursor, and other AI tools directly to your Alpacon infrastructure"
 readme = "README.md"
 license = { text = "MIT" }
@@ -66,6 +66,9 @@ dev = [
     "flake8>=6.0.0",
     "mypy>=1.0.0",
 ]
+
+[tool.hatch.version]
+source = "vcs"
 
 [tool.hatch.build.targets.wheel]
 include = [

--- a/uv.lock
+++ b/uv.lock
@@ -4,7 +4,6 @@ requires-python = ">=3.12"
 
 [[package]]
 name = "alpacon-mcp"
-version = "0.6.2"
 source = { editable = "." }
 dependencies = [
     { name = "httpx" },


### PR DESCRIPTION
## Background
The publish workflow failed because the version in pyproject.toml had to be bumped by hand for every release. A missed bump built 0.6.1 artifacts against the existing 0.6.1 release, and PyPI blocks adding files to a release older than 14 days. PR #129 bumped the version as a temporary fix; this PR removes the manual step entirely.

## Changes
Switch to hatch-vcs so the version comes from the git tag instead of a static field.

- pyproject.toml: replace the static version with dynamic = ["version"] and add the hatch-vcs backend.
- publish.yml and test.yml: set fetch-depth: 0 on checkout so the tag is visible when the version is derived.
- Dockerfile and docker.yml: the build context excludes .git, so CI resolves the version on the runner and passes it as a VERSION build arg, which hatch-vcs reads through setuptools-scm's SETUPTOOLS_SCM_PRETEND_VERSION. On release the version is the tag; on main merges it is a dev version such as 0.6.2.dev54+g<hash>. The Dockerfile keeps a 0.0.0 default only for a local docker build, which never runs the CI resolution step.

## Version resolution failures
The docker.yml resolution step previously used echo "value=$(hatchling version)". Command substitution inside echo does not trip set -e, so a hatchling failure silently emitted an empty version, which only surfaced later as a cryptic setuptools-scm LookupError during the Docker build. The step now assigns the output to a variable first so a hatchling failure fails the step at its source, and it rejects empty or 0.0.0 versions with an explicit error annotation. The 0.0.0 guard lives in the CI step rather than the Dockerfile because the Dockerfile cannot tell a local build from a CI build, and the 0.0.0 fallback for local builds is intentional.

## Testing
Built sdist and wheel locally and confirmed the version is derived from the tag. Verified the Docker path with SETUPTOOLS_SCM_PRETEND_VERSION on a tree without .git. Reproduced the empty-version LookupError to confirm the previous failure mode, and verified the new guard exits with a clear error for the failing, empty, and 0.0.0 cases. Health tests pass and ruff is clean.

## Checklist
- [x] Version derives from the git tag on release builds
- [x] Docker and test workflows produce a valid version
- [x] CI fails fast with a clear error when the version cannot be resolved
- [x] Runtime version lookup via importlib.metadata still works