### PR TITLE
refactor: quarantine Any into a typed boundary and make mypy strict a CI gate

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -51,8 +51,7 @@ jobs:
     - name: Type check with mypy
       run: |
         uv pip install mypy
-        uv run --no-sync mypy --ignore-missing-imports --no-strict-optional .
-      continue-on-error: true
+        uv run --no-sync mypy
 
     - name: Test with pytest
       run: |

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -128,6 +128,7 @@ This MCP server provides a **pure HTTP API bridge** to Alpacon's infrastructure 
 - `cert_tools.py`: Certificate authority, signing requests, and certificate management
 
 **Utilities** (all in `utils/` directory):
+- `api_types.py`: Shared TypedDicts and type aliases for tool responses and API-boundary payloads (the sole sanctioned use of `Any`)
 - `http_client.py`: Async HTTP client for Alpacon API
 - `token_manager.py`: Secure token storage and management
 - `decorators.py`: MCP tool decorators (token validation, input validation, error handling, logging)
@@ -182,6 +183,9 @@ A 60-second cooldown prevents infinite re-auth loops when 401s are not fixable b
 All tools use the unified `@mcp_tool_handler` decorator pattern for consistent error handling and token management:
 
 ```python
+from typing import Unpack
+
+from utils.api_types import ToolKwargs, ToolResponse
 from utils.http_client import http_client
 from utils.common import success_response, error_response
 from utils.decorators import mcp_tool_handler
@@ -191,8 +195,8 @@ async def tool_function(
     server_id: str,
     workspace: str,  # Required parameter (no default)
     region: str = "ap1",
-    **kwargs  # Receives token from decorator
-) -> Dict[str, Any]:
+    **kwargs: Unpack[ToolKwargs],  # Receives token from decorator
+) -> ToolResponse:
     """Tool implementation using HTTP API."""
     token = kwargs.get('token')
 
@@ -591,7 +595,7 @@ permissions:
 ### Adding new tools
 1. Create function in appropriate `tools/*.py` file
 2. Use `@mcp_tool_handler(description="...")` decorator
-3. Add `**kwargs` parameter to receive token from decorator
+3. Add `**kwargs: Unpack[ToolKwargs]` parameter to receive token from decorator, and declare the return type as `ToolResponse` (both from `utils.api_types`)
 4. Use `success_response()` and `error_response()` helpers
 5. Follow async/await pattern for HTTP calls
 6. For file path parameters, add inline `validate_file_path()` checks

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -192,7 +192,9 @@ async def test_list_servers_success():
 1. **Create Tool File**
    ```python
    # tools/your_feature_tools.py
-   from typing import Dict, Any, Optional
+   from typing import Unpack
+
+   from utils.api_types import ToolKwargs, ToolResponse
    from utils.http_client import http_client
    from utils.common import success_response, error_response
    from utils.decorators import mcp_tool_handler
@@ -202,8 +204,8 @@ async def test_list_servers_success():
        parameter: str,
        workspace: str,
        region: str = "ap1",
-       **kwargs  # Receives token from decorator
-   ) -> Dict[str, Any]:
+       **kwargs: Unpack[ToolKwargs],  # Receives token from decorator
+   ) -> ToolResponse:
        """Your tool documentation.
 
        Args:

--- a/main.py
+++ b/main.py
@@ -15,7 +15,7 @@ def check_token_exists() -> bool:
     return global_path.exists() or local_path.exists()
 
 
-def main():
+def main() -> None:
     """Main entry point for the CLI."""
     parser = argparse.ArgumentParser(
         description='Alpacon MCP Server - AI-powered server management',

--- a/main_http.py
+++ b/main_http.py
@@ -21,7 +21,7 @@ from utils.logger import get_logger
 logger = get_logger('main_http')
 
 
-def main():
+def main() -> None:
     """Main entry point for HTTP transport mode."""
     # Validate required Auth0 configuration (fail fast on missing env vars)
     missing = []

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -143,6 +143,8 @@ line-ending = "auto"
 
 [tool.mypy]
 python_version = "3.12"
+files = ["utils", "tools", "server.py", "main.py", "main_sse.py", "main_http.py"]
+strict = true
 ignore_missing_imports = true
 namespace_packages = true
 explicit_package_bases = true

--- a/server.py
+++ b/server.py
@@ -3,11 +3,15 @@ import signal
 import sys
 from collections.abc import AsyncIterator
 from contextlib import asynccontextmanager
+from types import FrameType
 from typing import Literal
 
 from mcp.server.fastmcp import FastMCP
+from starlette.requests import Request
+from starlette.responses import Response
 
 from utils.logger import get_logger
+from utils.oauth import typed_custom_route
 
 logger = get_logger('server')
 
@@ -52,7 +56,7 @@ async def app_lifespan(app: FastMCP) -> AsyncIterator[None]:
         logger.info('Graceful shutdown complete')
 
 
-def _sigterm_handler(signum, frame):
+def _sigterm_handler(signum: int, frame: FrameType | None) -> None:
     """Handle SIGTERM by raising KeyboardInterrupt for anyio's shutdown path."""
     raise KeyboardInterrupt
 
@@ -162,7 +166,7 @@ def _is_remote_mode() -> bool:
     return os.getenv('ALPACON_MCP_AUTH_ENABLED', '').lower() == 'true'
 
 
-def _install_upstream_auth_middleware():
+def _install_upstream_auth_middleware() -> None:
     """Override run_streamable_http_async to wrap app with auth error middleware.
 
     When the Alpacon API returns 401 (e.g., MFA timeout), the middleware
@@ -176,7 +180,7 @@ def _install_upstream_auth_middleware():
         f'{resource_url.rstrip("/")}/.well-known/oauth-protected-resource'
     )
 
-    async def patched_run():
+    async def patched_run() -> None:
         import uvicorn
 
         starlette_app = mcp.streamable_http_app()
@@ -195,19 +199,19 @@ def _install_upstream_auth_middleware():
         server = uvicorn.Server(config)
         await server.serve()
 
-    mcp.run_streamable_http_async = patched_run
+    mcp.run_streamable_http_async = patched_run  # type: ignore[method-assign]
     logger.info('Upstream auth error middleware installed for remote mode')
 
 
-def _register_http_health_endpoint():
+def _register_http_health_endpoint() -> None:
     """Register HTTP /health endpoint for HTTP transports (SSE, streamable-http).
 
     Bypasses auth for unauthenticated health probes
     (e.g., Kubernetes liveness/readiness checks, docker-compose).
     """
 
-    @mcp.custom_route('/health', methods=['GET'])
-    async def health_endpoint(request):
+    @typed_custom_route(mcp, '/health', methods=['GET'])
+    async def health_endpoint(request: Request) -> Response:
         from starlette.responses import JSONResponse
 
         from utils.health import get_health_info
@@ -226,7 +230,7 @@ def _register_http_health_endpoint():
 def run(
     transport: Literal['stdio', 'sse', 'streamable-http'] = 'stdio',
     config_file: str | None = None,
-):
+) -> None:
     """Run MCP server with optional config file path.
 
     Args:

--- a/tests/test_api_types.py
+++ b/tests/test_api_types.py
@@ -1,0 +1,22 @@
+"""Sanity tests for the shared response-envelope types."""
+
+from utils.api_types import is_api_error
+from utils.common import error_response, success_response
+
+
+def test_is_api_error_narrows_error_envelope():
+    assert is_api_error({'error': 'HTTP Error', 'message': 'boom'})
+    assert not is_api_error({'status': 'success'})
+    assert not is_api_error(['a', 'b'])
+
+
+def test_response_envelopes_unchanged_at_runtime():
+    ok = success_response(data={'x': 1}, region='ap1', workspace='w')
+    assert ok == {
+        'status': 'success',
+        'data': {'x': 1},
+        'region': 'ap1',
+        'workspace': 'w',
+    }
+    err = error_response('nope', workspace='w')
+    assert err == {'status': 'error', 'message': 'nope', 'workspace': 'w'}

--- a/tests/test_tool_schemas.py
+++ b/tests/test_tool_schemas.py
@@ -1,7 +1,7 @@
 """Regression tests for FastMCP-generated tool input schemas.
 
 The token-injection **kwargs on tool functions must never surface in the
-MCP inputSchema — FastMCP's func_metadata() does not special-case
+MCP inputSchema—FastMCP's func_metadata() does not special-case
 VAR_KEYWORD parameters, so the decorator has to strip them from the
 exposed signature.
 """
@@ -31,6 +31,6 @@ async def test_call_tool_without_kwargs_argument():
     # Before the fix this raises ToolError: "kwargs Field required".
     with patch('utils.decorators.validate_token', return_value=None):
         result = await mcp.call_tool('list_servers', {'workspace': 'testws'})
-    # Reaching here proves pydantic validation passed without a kwargs arg;
-    # the call itself short-circuits at token lookup (no network).
+    # Reaching here proves validation passed without kwargs; the call itself
+    # short-circuits at token lookup (no network).
     assert result is not None

--- a/tests/test_tool_schemas.py
+++ b/tests/test_tool_schemas.py
@@ -1,0 +1,36 @@
+"""Regression tests for FastMCP-generated tool input schemas.
+
+The token-injection **kwargs on tool functions must never surface in the
+MCP inputSchema — FastMCP's func_metadata() does not special-case
+VAR_KEYWORD parameters, so the decorator has to strip them from the
+exposed signature.
+"""
+
+from unittest.mock import patch
+
+import pytest
+
+import tools.command_tools  # noqa: F401 - trigger tool registration
+import tools.server_tools  # noqa: F401 - trigger tool registration
+from server import mcp
+
+
+@pytest.mark.asyncio
+async def test_tool_schemas_do_not_expose_kwargs():
+    tools_ = await mcp.list_tools()
+    assert tools_, 'no tools registered'
+    for tool in tools_:
+        props = tool.inputSchema.get('properties', {})
+        required = tool.inputSchema.get('required', [])
+        assert 'kwargs' not in props, f'{tool.name} exposes kwargs in schema'
+        assert 'kwargs' not in required, f'{tool.name} requires kwargs'
+
+
+@pytest.mark.asyncio
+async def test_call_tool_without_kwargs_argument():
+    # Before the fix this raises ToolError: "kwargs Field required".
+    with patch('utils.decorators.validate_token', return_value=None):
+        result = await mcp.call_tool('list_servers', {'workspace': 'testws'})
+    # Reaching here proves pydantic validation passed without a kwargs arg;
+    # the call itself short-circuits at token lookup (no network).
+    assert result is not None

--- a/tools/alert_tools.py
+++ b/tools/alert_tools.py
@@ -1,7 +1,8 @@
 """Alert management tools for Alpacon MCP server."""
 
-from typing import Any
+from typing import Unpack
 
+from utils.api_types import ToolKwargs, ToolResponse
 from utils.common import error_response, success_response, unwrap_http_result
 from utils.decorators import mcp_tool_handler
 from utils.http_client import http_client
@@ -29,8 +30,8 @@ async def list_alerts(
     page_size: int | None = None,
     acknowledged: bool | None = None,
     dismissed: bool | None = None,
-    **kwargs,
-) -> dict[str, Any]:
+    **kwargs: Unpack[ToolKwargs],
+) -> ToolResponse:
     """List alerts.
 
     Args:
@@ -48,7 +49,7 @@ async def list_alerts(
     """
     token = kwargs.get('token')
 
-    params: dict[str, Any] = {}
+    params: dict[str, object] = {}
     if server_id:
         params['server'] = server_id
     if status:
@@ -91,8 +92,8 @@ async def list_alerts(
     meta={'anthropic/searchHint': 'alert detail info specific'},
 )
 async def get_alert(
-    alert_id: str, workspace: str, region: str = '', **kwargs
-) -> dict[str, Any]:
+    alert_id: str, workspace: str, region: str = '', **kwargs: Unpack[ToolKwargs]
+) -> ToolResponse:
     """Get alert details by ID.
 
     Args:
@@ -137,8 +138,8 @@ async def mute_alert(
     workspace: str,
     duration: int | None = None,
     region: str = '',
-    **kwargs,
-) -> dict[str, Any]:
+    **kwargs: Unpack[ToolKwargs],
+) -> ToolResponse:
     """Mute an alert.
 
     Args:
@@ -152,7 +153,7 @@ async def mute_alert(
     """
     token = kwargs.get('token')
 
-    mute_data: dict[str, Any] = {}
+    mute_data: dict[str, object] = {}
     if duration is not None:
         mute_data['duration'] = duration
 
@@ -202,8 +203,8 @@ async def create_alert_rule(
     description: str | None = None,
     enabled: bool = True,
     region: str = '',
-    **kwargs,
-) -> dict[str, Any]:
+    **kwargs: Unpack[ToolKwargs],
+) -> ToolResponse:
     """Create an alert rule.
 
     Args:
@@ -223,7 +224,7 @@ async def create_alert_rule(
     """
     token = kwargs.get('token')
 
-    rule_data: dict[str, Any] = {
+    rule_data: dict[str, object] = {
         'name': name,
         'metric_type': metric_type,
         'condition': condition,
@@ -275,8 +276,8 @@ async def update_alert_rule(
     description: str | None = None,
     enabled: bool | None = None,
     region: str = '',
-    **kwargs,
-) -> dict[str, Any]:
+    **kwargs: Unpack[ToolKwargs],
+) -> ToolResponse:
     """Update an existing alert rule.
 
     Args:
@@ -297,7 +298,7 @@ async def update_alert_rule(
     """
     token = kwargs.get('token')
 
-    update_data: dict[str, Any] = {}
+    update_data: dict[str, object] = {}
     if name is not None:
         update_data['name'] = name
     if metric_type is not None:
@@ -347,8 +348,8 @@ async def update_alert_rule(
     meta={'anthropic/searchHint': 'alert rule delete remove'},
 )
 async def delete_alert_rule(
-    rule_id: str, workspace: str, region: str = '', **kwargs
-) -> dict[str, Any]:
+    rule_id: str, workspace: str, region: str = '', **kwargs: Unpack[ToolKwargs]
+) -> ToolResponse:
     """Delete an alert rule.
 
     Args:

--- a/tools/approval_tools.py
+++ b/tools/approval_tools.py
@@ -9,8 +9,9 @@ human, but provide no approve/reject mutation. The agent must escalate to a huma
 who approves out-of-band (Alpacon web console or Slack).
 """
 
-from typing import Any
+from typing import Unpack
 
+from utils.api_types import ResponseContext, ToolKwargs, ToolResponse
 from utils.common import (
     pending_approval_response,
     success_response,
@@ -36,8 +37,8 @@ async def list_approval_requests(
     region: str = '',
     page: int | None = None,
     page_size: int | None = None,
-    **kwargs,
-) -> dict[str, Any]:
+    **kwargs: Unpack[ToolKwargs],
+) -> ToolResponse:
     """List approval requests.
 
     Args:
@@ -52,7 +53,7 @@ async def list_approval_requests(
     """
     token = kwargs.get('token')
 
-    params: dict[str, Any] = {}
+    params: dict[str, object] = {}
     if status:
         params['status'] = status
     if page is not None:
@@ -86,8 +87,8 @@ async def list_approval_requests(
     meta={'anthropic/searchHint': 'approval request detail'},
 )
 async def get_approval_request(
-    request_id: str, workspace: str, region: str = '', **kwargs
-) -> dict[str, Any]:
+    request_id: str, workspace: str, region: str = '', **kwargs: Unpack[ToolKwargs]
+) -> ToolResponse:
     """Get approval request details by ID.
 
     Args:
@@ -145,8 +146,8 @@ async def explain_approval_decision(
     workspace: str,
     request_id: str | None = None,
     region: str = '',
-    **kwargs,
-) -> dict[str, Any]:
+    **kwargs: Unpack[ToolKwargs],
+) -> ToolResponse:
     """Explain that approving/rejecting a request is a human-only, out-of-band action.
 
     This tool performs no mutation and contacts no server endpoint—an agent must
@@ -161,7 +162,7 @@ async def explain_approval_decision(
     Returns:
         Structured pending-approval guidance (no approve/reject is performed)
     """
-    context: dict[str, Any] = {'region': region, 'workspace': workspace}
+    context: ResponseContext = {'region': region, 'workspace': workspace}
     if request_id is not None:
         context['request_id'] = request_id
 
@@ -190,8 +191,8 @@ async def list_sudo_policies(
     region: str = '',
     page: int | None = None,
     page_size: int | None = None,
-    **kwargs,
-) -> dict[str, Any]:
+    **kwargs: Unpack[ToolKwargs],
+) -> ToolResponse:
     """List sudo policies.
 
     Args:
@@ -205,7 +206,7 @@ async def list_sudo_policies(
     """
     token = kwargs.get('token')
 
-    params: dict[str, Any] = {}
+    params: dict[str, object] = {}
     if page is not None:
         params['page'] = page
     if page_size is not None:
@@ -247,8 +248,8 @@ async def create_sudo_policy(
     no_password: bool = False,
     description: str | None = None,
     region: str = '',
-    **kwargs,
-) -> dict[str, Any]:
+    **kwargs: Unpack[ToolKwargs],
+) -> ToolResponse:
     """Create a sudo policy.
 
     Args:
@@ -268,7 +269,7 @@ async def create_sudo_policy(
     """
     token = kwargs.get('token')
 
-    policy_data: dict[str, Any] = {
+    policy_data: dict[str, object] = {
         'name': name,
         'commands': commands,
         'no_password': no_password,

--- a/tools/audit_tools.py
+++ b/tools/audit_tools.py
@@ -1,7 +1,8 @@
 """Audit and logging tools for Alpacon MCP server."""
 
-from typing import Any
+from typing import Unpack
 
+from utils.api_types import ToolKwargs, ToolResponse
 from utils.common import success_response, unwrap_http_result
 from utils.decorators import mcp_tool_handler
 from utils.http_client import http_client
@@ -22,8 +23,8 @@ async def list_activity_logs(
     region: str = '',
     page: int | None = None,
     page_size: int | None = None,
-    **kwargs,
-) -> dict[str, Any]:
+    **kwargs: Unpack[ToolKwargs],
+) -> ToolResponse:
     """List activity logs.
 
     Args:
@@ -37,7 +38,7 @@ async def list_activity_logs(
     """
     token = kwargs.get('token')
 
-    params = {}
+    params: dict[str, object] = {}
     if page is not None:
         params['page'] = page
     if page_size is not None:
@@ -69,8 +70,8 @@ async def list_activity_logs(
     meta={'anthropic/searchHint': 'audit activity log detail'},
 )
 async def get_activity_log(
-    log_id: str, workspace: str, region: str = '', **kwargs
-) -> dict[str, Any]:
+    log_id: str, workspace: str, region: str = '', **kwargs: Unpack[ToolKwargs]
+) -> ToolResponse:
     """Get activity log details by ID.
 
     Args:
@@ -121,8 +122,8 @@ async def list_server_logs(
     region: str = '',
     page: int | None = None,
     page_size: int | None = None,
-    **kwargs,
-) -> dict[str, Any]:
+    **kwargs: Unpack[ToolKwargs],
+) -> ToolResponse:
     """List server command execution logs.
 
     Args:
@@ -137,7 +138,7 @@ async def list_server_logs(
     """
     token = kwargs.get('token')
 
-    params: dict[str, Any] = {}
+    params: dict[str, object] = {}
     if server_id:
         params['server'] = server_id
     if page is not None:
@@ -179,8 +180,8 @@ async def list_webftp_logs(
     region: str = '',
     page: int | None = None,
     page_size: int | None = None,
-    **kwargs,
-) -> dict[str, Any]:
+    **kwargs: Unpack[ToolKwargs],
+) -> ToolResponse:
     """List WebFTP file transfer logs.
 
     Args:
@@ -195,7 +196,7 @@ async def list_webftp_logs(
     """
     token = kwargs.get('token')
 
-    params: dict[str, Any] = {}
+    params: dict[str, object] = {}
     if server_id:
         params['server'] = server_id
     if page is not None:
@@ -244,8 +245,8 @@ async def list_session_analyses(
     region: str = '',
     page: int | None = None,
     page_size: int | None = None,
-    **kwargs,
-) -> dict[str, Any]:
+    **kwargs: Unpack[ToolKwargs],
+) -> ToolResponse:
     """List session security analyses.
 
     Args:
@@ -262,7 +263,7 @@ async def list_session_analyses(
     """
     token = kwargs.get('token')
 
-    params: dict[str, Any] = {}
+    params: dict[str, object] = {}
     if server_id:
         params['server'] = server_id
     if status:
@@ -306,8 +307,8 @@ async def get_session_analysis_detail(
     analysis_id: str,
     workspace: str,
     region: str = '',
-    **kwargs,
-) -> dict[str, Any]:
+    **kwargs: Unpack[ToolKwargs],
+) -> ToolResponse:
     """Get detailed session analysis by ID.
 
     Args:

--- a/tools/cert_tools.py
+++ b/tools/cert_tools.py
@@ -1,7 +1,8 @@
 """Certificate and PKI management tools for Alpacon MCP server."""
 
-from typing import Any
+from typing import Unpack
 
+from utils.api_types import ToolKwargs, ToolResponse
 from utils.common import error_response, success_response, unwrap_http_result
 from utils.decorators import mcp_tool_handler
 from utils.http_client import http_client
@@ -22,8 +23,8 @@ async def list_certificate_authorities(
     region: str = '',
     page: int | None = None,
     page_size: int | None = None,
-    **kwargs,
-) -> dict[str, Any]:
+    **kwargs: Unpack[ToolKwargs],
+) -> ToolResponse:
     """List certificate authorities.
 
     Args:
@@ -37,7 +38,7 @@ async def list_certificate_authorities(
     """
     token = kwargs.get('token')
 
-    params: dict[str, Any] = {}
+    params: dict[str, object] = {}
     if page is not None:
         params['page'] = page
     if page_size is not None:
@@ -82,8 +83,8 @@ async def create_certificate_authority(
     key_size: int | None = None,
     install: bool | None = None,
     region: str = '',
-    **kwargs,
-) -> dict[str, Any]:
+    **kwargs: Unpack[ToolKwargs],
+) -> ToolResponse:
     """Create a certificate authority.
 
     Args:
@@ -106,7 +107,7 @@ async def create_certificate_authority(
     """
     token = kwargs.get('token')
 
-    ca_data: dict[str, Any] = {
+    ca_data: dict[str, object] = {
         'name': name,
         'domain': domain,
         'organization': organization,
@@ -156,8 +157,8 @@ async def get_certificate_authority(
     ca_id: str,
     workspace: str,
     region: str = '',
-    **kwargs,
-) -> dict[str, Any]:
+    **kwargs: Unpack[ToolKwargs],
+) -> ToolResponse:
     """Get certificate authority details.
 
     Args:
@@ -204,8 +205,8 @@ async def update_certificate_authority(
     max_valid_days: int | None = None,
     owner: str | None = None,
     region: str = '',
-    **kwargs,
-) -> dict[str, Any]:
+    **kwargs: Unpack[ToolKwargs],
+) -> ToolResponse:
     """Update a certificate authority (partial update).
 
     Args:
@@ -221,7 +222,7 @@ async def update_certificate_authority(
     """
     token = kwargs.get('token')
 
-    patch_data: dict[str, Any] = {}
+    patch_data: dict[str, object] = {}
     if default_valid_days is not None:
         patch_data['default_valid_days'] = default_valid_days
     if max_valid_days is not None:
@@ -264,8 +265,8 @@ async def delete_certificate_authority(
     ca_id: str,
     workspace: str,
     region: str = '',
-    **kwargs,
-) -> dict[str, Any]:
+    **kwargs: Unpack[ToolKwargs],
+) -> ToolResponse:
     """Delete a certificate authority.
 
     Args:
@@ -315,8 +316,8 @@ async def list_sign_requests(
     region: str = '',
     page: int | None = None,
     page_size: int | None = None,
-    **kwargs,
-) -> dict[str, Any]:
+    **kwargs: Unpack[ToolKwargs],
+) -> ToolResponse:
     """List certificate signing requests.
 
     Args:
@@ -330,7 +331,7 @@ async def list_sign_requests(
     """
     token = kwargs.get('token')
 
-    params: dict[str, Any] = {}
+    params: dict[str, object] = {}
     if page is not None:
         params['page'] = page
     if page_size is not None:
@@ -367,8 +368,8 @@ async def create_sign_request(
     ip_list: list[str] | None = None,
     valid_days: int | None = None,
     region: str = '',
-    **kwargs,
-) -> dict[str, Any]:
+    **kwargs: Unpack[ToolKwargs],
+) -> ToolResponse:
     """Create a certificate signing request.
 
     Args:
@@ -390,7 +391,7 @@ async def create_sign_request(
             'At least one entry in domain_list or ip_list is required'
         )
 
-    csr_data: dict[str, Any] = {
+    csr_data: dict[str, object] = {
         'domain_list': domains,
         'ip_list': ips,
     }
@@ -427,8 +428,8 @@ async def get_sign_request(
     csr_id: str,
     workspace: str,
     region: str = '',
-    **kwargs,
-) -> dict[str, Any]:
+    **kwargs: Unpack[ToolKwargs],
+) -> ToolResponse:
     """Get certificate signing request details.
 
     Args:
@@ -472,8 +473,8 @@ async def delete_sign_request(
     csr_id: str,
     workspace: str,
     region: str = '',
-    **kwargs,
-) -> dict[str, Any]:
+    **kwargs: Unpack[ToolKwargs],
+) -> ToolResponse:
     """Cancel a certificate signing request.
 
     Args:
@@ -517,8 +518,8 @@ async def approve_sign_request(
     csr_id: str,
     workspace: str,
     region: str = '',
-    **kwargs,
-) -> dict[str, Any]:
+    **kwargs: Unpack[ToolKwargs],
+) -> ToolResponse:
     """Approve a certificate signing request.
 
     Args:
@@ -563,8 +564,8 @@ async def deny_sign_request(
     csr_id: str,
     workspace: str,
     region: str = '',
-    **kwargs,
-) -> dict[str, Any]:
+    **kwargs: Unpack[ToolKwargs],
+) -> ToolResponse:
     """Deny a certificate signing request.
 
     Args:
@@ -611,8 +612,8 @@ async def retry_sign_request(
     csr_id: str,
     workspace: str,
     region: str = '',
-    **kwargs,
-) -> dict[str, Any]:
+    **kwargs: Unpack[ToolKwargs],
+) -> ToolResponse:
     """Retry a certificate signing request stuck in the signing state.
 
     Args:
@@ -664,8 +665,8 @@ async def list_certificates(
     region: str = '',
     page: int | None = None,
     page_size: int | None = None,
-    **kwargs,
-) -> dict[str, Any]:
+    **kwargs: Unpack[ToolKwargs],
+) -> ToolResponse:
     """List issued certificates.
 
     Args:
@@ -680,7 +681,7 @@ async def list_certificates(
     """
     token = kwargs.get('token')
 
-    params: dict[str, Any] = {}
+    params: dict[str, object] = {}
     if authority_id is not None:
         params['csr__authority__id'] = authority_id
     if page is not None:
@@ -717,8 +718,8 @@ async def get_certificate(
     certificate_id: str,
     workspace: str,
     region: str = '',
-    **kwargs,
-) -> dict[str, Any]:
+    **kwargs: Unpack[ToolKwargs],
+) -> ToolResponse:
     """Get certificate details.
 
     Args:
@@ -767,8 +768,8 @@ async def revoke_certificate(
     reason: int | None = None,
     requested_reason: str | None = None,
     region: str = '',
-    **kwargs,
-) -> dict[str, Any]:
+    **kwargs: Unpack[ToolKwargs],
+) -> ToolResponse:
     """Create a certificate revocation request.
 
     If the caller is the CA owner or an admin the request is auto-approved and
@@ -787,7 +788,7 @@ async def revoke_certificate(
     """
     token = kwargs.get('token')
 
-    data: dict[str, Any] = {
+    data: dict[str, object] = {
         'certificate': certificate_id,
     }
     if reason is not None:
@@ -836,8 +837,8 @@ async def list_revoke_requests(
     region: str = '',
     page: int | None = None,
     page_size: int | None = None,
-    **kwargs,
-) -> dict[str, Any]:
+    **kwargs: Unpack[ToolKwargs],
+) -> ToolResponse:
     """List certificate revocation requests.
 
     Args:
@@ -851,7 +852,7 @@ async def list_revoke_requests(
     """
     token = kwargs.get('token')
 
-    params: dict[str, Any] = {}
+    params: dict[str, object] = {}
     if page is not None:
         params['page'] = page
     if page_size is not None:
@@ -886,8 +887,8 @@ async def get_revoke_request(
     revoke_id: str,
     workspace: str,
     region: str = '',
-    **kwargs,
-) -> dict[str, Any]:
+    **kwargs: Unpack[ToolKwargs],
+) -> ToolResponse:
     """Get certificate revocation request details.
 
     Args:
@@ -931,8 +932,8 @@ async def approve_revoke_request(
     revoke_id: str,
     workspace: str,
     region: str = '',
-    **kwargs,
-) -> dict[str, Any]:
+    **kwargs: Unpack[ToolKwargs],
+) -> ToolResponse:
     """Approve a certificate revocation request.
 
     Args:
@@ -977,8 +978,8 @@ async def deny_revoke_request(
     revoke_id: str,
     workspace: str,
     region: str = '',
-    **kwargs,
-) -> dict[str, Any]:
+    **kwargs: Unpack[ToolKwargs],
+) -> ToolResponse:
     """Deny a certificate revocation request.
 
     Args:
@@ -1025,8 +1026,8 @@ async def retry_revoke_request(
     revoke_id: str,
     workspace: str,
     region: str = '',
-    **kwargs,
-) -> dict[str, Any]:
+    **kwargs: Unpack[ToolKwargs],
+) -> ToolResponse:
     """Retry a certificate revocation request stuck in the revoking state.
 
     Args:
@@ -1071,8 +1072,8 @@ async def cancel_revoke_request(
     revoke_id: str,
     workspace: str,
     region: str = '',
-    **kwargs,
-) -> dict[str, Any]:
+    **kwargs: Unpack[ToolKwargs],
+) -> ToolResponse:
     """Cancel a pending certificate revocation request.
 
     Args:

--- a/tools/command_tools.py
+++ b/tools/command_tools.py
@@ -1,8 +1,15 @@
 """Command execution tools for Alpacon MCP server."""
 
 import asyncio
-from typing import Any, cast
+from typing import Unpack, cast
 
+from utils.api_types import (
+    ApiPayload,
+    ApiResult,
+    ToolKwargs,
+    ToolResponse,
+    is_api_error,
+)
 from utils.common import (
     error_response,
     pending_approval_response,
@@ -66,7 +73,7 @@ _SUDO_HUMAN_APPROVAL_CODES = frozenset(
 )
 
 
-def _sudo_denial(result: dict[str, Any]) -> tuple[str, str] | None:
+def _sudo_denial(result: dict[str, object]) -> tuple[str, str] | None:
     """Detect a non-interactive sudo denial in the command output.
 
     Returns ``(code, hint)`` for the matched denial category so the caller can
@@ -87,7 +94,7 @@ def _sudo_denial(result: dict[str, Any]) -> tuple[str, str] | None:
     return None
 
 
-def _sudo_denial_hint(result: dict[str, Any]) -> str | None:
+def _sudo_denial_hint(result: dict[str, object]) -> str | None:
     """Return the free-text denial hint for a sudo denial, or None.
 
     Thin wrapper over :func:`_sudo_denial` kept for callers/tests that only need
@@ -112,8 +119,8 @@ async def _submit_command(
     region: str = '',
     *,
     token: str | None = None,
-) -> dict[str, Any] | list[Any]:
-    command_data: dict[str, Any] = {
+) -> ApiResult:
+    command_data: dict[str, object] = {
         'server': server_id,
         'shell': shell,
         'line': command,
@@ -148,7 +155,7 @@ async def _get_command_result(
     region: str = '',
     *,
     token: str | None = None,
-) -> dict[str, Any]:
+) -> ApiResult:
     return await http_client.get(
         region=region,
         workspace=workspace,
@@ -167,12 +174,12 @@ async def list_commands(
     server_id: str | None = None,
     limit: int = 20,
     region: str = '',
-    **kwargs,
-) -> dict[str, Any]:
+    **kwargs: Unpack[ToolKwargs],
+) -> ToolResponse:
     """List recent commands executed on servers."""
     token = kwargs.get('token')
 
-    params = {'page_size': limit, 'ordering': '-added_at'}
+    params: dict[str, object] = {'page_size': limit, 'ordering': '-added_at'}
 
     if server_id:
         params['server'] = server_id
@@ -224,8 +231,8 @@ async def execute_command(
     timeout: int = 300,
     work_session_id: str | None = None,
     region: str = '',
-    **kwargs,
-) -> dict[str, Any]:
+    **kwargs: Unpack[ToolKwargs],
+) -> ToolResponse:
     """Execute a command on a server and wait for the result (requires ACL permission)."""
     token = kwargs.get('token')
 
@@ -245,31 +252,32 @@ async def execute_command(
         token=token,
     )
 
-    if isinstance(exec_data, dict) and 'error' in exec_data:
-        # unwrap_http_result returns non-None whenever 'error' is in the dict
-        return cast(
-            dict[str, Any],
-            unwrap_http_result(
-                exec_data,
-                default_message='Command execution failed',
-                server_id=server_id,
-                region=region,
-                workspace=workspace,
-            ),
+    if is_api_error(exec_data):
+        err = unwrap_http_result(
+            exec_data,
+            default_message='Command execution failed',
+            server_id=server_id,
+            region=region,
+            workspace=workspace,
         )
+        if err is None:
+            # is_api_error(exec_data) guarantees unwrap_http_result returns non-None.
+            raise AssertionError('unwrap_http_result returned None for an API error')
+        return err
 
-    if isinstance(exec_data, list):
-        if exec_data:
-            command_id = exec_data[0].get('id')
+    payload = cast(ApiPayload, exec_data)
+    if isinstance(payload, list):
+        if payload:
+            command_id = payload[0].get('id')
         else:
             return error_response(
                 'No command data returned', workspace=workspace, region=region
             )
-    elif isinstance(exec_data, dict):
-        command_id = exec_data.get('id')
+    elif isinstance(payload, dict):
+        command_id = payload.get('id')
     else:
         return error_response(
-            f'Unexpected response format: {type(exec_data).__name__}',
+            f'Unexpected response format: {type(payload).__name__}',
             workspace=workspace,
             region=region,
         )
@@ -295,7 +303,7 @@ async def execute_command(
             token=token,
         )
 
-        if isinstance(result, dict) and 'error' in result:
+        if is_api_error(result):
             return error_response(
                 f'Failed to poll command result: {result.get("error")}',
                 command_id=command_id,
@@ -306,12 +314,13 @@ async def execute_command(
                 details=result,
             )
 
-        if isinstance(result, dict):
-            status = result.get('status', '')
+        poll_payload = cast(ApiPayload, result)
+        if isinstance(poll_payload, dict):
+            status = poll_payload.get('status', '')
 
-            if result.get('finished_at') is not None:
+            if poll_payload.get('finished_at') is not None:
                 response = success_response(
-                    data=result,
+                    data=poll_payload,
                     command_id=command_id,
                     server_id=server_id,
                     command=command,
@@ -319,7 +328,7 @@ async def execute_command(
                     region=region,
                     workspace=workspace,
                 )
-                denial = _sudo_denial(result)
+                denial = _sudo_denial(poll_payload)
                 if denial:
                     code, hint = denial
                     # Backward-compatible free-text hint.
@@ -343,7 +352,7 @@ async def execute_command(
                     command=command,
                     region=region,
                     workspace=workspace,
-                    details=result,
+                    details=poll_payload,
                 )
 
             # Command still in progress — reset deadline (within hard cap)
@@ -382,15 +391,15 @@ async def execute_command_multi_server(
     region: str = '',
     parallel: bool = True,
     work_session_id: str | None = None,
-    **kwargs,
-) -> dict[str, Any]:
+    **kwargs: Unpack[ToolKwargs],
+) -> ToolResponse:
     """Execute a command on multiple servers using Command API (requires ACL permission)."""
     token = kwargs.get('token')
 
     if not server_ids:
         return error_response('server_ids cannot be empty')
 
-    async def _submit_one(sid: str) -> dict[str, Any] | list[Any]:
+    async def _submit_one(sid: str) -> ApiResult:
         return await _submit_command(
             server_id=sid,
             command=command,
@@ -404,7 +413,7 @@ async def execute_command_multi_server(
             token=token,
         )
 
-    deploy_results: dict[str, Any] = {}
+    deploy_results: dict[str, object] = {}
     successful_count = 0
     failed_count = 0
 
@@ -421,7 +430,7 @@ async def execute_command_multi_server(
                     'message': str(result),
                 }
                 failed_count += 1
-            elif isinstance(result, dict) and 'error' in result:
+            elif is_api_error(result):
                 # unwrap_http_result returns non-None whenever 'error' is in the dict
                 deploy_results[sid] = unwrap_http_result(
                     result,
@@ -438,7 +447,7 @@ async def execute_command_multi_server(
         for sid in server_ids:
             try:
                 result = await _submit_one(sid)
-                if isinstance(result, dict) and 'error' in result:
+                if is_api_error(result):
                     # unwrap_http_result returns non-None whenever 'error' is in the dict
                     deploy_results[sid] = unwrap_http_result(
                         result,

--- a/tools/events_tools.py
+++ b/tools/events_tools.py
@@ -1,7 +1,8 @@
 """Event management tools for Alpacon MCP server - Refactored version."""
 
-from typing import Any
+from typing import Unpack
 
+from utils.api_types import ToolKwargs, ToolResponse
 from utils.common import success_response, unwrap_http_result
 from utils.decorators import mcp_tool_handler
 from utils.http_client import http_client
@@ -19,12 +20,12 @@ async def list_events(
     reporter: str | None = None,
     limit: int = 50,
     region: str = '',
-    **kwargs,
-) -> dict[str, Any]:
+    **kwargs: Unpack[ToolKwargs],
+) -> ToolResponse:
     """List events from servers."""
     token = kwargs.get('token')
 
-    params = {'page_size': limit, 'ordering': '-added_at'}
+    params: dict[str, object] = {'page_size': limit, 'ordering': '-added_at'}
 
     if server_id:
         params['server'] = server_id
@@ -67,8 +68,8 @@ async def list_events(
     meta={'anthropic/searchHint': 'event detail specific'},
 )
 async def get_event(
-    event_id: str, workspace: str, region: str = '', **kwargs
-) -> dict[str, Any]:
+    event_id: str, workspace: str, region: str = '', **kwargs: Unpack[ToolKwargs]
+) -> ToolResponse:
     """Get detailed information about a specific event."""
     token = kwargs.get('token')
 
@@ -105,12 +106,16 @@ async def search_events(
     server_id: str | None = None,
     limit: int = 20,
     region: str = '',
-    **kwargs,
-) -> dict[str, Any]:
+    **kwargs: Unpack[ToolKwargs],
+) -> ToolResponse:
     """Search events by server name, reporter, record, or description."""
     token = kwargs.get('token')
 
-    params = {'search': search_query, 'page_size': limit, 'ordering': '-added_at'}
+    params: dict[str, object] = {
+        'search': search_query,
+        'page_size': limit,
+        'ordering': '-added_at',
+    }
 
     if server_id:
         params['server'] = server_id

--- a/tools/health_tools.py
+++ b/tools/health_tools.py
@@ -1,10 +1,9 @@
 """Health check tool for MCP clients."""
 
-from typing import Any
-
 from mcp.types import ToolAnnotations
 
 from server import mcp
+from utils.api_types import ToolResponse
 from utils.common import success_response
 
 
@@ -16,7 +15,7 @@ from utils.common import success_response
         'anthropic/searchHint': 'health check status ping connectivity',
     },
 )
-async def health_check() -> dict[str, Any]:
+async def health_check() -> ToolResponse:
     """Check MCP server health and return status information.
 
     No parameters required - returns server health metrics including

--- a/tools/iam_tools.py
+++ b/tools/iam_tools.py
@@ -1,8 +1,9 @@
 """IAM (Identity and Access Management) tools for Alpacon MCP server."""
 
 import re
-from typing import Any
+from typing import Unpack, cast
 
+from utils.api_types import ToolKwargs, ToolResponse
 from utils.common import error_response, success_response, unwrap_http_result
 from utils.decorators import mcp_tool_handler
 from utils.error_handler import format_validation_error, validate_server_id_format
@@ -14,12 +15,15 @@ VALID_SERVICE_TYPES = frozenset({'ci_cd', 'monitoring', 'automation', 'integrati
 GROUP_NAME_PATTERN = re.compile(r'^[a-z0-9_-]+$')
 
 
-def _validate_uuid(field: str, value: str) -> dict[str, Any] | None:
+def _validate_uuid(field: str, value: str) -> ToolResponse | None:
     if not validate_server_id_format(value):
-        return format_validation_error(
-            field,
-            value,
-            'Must be a valid UUID. Example: 550e8400-e29b-41d4-a716-446655440000',
+        return cast(
+            ToolResponse,
+            format_validation_error(
+                field,
+                value,
+                'Must be a valid UUID. Example: 550e8400-e29b-41d4-a716-446655440000',
+            ),
         )
     return None
 
@@ -39,8 +43,8 @@ async def list_iam_users(
     region: str = '',
     page: int | None = None,
     page_size: int | None = None,
-    **kwargs,
-) -> dict[str, Any]:
+    **kwargs: Unpack[ToolKwargs],
+) -> ToolResponse:
     """List all IAM users in workspace.
 
     Args:
@@ -54,7 +58,7 @@ async def list_iam_users(
     """
     token = kwargs.get('token')
 
-    params = {}
+    params: dict[str, object] = {}
     if page is not None:
         params['page'] = page
     if page_size is not None:
@@ -86,8 +90,8 @@ async def list_iam_users(
     meta={'anthropic/searchHint': 'iam user detail profile'},
 )
 async def get_iam_user(
-    user_id: str, workspace: str, region: str = '', **kwargs
-) -> dict[str, Any]:
+    user_id: str, workspace: str, region: str = '', **kwargs: Unpack[ToolKwargs]
+) -> ToolResponse:
     """Get detailed information about a specific IAM user.
 
     Group memberships are not included in the user payload (the user
@@ -143,8 +147,8 @@ async def create_iam_user(
     last_name: str | None = None,
     is_active: bool = True,
     region: str = '',
-    **kwargs,
-) -> dict[str, Any]:
+    **kwargs: Unpack[ToolKwargs],
+) -> ToolResponse:
     """Create a new IAM user.
 
     Group assignment is handled separately via add_iam_member
@@ -164,7 +168,11 @@ async def create_iam_user(
     """
     token = kwargs.get('token')
 
-    user_data = {'username': username, 'email': email, 'is_active': is_active}
+    user_data: dict[str, object] = {
+        'username': username,
+        'email': email,
+        'is_active': is_active,
+    }
 
     if first_name is not None:
         user_data['first_name'] = first_name
@@ -207,8 +215,8 @@ async def update_iam_user(
     last_name: str | None = None,
     is_active: bool | None = None,
     region: str = '',
-    **kwargs,
-) -> dict[str, Any]:
+    **kwargs: Unpack[ToolKwargs],
+) -> ToolResponse:
     """Update an existing IAM user.
 
     Group membership changes are handled separately via
@@ -232,7 +240,7 @@ async def update_iam_user(
 
     token = kwargs.get('token')
 
-    update_data: dict[str, Any] = {}
+    update_data: dict[str, object] = {}
     if email is not None:
         update_data['email'] = email
     if first_name is not None:
@@ -274,8 +282,8 @@ async def update_iam_user(
     meta={'anthropic/searchHint': 'iam user delete remove'},
 )
 async def delete_iam_user(
-    user_id: str, workspace: str, region: str = '', **kwargs
-) -> dict[str, Any]:
+    user_id: str, workspace: str, region: str = '', **kwargs: Unpack[ToolKwargs]
+) -> ToolResponse:
     """Delete an IAM user.
 
     Args:
@@ -329,8 +337,8 @@ async def list_iam_groups(
     region: str = '',
     page: int | None = None,
     page_size: int | None = None,
-    **kwargs,
-) -> dict[str, Any]:
+    **kwargs: Unpack[ToolKwargs],
+) -> ToolResponse:
     """List all IAM groups in workspace.
 
     Args:
@@ -344,7 +352,7 @@ async def list_iam_groups(
     """
     token = kwargs.get('token')
 
-    params = {}
+    params: dict[str, object] = {}
     if page is not None:
         params['page'] = page
     if page_size is not None:
@@ -381,8 +389,8 @@ async def create_iam_group(
     display_name: str | None = None,
     description: str | None = None,
     region: str = '',
-    **kwargs,
-) -> dict[str, Any]:
+    **kwargs: Unpack[ToolKwargs],
+) -> ToolResponse:
     """Create a new IAM group.
 
     Args:
@@ -396,15 +404,18 @@ async def create_iam_group(
         Group creation response
     """
     if not GROUP_NAME_PATTERN.match(name):
-        return format_validation_error(
-            'name',
-            name,
-            'Must contain only lowercase letters, digits, hyphens, and underscores',
+        return cast(
+            ToolResponse,
+            format_validation_error(
+                'name',
+                name,
+                'Must contain only lowercase letters, digits, hyphens, and underscores',
+            ),
         )
 
     token = kwargs.get('token')
 
-    group_data: dict[str, Any] = {'name': name}
+    group_data: dict[str, object] = {'name': name}
 
     if display_name is not None:
         group_data['display_name'] = display_name
@@ -456,8 +467,8 @@ async def get_iam_group(
     group_id: str,
     workspace: str,
     region: str = '',
-    **kwargs,
-) -> dict[str, Any]:
+    **kwargs: Unpack[ToolKwargs],
+) -> ToolResponse:
     """Get IAM group details.
 
     Args:
@@ -504,8 +515,8 @@ async def update_iam_group(
     display_name: str | None = None,
     description: str | None = None,
     region: str = '',
-    **kwargs,
-) -> dict[str, Any]:
+    **kwargs: Unpack[ToolKwargs],
+) -> ToolResponse:
     """Update an existing IAM group.
 
     The group name is read-only on the server (GroupUpdateSerializer);
@@ -527,7 +538,7 @@ async def update_iam_group(
 
     token = kwargs.get('token')
 
-    update_data: dict[str, Any] = {}
+    update_data: dict[str, object] = {}
     if display_name is not None:
         update_data['display_name'] = display_name
     if description is not None:
@@ -566,8 +577,8 @@ async def delete_iam_group(
     group_id: str,
     workspace: str,
     region: str = '',
-    **kwargs,
-) -> dict[str, Any]:
+    **kwargs: Unpack[ToolKwargs],
+) -> ToolResponse:
     """Delete an IAM group.
 
     Args:
@@ -619,8 +630,8 @@ async def list_iam_memberships(
     region: str = '',
     page: int | None = None,
     page_size: int | None = None,
-    **kwargs,
-) -> dict[str, Any]:
+    **kwargs: Unpack[ToolKwargs],
+) -> ToolResponse:
     """List IAM group memberships.
 
     Args:
@@ -640,7 +651,7 @@ async def list_iam_memberships(
 
     token = kwargs.get('token')
 
-    params: dict[str, Any] = {}
+    params: dict[str, object] = {}
     if group_id is not None:
         params['group'] = group_id
     if page is not None:
@@ -677,8 +688,8 @@ async def add_iam_member(
     workspace: str,
     role: str = 'member',
     region: str = '',
-    **kwargs,
-) -> dict[str, Any]:
+    **kwargs: Unpack[ToolKwargs],
+) -> ToolResponse:
     """Add a user to an IAM group.
 
     Args:
@@ -695,8 +706,13 @@ async def add_iam_member(
     if err:
         return err
     if role not in VALID_MEMBERSHIP_ROLES:
-        return format_validation_error(
-            'role', role, f'Must be one of: {", ".join(sorted(VALID_MEMBERSHIP_ROLES))}'
+        return cast(
+            ToolResponse,
+            format_validation_error(
+                'role',
+                role,
+                f'Must be one of: {", ".join(sorted(VALID_MEMBERSHIP_ROLES))}',
+            ),
         )
 
     token = kwargs.get('token')
@@ -735,8 +751,8 @@ async def remove_iam_member(
     membership_id: str,
     workspace: str,
     region: str = '',
-    **kwargs,
-) -> dict[str, Any]:
+    **kwargs: Unpack[ToolKwargs],
+) -> ToolResponse:
     """Remove a user from an IAM group.
 
     Args:
@@ -789,8 +805,8 @@ async def invite_workspace_user(
     email: str,
     workspace: str,
     region: str = '',
-    **kwargs,
-) -> dict[str, Any]:
+    **kwargs: Unpack[ToolKwargs],
+) -> ToolResponse:
     """Invite a user to the workspace by email.
 
     Sends an Auth0 organization invitation and records a pending
@@ -841,8 +857,8 @@ async def list_iam_applications(
     region: str = '',
     page: int | None = None,
     page_size: int | None = None,
-    **kwargs,
-) -> dict[str, Any]:
+    **kwargs: Unpack[ToolKwargs],
+) -> ToolResponse:
     """List all IAM applications in the workspace.
 
     Args:
@@ -856,7 +872,7 @@ async def list_iam_applications(
     """
     token = kwargs.get('token')
 
-    params: dict[str, Any] = {}
+    params: dict[str, object] = {}
     if page is not None:
         params['page'] = page
     if page_size is not None:
@@ -891,8 +907,8 @@ async def create_iam_application(
     description: str | None = None,
     service_type: str | None = None,
     region: str = '',
-    **kwargs,
-) -> dict[str, Any]:
+    **kwargs: Unpack[ToolKwargs],
+) -> ToolResponse:
     """Create a new IAM application.
 
     Args:
@@ -907,15 +923,18 @@ async def create_iam_application(
         IAM application creation response
     """
     if service_type is not None and service_type not in VALID_SERVICE_TYPES:
-        return format_validation_error(
-            'service_type',
-            service_type,
-            f'Must be one of: {", ".join(sorted(VALID_SERVICE_TYPES))}',
+        return cast(
+            ToolResponse,
+            format_validation_error(
+                'service_type',
+                service_type,
+                f'Must be one of: {", ".join(sorted(VALID_SERVICE_TYPES))}',
+            ),
         )
 
     token = kwargs.get('token')
 
-    app_data: dict[str, Any] = {'name': name}
+    app_data: dict[str, object] = {'name': name}
     if description is not None:
         app_data['description'] = description
     if service_type is not None:
@@ -951,8 +970,8 @@ async def get_iam_application(
     app_id: str,
     workspace: str,
     region: str = '',
-    **kwargs,
-) -> dict[str, Any]:
+    **kwargs: Unpack[ToolKwargs],
+) -> ToolResponse:
     """Get IAM application details.
 
     Args:
@@ -999,8 +1018,8 @@ async def update_iam_application(
     name: str | None = None,
     description: str | None = None,
     region: str = '',
-    **kwargs,
-) -> dict[str, Any]:
+    **kwargs: Unpack[ToolKwargs],
+) -> ToolResponse:
     """Update an existing IAM application.
 
     Args:
@@ -1019,7 +1038,7 @@ async def update_iam_application(
 
     token = kwargs.get('token')
 
-    update_data: dict[str, Any] = {}
+    update_data: dict[str, object] = {}
     if name is not None:
         update_data['name'] = name
     if description is not None:
@@ -1058,8 +1077,8 @@ async def delete_iam_application(
     app_id: str,
     workspace: str,
     region: str = '',
-    **kwargs,
-) -> dict[str, Any]:
+    **kwargs: Unpack[ToolKwargs],
+) -> ToolResponse:
     """Delete an IAM application.
 
     Args:
@@ -1107,8 +1126,8 @@ async def assign_application_system_users(
     system_user_ids: list[str],
     workspace: str,
     region: str = '',
-    **kwargs,
-) -> dict[str, Any]:
+    **kwargs: Unpack[ToolKwargs],
+) -> ToolResponse:
     """Assign system users to an IAM application.
 
     Args:
@@ -1124,10 +1143,13 @@ async def assign_application_system_users(
     if err:
         return err
     if not system_user_ids:
-        return format_validation_error(
-            'system_user_ids',
-            system_user_ids,
-            'Must contain at least one system user ID',
+        return cast(
+            ToolResponse,
+            format_validation_error(
+                'system_user_ids',
+                system_user_ids,
+                'Must contain at least one system user ID',
+            ),
         )
     for su_id in system_user_ids:
         err = _validate_uuid('system_user_ids', su_id)
@@ -1168,8 +1190,8 @@ async def unassign_application_system_users(
     system_user_ids: list[str],
     workspace: str,
     region: str = '',
-    **kwargs,
-) -> dict[str, Any]:
+    **kwargs: Unpack[ToolKwargs],
+) -> ToolResponse:
     """Unassign system users from an IAM application.
 
     Args:
@@ -1185,10 +1207,13 @@ async def unassign_application_system_users(
     if err:
         return err
     if not system_user_ids:
-        return format_validation_error(
-            'system_user_ids',
-            system_user_ids,
-            'Must contain at least one system user ID',
+        return cast(
+            ToolResponse,
+            format_validation_error(
+                'system_user_ids',
+                system_user_ids,
+                'Must contain at least one system user ID',
+            ),
         )
     for su_id in system_user_ids:
         err = _validate_uuid('system_user_ids', su_id)

--- a/tools/iam_tools.py
+++ b/tools/iam_tools.py
@@ -1,7 +1,7 @@
 """IAM (Identity and Access Management) tools for Alpacon MCP server."""
 
 import re
-from typing import Unpack, cast
+from typing import Unpack
 
 from utils.api_types import ToolKwargs, ToolResponse
 from utils.common import error_response, success_response, unwrap_http_result
@@ -17,13 +17,10 @@ GROUP_NAME_PATTERN = re.compile(r'^[a-z0-9_-]+$')
 
 def _validate_uuid(field: str, value: str) -> ToolResponse | None:
     if not validate_server_id_format(value):
-        return cast(
-            ToolResponse,
-            format_validation_error(
-                field,
-                value,
-                'Must be a valid UUID. Example: 550e8400-e29b-41d4-a716-446655440000',
-            ),
+        return format_validation_error(
+            field,
+            value,
+            'Must be a valid UUID. Example: 550e8400-e29b-41d4-a716-446655440000',
         )
     return None
 
@@ -404,13 +401,10 @@ async def create_iam_group(
         Group creation response
     """
     if not GROUP_NAME_PATTERN.match(name):
-        return cast(
-            ToolResponse,
-            format_validation_error(
-                'name',
-                name,
-                'Must contain only lowercase letters, digits, hyphens, and underscores',
-            ),
+        return format_validation_error(
+            'name',
+            name,
+            'Must contain only lowercase letters, digits, hyphens, and underscores',
         )
 
     token = kwargs.get('token')
@@ -706,13 +700,10 @@ async def add_iam_member(
     if err:
         return err
     if role not in VALID_MEMBERSHIP_ROLES:
-        return cast(
-            ToolResponse,
-            format_validation_error(
-                'role',
-                role,
-                f'Must be one of: {", ".join(sorted(VALID_MEMBERSHIP_ROLES))}',
-            ),
+        return format_validation_error(
+            'role',
+            role,
+            f'Must be one of: {", ".join(sorted(VALID_MEMBERSHIP_ROLES))}',
         )
 
     token = kwargs.get('token')
@@ -923,13 +914,10 @@ async def create_iam_application(
         IAM application creation response
     """
     if service_type is not None and service_type not in VALID_SERVICE_TYPES:
-        return cast(
-            ToolResponse,
-            format_validation_error(
-                'service_type',
-                service_type,
-                f'Must be one of: {", ".join(sorted(VALID_SERVICE_TYPES))}',
-            ),
+        return format_validation_error(
+            'service_type',
+            service_type,
+            f'Must be one of: {", ".join(sorted(VALID_SERVICE_TYPES))}',
         )
 
     token = kwargs.get('token')
@@ -1143,13 +1131,10 @@ async def assign_application_system_users(
     if err:
         return err
     if not system_user_ids:
-        return cast(
-            ToolResponse,
-            format_validation_error(
-                'system_user_ids',
-                system_user_ids,
-                'Must contain at least one system user ID',
-            ),
+        return format_validation_error(
+            'system_user_ids',
+            system_user_ids,
+            'Must contain at least one system user ID',
         )
     for su_id in system_user_ids:
         err = _validate_uuid('system_user_ids', su_id)
@@ -1207,13 +1192,10 @@ async def unassign_application_system_users(
     if err:
         return err
     if not system_user_ids:
-        return cast(
-            ToolResponse,
-            format_validation_error(
-                'system_user_ids',
-                system_user_ids,
-                'Must contain at least one system user ID',
-            ),
+        return format_validation_error(
+            'system_user_ids',
+            system_user_ids,
+            'Must contain at least one system user ID',
         )
     for su_id in system_user_ids:
         err = _validate_uuid('system_user_ids', su_id)

--- a/tools/metrics_tools.py
+++ b/tools/metrics_tools.py
@@ -72,20 +72,16 @@ class DiskUsageStats(TypedDict, total=False):
     time_range: _TimeRange
 
 
-class _NetworkCurrent(TypedDict):
-    peak_input_bps: str
-    peak_output_bps: str
-    avg_input_bps: str
-    avg_output_bps: str
-    peak_input_pps: str
-    peak_output_pps: str
-
-
 class _NetworkAverages(TypedDict):
     peak_input_bps: str
     peak_output_bps: str
     avg_input_bps: str
     avg_output_bps: str
+
+
+class _NetworkCurrent(_NetworkAverages):
+    peak_input_pps: str
+    peak_output_pps: str
 
 
 class _NetworkPeaks(TypedDict):
@@ -106,6 +102,21 @@ class NetworkTrafficStats(TypedDict, total=False):
     peaks: _NetworkPeaks
     data_points: int
     time_range: _TimeRange
+
+
+def _results_of(payload: ApiPayload) -> list[dict[str, object]]:
+    """Normalize a metrics API payload (paginated dict or bare list) to its entries."""
+    if isinstance(payload, dict):
+        return cast(list[dict[str, object]], payload.get('results', []))
+    return payload
+
+
+def _time_range(results: list[dict[str, object]]) -> _TimeRange:
+    """First/last entry timestamps echoed back by every parser below."""
+    return {
+        'start': cast(str | None, results[0].get('timestamp')) if results else None,
+        'end': cast(str | None, results[-1].get('timestamp')) if results else None,
+    }
 
 
 def parse_cpu_metrics(results: list[dict[str, object]]) -> UsagePercentStats:
@@ -158,14 +169,7 @@ def parse_cpu_metrics(results: list[dict[str, object]]) -> UsagePercentStats:
         if current < 95
         else 'critical',
         'data_points': len(usage_values),
-        'time_range': {
-            'start': cast(str | None, results[0].get('timestamp'))
-            if results
-            else None,
-            'end': cast(str | None, results[-1].get('timestamp'))
-            if results
-            else None,
-        },
+        'time_range': _time_range(results),
         'raw_values': {
             'current': current,
             'average': average,
@@ -236,9 +240,7 @@ async def get_cpu_usage(
     parsed_data = {
         'server_id': server_id,
         'metric_type': 'cpu_usage',
-        'statistics': parse_cpu_metrics(payload.get('results', []))
-        if isinstance(payload, dict)
-        else parse_cpu_metrics(payload if isinstance(payload, list) else []),
+        'statistics': parse_cpu_metrics(_results_of(payload)),
         'raw_data_available': True,
     }
 
@@ -295,14 +297,7 @@ def parse_memory_metrics(results: list[dict[str, object]]) -> UsagePercentStats:
         if current < 95
         else 'critical',
         'data_points': len(usage_values),
-        'time_range': {
-            'start': cast(str | None, results[0].get('timestamp'))
-            if results
-            else None,
-            'end': cast(str | None, results[-1].get('timestamp'))
-            if results
-            else None,
-        },
+        'time_range': _time_range(results),
         'raw_values': {
             'current': current,
             'average': average,
@@ -373,9 +368,7 @@ async def get_memory_usage(
     parsed_data = {
         'server_id': server_id,
         'metric_type': 'memory_usage',
-        'statistics': parse_memory_metrics(payload.get('results', []))
-        if isinstance(payload, dict)
-        else parse_memory_metrics(payload if isinstance(payload, list) else []),
+        'statistics': parse_memory_metrics(_results_of(payload)),
         'raw_data_available': True,
     }
 
@@ -429,14 +422,7 @@ def parse_disk_metrics(results: list[dict[str, object]]) -> DiskUsageStats:
             'mount_point': cast(str | None, latest_entry.get('mount_point')),
         },
         'data_points': len(usage_values),
-        'time_range': {
-            'start': cast(str | None, results[0].get('timestamp'))
-            if results
-            else None,
-            'end': cast(str | None, results[-1].get('timestamp'))
-            if results
-            else None,
-        },
+        'time_range': _time_range(results),
     }
 
 
@@ -565,9 +551,7 @@ async def get_disk_usage(
         'metric_type': 'disk_usage',
         'device': device,
         'partition': partition,
-        'statistics': parse_disk_metrics(payload.get('results', []))
-        if isinstance(payload, dict)
-        else parse_disk_metrics(payload if isinstance(payload, list) else []),
+        'statistics': parse_disk_metrics(_results_of(payload)),
         'raw_data_available': True,
     }
 
@@ -660,14 +644,7 @@ def parse_network_metrics(results: list[dict[str, object]]) -> NetworkTrafficSta
             else '0 pps',
         },
         'data_points': len(results),
-        'time_range': {
-            'start': cast(str | None, results[0].get('timestamp'))
-            if results
-            else None,
-            'end': cast(str | None, results[-1].get('timestamp'))
-            if results
-            else None,
-        },
+        'time_range': _time_range(results),
     }
 
 
@@ -812,9 +789,7 @@ async def get_network_traffic(
         'server_id': server_id,
         'metric_type': 'network_traffic',
         'interface': interface,
-        'statistics': parse_network_metrics(payload.get('results', []))
-        if isinstance(payload, dict)
-        else parse_network_metrics(payload if isinstance(payload, list) else []),
+        'statistics': parse_network_metrics(_results_of(payload)),
         'raw_data_available': True,
     }
 
@@ -906,9 +881,8 @@ async def get_top_servers(
             )
 
         err = unwrap_http_result(
-            # Not an Exception per the check above; the only other BaseException
-            # members (CancelledError etc.) would already have propagated out of
-            # asyncio.gather rather than landing here as a value.
+            # Non-Exception BaseExceptions (CancelledError etc.) propagate out
+            # of asyncio.gather instead of landing here as values.
             cast(ApiResult, result),
             default_message=f'Failed to fetch {metric} metrics',
             region=region,
@@ -1055,9 +1029,8 @@ async def get_server_metrics_summary(
 
         # http_client.get returns raw API response (paginated list format)
         if isinstance(partitions_result, dict) and 'results' in partitions_result:
-            partitions_payload = cast(dict[str, object], partitions_result)
             partitions = cast(
-                list[dict[str, object]], partitions_payload.get('results', [])
+                list[dict[str, object]], partitions_result.get('results', [])
             )
             # Find the root partition (mounted at /)
             for partition in partitions:
@@ -1082,9 +1055,8 @@ async def get_server_metrics_summary(
 
         # http_client.get returns raw API response (paginated list format)
         if isinstance(interfaces_result, dict) and 'results' in interfaces_result:
-            interfaces_payload = cast(dict[str, object], interfaces_result)
             interfaces = cast(
-                list[dict[str, object]], interfaces_payload.get('results', [])
+                list[dict[str, object]], interfaces_result.get('results', [])
             )
             # Find first non-loopback, active interface
             for iface in interfaces:

--- a/tools/metrics_tools.py
+++ b/tools/metrics_tools.py
@@ -1,9 +1,16 @@
 """Metrics and monitoring tools for Alpacon MCP server."""
 
 import asyncio
+from collections.abc import Awaitable
 from datetime import UTC, datetime, timedelta
-from typing import Any
+from typing import Required, TypedDict, Unpack, cast
 
+from utils.api_types import (
+    ApiPayload,
+    ApiResult,
+    ToolKwargs,
+    ToolResponse,
+)
 from utils.common import error_response, success_response, unwrap_http_result
 from utils.decorators import mcp_tool_handler
 from utils.error_handler import UpstreamAuthError
@@ -11,7 +18,97 @@ from utils.http_client import http_client
 from utils.tool_annotations import READ_ONLY
 
 
-def parse_cpu_metrics(results: list) -> dict[str, Any]:
+class _TimeRange(TypedDict):
+    """Fixed ``{start, end}`` window echoed back by every parser below."""
+
+    start: str | None
+    end: str | None
+
+
+class _UsageRawValues(TypedDict):
+    """Unformatted current/average/min/max backing a ``*_usage_percent`` stat."""
+
+    current: float
+    average: float
+    min: float
+    max: float
+
+
+class UsagePercentStats(TypedDict, total=False):
+    """Return shape shared by :func:`parse_cpu_metrics` and :func:`parse_memory_metrics`."""
+
+    available: Required[bool]
+    message: str
+    current_usage_percent: str
+    average_usage_percent: str
+    min_usage_percent: str
+    max_usage_percent: str
+    status: str
+    health: str
+    data_points: int
+    time_range: _TimeRange
+    raw_values: _UsageRawValues
+
+
+class _DiskSpaceInfo(TypedDict):
+    total: str
+    used: str
+    free: str
+    device: str | None
+    mount_point: str | None
+
+
+class DiskUsageStats(TypedDict, total=False):
+    """Return shape of :func:`parse_disk_metrics`."""
+
+    available: Required[bool]
+    message: str
+    current_usage: float
+    average_usage: float
+    min_usage: float
+    max_usage: float
+    space_info: _DiskSpaceInfo
+    data_points: int
+    time_range: _TimeRange
+
+
+class _NetworkCurrent(TypedDict):
+    peak_input_bps: str
+    peak_output_bps: str
+    avg_input_bps: str
+    avg_output_bps: str
+    peak_input_pps: str
+    peak_output_pps: str
+
+
+class _NetworkAverages(TypedDict):
+    peak_input_bps: str
+    peak_output_bps: str
+    avg_input_bps: str
+    avg_output_bps: str
+
+
+class _NetworkPeaks(TypedDict):
+    max_input_bps: str
+    max_output_bps: str
+    max_input_pps: str
+    max_output_pps: str
+
+
+class NetworkTrafficStats(TypedDict, total=False):
+    """Return shape of :func:`parse_network_metrics`."""
+
+    available: Required[bool]
+    message: str
+    interface: str | None
+    current: _NetworkCurrent
+    averages: _NetworkAverages
+    peaks: _NetworkPeaks
+    data_points: int
+    time_range: _TimeRange
+
+
+def parse_cpu_metrics(results: list[dict[str, object]]) -> UsagePercentStats:
     """Parse CPU usage metrics to extract meaningful statistics.
 
     Args:
@@ -23,7 +120,9 @@ def parse_cpu_metrics(results: list) -> dict[str, Any]:
     if not results or len(results) == 0:
         return {'available': False, 'message': 'No CPU data available'}
 
-    usage_values = [entry.get('usage', 0) for entry in results if 'usage' in entry]
+    usage_values = [
+        cast(float, entry.get('usage', 0)) for entry in results if 'usage' in entry
+    ]
 
     if not usage_values:
         return {'available': False, 'message': 'No usage values found'}
@@ -34,7 +133,7 @@ def parse_cpu_metrics(results: list) -> dict[str, Any]:
     maximum = max(usage_values)
 
     # Determine usage status
-    def get_status(usage):
+    def get_status(usage: float) -> str:
         if usage < 20:
             return 'idle'
         elif usage < 50:
@@ -60,8 +159,12 @@ def parse_cpu_metrics(results: list) -> dict[str, Any]:
         else 'critical',
         'data_points': len(usage_values),
         'time_range': {
-            'start': results[0].get('timestamp') if results else None,
-            'end': results[-1].get('timestamp') if results else None,
+            'start': cast(str | None, results[0].get('timestamp'))
+            if results
+            else None,
+            'end': cast(str | None, results[-1].get('timestamp'))
+            if results
+            else None,
         },
         'raw_values': {
             'current': current,
@@ -83,8 +186,8 @@ async def get_cpu_usage(
     start_date: str | None = None,
     end_date: str | None = None,
     region: str = '',
-    **kwargs,
-) -> dict[str, Any]:
+    **kwargs: Unpack[ToolKwargs],
+) -> ToolResponse:
     """Get CPU usage metrics for a server with parsed statistics.
 
     Args:
@@ -100,7 +203,7 @@ async def get_cpu_usage(
     token = kwargs.get('token')
 
     # Prepare query parameters with required start date
-    params = {'server': server_id}
+    params: dict[str, object] = {'server': server_id}
     if start_date:
         params['start'] = start_date
     else:
@@ -129,19 +232,20 @@ async def get_cpu_usage(
         return err
 
     # Parse metrics for better readability
+    payload = cast(ApiPayload, result)
     parsed_data = {
         'server_id': server_id,
         'metric_type': 'cpu_usage',
-        'statistics': parse_cpu_metrics(result.get('results', []))
-        if isinstance(result, dict)
-        else parse_cpu_metrics(result if isinstance(result, list) else []),
+        'statistics': parse_cpu_metrics(payload.get('results', []))
+        if isinstance(payload, dict)
+        else parse_cpu_metrics(payload if isinstance(payload, list) else []),
         'raw_data_available': True,
     }
 
     return success_response(data=parsed_data, region=region, workspace=workspace)
 
 
-def parse_memory_metrics(results: list) -> dict[str, Any]:
+def parse_memory_metrics(results: list[dict[str, object]]) -> UsagePercentStats:
     """Parse memory usage metrics to extract meaningful statistics.
 
     Args:
@@ -153,7 +257,9 @@ def parse_memory_metrics(results: list) -> dict[str, Any]:
     if not results or len(results) == 0:
         return {'available': False, 'message': 'No memory data available'}
 
-    usage_values = [entry.get('usage', 0) for entry in results if 'usage' in entry]
+    usage_values = [
+        cast(float, entry.get('usage', 0)) for entry in results if 'usage' in entry
+    ]
 
     if not usage_values:
         return {'available': False, 'message': 'No usage values found'}
@@ -164,7 +270,7 @@ def parse_memory_metrics(results: list) -> dict[str, Any]:
     maximum = max(usage_values)
 
     # Determine usage status
-    def get_status(usage):
+    def get_status(usage: float) -> str:
         if usage < 30:
             return 'idle'
         elif usage < 60:
@@ -190,8 +296,12 @@ def parse_memory_metrics(results: list) -> dict[str, Any]:
         else 'critical',
         'data_points': len(usage_values),
         'time_range': {
-            'start': results[0].get('timestamp') if results else None,
-            'end': results[-1].get('timestamp') if results else None,
+            'start': cast(str | None, results[0].get('timestamp'))
+            if results
+            else None,
+            'end': cast(str | None, results[-1].get('timestamp'))
+            if results
+            else None,
         },
         'raw_values': {
             'current': current,
@@ -213,8 +323,8 @@ async def get_memory_usage(
     start_date: str | None = None,
     end_date: str | None = None,
     region: str = '',
-    **kwargs,
-) -> dict[str, Any]:
+    **kwargs: Unpack[ToolKwargs],
+) -> ToolResponse:
     """Get memory usage metrics for a server with parsed statistics.
 
     Args:
@@ -230,7 +340,7 @@ async def get_memory_usage(
     token = kwargs.get('token')
 
     # Prepare query parameters with required start date
-    params = {'server': server_id}
+    params: dict[str, object] = {'server': server_id}
     if start_date:
         params['start'] = start_date
     else:
@@ -259,19 +369,20 @@ async def get_memory_usage(
         return err
 
     # Parse metrics for better readability
+    payload = cast(ApiPayload, result)
     parsed_data = {
         'server_id': server_id,
         'metric_type': 'memory_usage',
-        'statistics': parse_memory_metrics(result.get('results', []))
-        if isinstance(result, dict)
-        else parse_memory_metrics(result if isinstance(result, list) else []),
+        'statistics': parse_memory_metrics(payload.get('results', []))
+        if isinstance(payload, dict)
+        else parse_memory_metrics(payload if isinstance(payload, list) else []),
         'raw_data_available': True,
     }
 
     return success_response(data=parsed_data, region=region, workspace=workspace)
 
 
-def parse_disk_metrics(results: list) -> dict[str, Any]:
+def parse_disk_metrics(results: list[dict[str, object]]) -> DiskUsageStats:
     """Parse disk usage metrics to extract meaningful statistics.
 
     Args:
@@ -283,19 +394,21 @@ def parse_disk_metrics(results: list) -> dict[str, Any]:
     if not results or len(results) == 0:
         return {'available': False, 'message': 'No disk data available'}
 
-    usage_values = [entry.get('usage', 0) for entry in results if 'usage' in entry]
+    usage_values = [
+        cast(float, entry.get('usage', 0)) for entry in results if 'usage' in entry
+    ]
 
     if not usage_values:
         return {'available': False, 'message': 'No usage values found'}
 
     # Get space information from the latest entry
     latest_entry = results[-1]
-    total_bytes = latest_entry.get('total', 0)
-    used_bytes = latest_entry.get('used', 0)
-    free_bytes = latest_entry.get('free', 0)
+    total_bytes = cast(float, latest_entry.get('total', 0))
+    used_bytes = cast(float, latest_entry.get('used', 0))
+    free_bytes = cast(float, latest_entry.get('free', 0))
 
     # Convert bytes to human-readable format
-    def bytes_to_human(bytes_value):
+    def bytes_to_human(bytes_value: float) -> str:
         for unit in ['B', 'KB', 'MB', 'GB', 'TB']:
             if bytes_value < 1024.0:
                 return f'{bytes_value:.2f} {unit}'
@@ -312,13 +425,17 @@ def parse_disk_metrics(results: list) -> dict[str, Any]:
             'total': bytes_to_human(total_bytes),
             'used': bytes_to_human(used_bytes),
             'free': bytes_to_human(free_bytes),
-            'device': latest_entry.get('device'),
-            'mount_point': latest_entry.get('mount_point'),
+            'device': cast(str | None, latest_entry.get('device')),
+            'mount_point': cast(str | None, latest_entry.get('mount_point')),
         },
         'data_points': len(usage_values),
         'time_range': {
-            'start': results[0].get('timestamp') if results else None,
-            'end': results[-1].get('timestamp') if results else None,
+            'start': cast(str | None, results[0].get('timestamp'))
+            if results
+            else None,
+            'end': cast(str | None, results[-1].get('timestamp'))
+            if results
+            else None,
         },
     }
 
@@ -336,8 +453,8 @@ async def get_disk_usage(
     start_date: str | None = None,
     end_date: str | None = None,
     region: str = '',
-    **kwargs,
-) -> dict[str, Any]:
+    **kwargs: Unpack[ToolKwargs],
+) -> ToolResponse:
     """Get disk usage metrics for a server with parsed statistics.
 
     Note: This endpoint requires either 'device' or 'partition' parameter.
@@ -381,9 +498,10 @@ async def get_disk_usage(
                 return err
 
             # Extract device list from response
+            devices_payload = cast(ApiPayload, devices_result)
             available_devices = (
-                devices_result.get('devices', [])
-                if isinstance(devices_result, dict)
+                devices_payload.get('devices', [])
+                if isinstance(devices_payload, dict)
                 else []
             )
 
@@ -408,7 +526,7 @@ async def get_disk_usage(
             )
 
     # Prepare query parameters with required start date
-    params = {'server': server_id}
+    params: dict[str, object] = {'server': server_id}
     if device:
         params['device'] = device
     if partition:
@@ -441,21 +559,22 @@ async def get_disk_usage(
         return err
 
     # Parse metrics for better readability
+    payload = cast(ApiPayload, result)
     parsed_data = {
         'server_id': server_id,
         'metric_type': 'disk_usage',
         'device': device,
         'partition': partition,
-        'statistics': parse_disk_metrics(result.get('results', []))
-        if isinstance(result, dict)
-        else parse_disk_metrics(result if isinstance(result, list) else []),
+        'statistics': parse_disk_metrics(payload.get('results', []))
+        if isinstance(payload, dict)
+        else parse_disk_metrics(payload if isinstance(payload, list) else []),
         'raw_data_available': True,
     }
 
     return success_response(data=parsed_data, region=region, workspace=workspace)
 
 
-def parse_network_metrics(results: list) -> dict[str, Any]:
+def parse_network_metrics(results: list[dict[str, object]]) -> NetworkTrafficStats:
     """Parse network traffic metrics to extract meaningful statistics.
 
     Args:
@@ -468,15 +587,19 @@ def parse_network_metrics(results: list) -> dict[str, Any]:
         return {'available': False, 'message': 'No network data available'}
 
     # Extract various metrics
-    peak_input_bps = [entry.get('peak_input_bps', 0) for entry in results]
-    peak_output_bps = [entry.get('peak_output_bps', 0) for entry in results]
-    avg_input_bps = [entry.get('avg_input_bps', 0) for entry in results]
-    avg_output_bps = [entry.get('avg_output_bps', 0) for entry in results]
-    peak_input_pps = [entry.get('peak_input_pps', 0) for entry in results]
-    peak_output_pps = [entry.get('peak_output_pps', 0) for entry in results]
+    peak_input_bps = [cast(float, entry.get('peak_input_bps', 0)) for entry in results]
+    peak_output_bps = [
+        cast(float, entry.get('peak_output_bps', 0)) for entry in results
+    ]
+    avg_input_bps = [cast(float, entry.get('avg_input_bps', 0)) for entry in results]
+    avg_output_bps = [cast(float, entry.get('avg_output_bps', 0)) for entry in results]
+    peak_input_pps = [cast(float, entry.get('peak_input_pps', 0)) for entry in results]
+    peak_output_pps = [
+        cast(float, entry.get('peak_output_pps', 0)) for entry in results
+    ]
 
     # Convert bps to human-readable format
-    def bps_to_human(bps_value):
+    def bps_to_human(bps_value: float) -> str:
         for unit in ['bps', 'Kbps', 'Mbps', 'Gbps']:
             if bps_value < 1024.0:
                 return f'{bps_value:.2f} {unit}'
@@ -487,7 +610,7 @@ def parse_network_metrics(results: list) -> dict[str, Any]:
 
     return {
         'available': True,
-        'interface': latest_entry.get('interface'),
+        'interface': cast(str | None, latest_entry.get('interface')),
         'current': {
             'peak_input_bps': bps_to_human(peak_input_bps[-1])
             if peak_input_bps
@@ -538,8 +661,12 @@ def parse_network_metrics(results: list) -> dict[str, Any]:
         },
         'data_points': len(results),
         'time_range': {
-            'start': results[0].get('timestamp') if results else None,
-            'end': results[-1].get('timestamp') if results else None,
+            'start': cast(str | None, results[0].get('timestamp'))
+            if results
+            else None,
+            'end': cast(str | None, results[-1].get('timestamp'))
+            if results
+            else None,
         },
     }
 
@@ -558,8 +685,8 @@ async def get_disk_io(
     start_date: str | None = None,
     end_date: str | None = None,
     region: str = '',
-    **kwargs,
-) -> dict[str, Any]:
+    **kwargs: Unpack[ToolKwargs],
+) -> ToolResponse:
     """Get disk I/O performance metrics for a server.
 
     Returns disk read/write throughput metrics with peak and average values.
@@ -578,7 +705,7 @@ async def get_disk_io(
     token = kwargs.get('token')
 
     # Prepare query parameters with required start date
-    params = {'server': server_id}
+    params: dict[str, object] = {'server': server_id}
     if device:
         params['device'] = device
     if start_date:
@@ -631,8 +758,8 @@ async def get_network_traffic(
     start_date: str | None = None,
     end_date: str | None = None,
     region: str = '',
-    **kwargs,
-) -> dict[str, Any]:
+    **kwargs: Unpack[ToolKwargs],
+) -> ToolResponse:
     """Get network traffic metrics for a server with parsed statistics.
 
     Args:
@@ -649,7 +776,7 @@ async def get_network_traffic(
     token = kwargs.get('token')
 
     # Prepare query parameters with required start date
-    params = {'server': server_id}
+    params: dict[str, object] = {'server': server_id}
     if interface:
         params['interface'] = interface
     if start_date:
@@ -680,13 +807,14 @@ async def get_network_traffic(
         return err
 
     # Parse metrics for better readability
+    payload = cast(ApiPayload, result)
     parsed_data = {
         'server_id': server_id,
         'metric_type': 'network_traffic',
         'interface': interface,
-        'statistics': parse_network_metrics(result.get('results', []))
-        if isinstance(result, dict)
-        else parse_network_metrics(result if isinstance(result, list) else []),
+        'statistics': parse_network_metrics(payload.get('results', []))
+        if isinstance(payload, dict)
+        else parse_network_metrics(payload if isinstance(payload, list) else []),
         'raw_data_available': True,
     }
 
@@ -701,8 +829,11 @@ async def get_network_traffic(
     },
 )
 async def get_top_servers(
-    workspace: str, metric_types: str = '', region: str = '', **kwargs
-) -> dict[str, Any]:
+    workspace: str,
+    metric_types: str = '',
+    region: str = '',
+    **kwargs: Unpack[ToolKwargs],
+) -> ToolResponse:
     """Get top 5 servers by specified metric types in the last 24 hours.
 
     Supports querying multiple metrics simultaneously for efficiency.
@@ -749,7 +880,7 @@ async def get_top_servers(
         requested_metrics = list(metric_endpoints.keys())
 
     # Create async tasks for all requested metrics
-    tasks = {}
+    tasks: dict[str, Awaitable[ApiResult]] = {}
     for metric in requested_metrics:
         tasks[metric] = http_client.get(
             region=region,
@@ -775,7 +906,10 @@ async def get_top_servers(
             )
 
         err = unwrap_http_result(
-            result,
+            # Not an Exception per the check above; the only other BaseException
+            # members (CancelledError etc.) would already have propagated out of
+            # asyncio.gather rather than landing here as a value.
+            cast(ApiResult, result),
             default_message=f'Failed to fetch {metric} metrics',
             region=region,
             workspace=workspace,
@@ -788,7 +922,7 @@ async def get_top_servers(
         )
 
     # Multiple metrics - combine into dict
-    combined_data = {}
+    combined_data: dict[str, object] = {}
     for metric, result in zip(tasks.keys(), results, strict=False):
         if isinstance(result, BaseException):
             if not isinstance(result, Exception):
@@ -818,8 +952,11 @@ async def get_top_servers(
     },
 )
 async def get_alert_rules(
-    workspace: str, server_id: str | None = None, region: str = '', **kwargs
-) -> dict[str, Any]:
+    workspace: str,
+    server_id: str | None = None,
+    region: str = '',
+    **kwargs: Unpack[ToolKwargs],
+) -> ToolResponse:
     """Get alert rules for servers.
 
     Args:
@@ -833,7 +970,7 @@ async def get_alert_rules(
     token = kwargs.get('token')
 
     # Prepare query parameters
-    params = {}
+    params: dict[str, object] = {}
     if server_id:
         params['server'] = server_id
 
@@ -870,8 +1007,12 @@ async def get_alert_rules(
     },
 )
 async def get_server_metrics_summary(
-    server_id: str, workspace: str, hours: int = 24, region: str = '', **kwargs
-) -> dict[str, Any]:
+    server_id: str,
+    workspace: str,
+    hours: int = 24,
+    region: str = '',
+    **kwargs: Unpack[ToolKwargs],
+) -> ToolResponse:
     """Get comprehensive metrics summary for a server.
 
     Args:
@@ -899,8 +1040,8 @@ async def get_server_metrics_summary(
     # First, get disk and network interface information to satisfy API requirements
     # DiskUsage API requires: server + start + (device OR partition)
     # Traffic API accepts: server + start + interface (optional, but may have no data without it)
-    disk_device = None
-    network_interface = None
+    disk_device: str | None = None
+    network_interface: str | None = None
 
     try:
         # Get partition information using /api/proc/partitions/
@@ -914,12 +1055,15 @@ async def get_server_metrics_summary(
 
         # http_client.get returns raw API response (paginated list format)
         if isinstance(partitions_result, dict) and 'results' in partitions_result:
-            partitions = partitions_result.get('results', [])
+            partitions_payload = cast(dict[str, object], partitions_result)
+            partitions = cast(
+                list[dict[str, object]], partitions_payload.get('results', [])
+            )
             # Find the root partition (mounted at /)
             for partition in partitions:
-                mount_points = partition.get('mount_points', [])
+                mount_points = cast(list[str], partition.get('mount_points', []))
                 if '/' in mount_points:
-                    disk_device = partition.get('name')
+                    disk_device = cast(str | None, partition.get('name'))
                     break
     except UpstreamAuthError:
         raise
@@ -938,11 +1082,14 @@ async def get_server_metrics_summary(
 
         # http_client.get returns raw API response (paginated list format)
         if isinstance(interfaces_result, dict) and 'results' in interfaces_result:
-            interfaces = interfaces_result.get('results', [])
+            interfaces_payload = cast(dict[str, object], interfaces_result)
+            interfaces = cast(
+                list[dict[str, object]], interfaces_payload.get('results', [])
+            )
             # Find first non-loopback, active interface
             for iface in interfaces:
                 if not iface.get('is_loopback', False) and iface.get('is_up', False):
-                    network_interface = iface.get('name')
+                    network_interface = cast(str | None, iface.get('name'))
                     break
     except UpstreamAuthError:
         raise
@@ -950,10 +1097,26 @@ async def get_server_metrics_summary(
         pass  # Network metrics will show as unavailable
 
     # Prepare query parameters
-    cpu_params = {'server': server_id, 'start': start_date, 'end': end_date}
-    memory_params = {'server': server_id, 'start': start_date, 'end': end_date}
-    disk_params = {'server': server_id, 'start': start_date, 'end': end_date}
-    traffic_params = {'server': server_id, 'start': start_date, 'end': end_date}
+    cpu_params: dict[str, object] = {
+        'server': server_id,
+        'start': start_date,
+        'end': end_date,
+    }
+    memory_params: dict[str, object] = {
+        'server': server_id,
+        'start': start_date,
+        'end': end_date,
+    }
+    disk_params: dict[str, object] = {
+        'server': server_id,
+        'start': start_date,
+        'end': end_date,
+    }
+    traffic_params: dict[str, object] = {
+        'server': server_id,
+        'start': start_date,
+        'end': end_date,
+    }
 
     # Add device/interface to satisfy API requirements
     # DiskUsage API: requires device OR partition (at least one optional field)
@@ -999,7 +1162,7 @@ async def get_server_metrics_summary(
     cpu_result, memory_result, disk_result, traffic_result = gather_results
 
     # Helper function to extract summary from metric result (from http_client directly)
-    def extract_summary(result, metric_type):
+    def extract_summary(result: object, metric_type: str) -> dict[str, object]:
         # Handle exceptions first
         if isinstance(result, Exception):
             return {'available': False, 'error': str(result)}
@@ -1009,6 +1172,7 @@ async def get_server_metrics_summary(
             # Check for HTTP error
             if 'error' in result:
                 # Extract actual error message from response if available
+                error_info: dict[str, object]
                 if 'response' in result:
                     error_info = {
                         'available': False,

--- a/tools/package_tools.py
+++ b/tools/package_tools.py
@@ -1,7 +1,8 @@
 """Package management tools for Alpacon MCP server."""
 
-from typing import Any
+from typing import Unpack
 
+from utils.api_types import ToolKwargs, ToolResponse
 from utils.common import success_response, unwrap_http_result
 from utils.decorators import mcp_tool_handler
 from utils.http_client import http_client
@@ -23,8 +24,8 @@ async def list_system_package_entries(
     region: str = '',
     page: int | None = None,
     page_size: int | None = None,
-    **kwargs,
-) -> dict[str, Any]:
+    **kwargs: Unpack[ToolKwargs],
+) -> ToolResponse:
     """List system package entries on a server.
 
     Args:
@@ -39,7 +40,7 @@ async def list_system_package_entries(
     """
     token = kwargs.get('token')
 
-    params: dict[str, Any] = {'server': server_id}
+    params: dict[str, object] = {'server': server_id}
     if page is not None:
         params['page'] = page
     if page_size is not None:
@@ -79,8 +80,8 @@ async def install_system_package(
     workspace: str,
     version: str | None = None,
     region: str = '',
-    **kwargs,
-) -> dict[str, Any]:
+    **kwargs: Unpack[ToolKwargs],
+) -> ToolResponse:
     """Install a system package on a server.
 
     Args:
@@ -95,7 +96,7 @@ async def install_system_package(
     """
     token = kwargs.get('token')
 
-    package_data: dict[str, Any] = {
+    package_data: dict[str, object] = {
         'server': server_id,
         'name': package_name,
     }
@@ -132,8 +133,8 @@ async def install_system_package(
     meta={'anthropic/searchHint': 'system package remove uninstall delete'},
 )
 async def remove_system_package(
-    entry_id: str, workspace: str, region: str = '', **kwargs
-) -> dict[str, Any]:
+    entry_id: str, workspace: str, region: str = '', **kwargs: Unpack[ToolKwargs]
+) -> ToolResponse:
     """Remove a system package entry.
 
     Args:
@@ -184,8 +185,8 @@ async def list_python_packages(
     region: str = '',
     page: int | None = None,
     page_size: int | None = None,
-    **kwargs,
-) -> dict[str, Any]:
+    **kwargs: Unpack[ToolKwargs],
+) -> ToolResponse:
     """List Python packages on a server.
 
     Args:
@@ -200,7 +201,7 @@ async def list_python_packages(
     """
     token = kwargs.get('token')
 
-    params: dict[str, Any] = {'server': server_id}
+    params: dict[str, object] = {'server': server_id}
     if page is not None:
         params['page'] = page
     if page_size is not None:
@@ -240,8 +241,8 @@ async def install_python_package(
     workspace: str,
     version: str | None = None,
     region: str = '',
-    **kwargs,
-) -> dict[str, Any]:
+    **kwargs: Unpack[ToolKwargs],
+) -> ToolResponse:
     """Install a Python package on a server.
 
     Args:
@@ -256,7 +257,7 @@ async def install_python_package(
     """
     token = kwargs.get('token')
 
-    package_data: dict[str, Any] = {
+    package_data: dict[str, object] = {
         'server': server_id,
         'name': package_name,
     }
@@ -293,8 +294,8 @@ async def install_python_package(
     meta={'anthropic/searchHint': 'python package pip remove uninstall'},
 )
 async def remove_python_package(
-    entry_id: str, workspace: str, region: str = '', **kwargs
-) -> dict[str, Any]:
+    entry_id: str, workspace: str, region: str = '', **kwargs: Unpack[ToolKwargs]
+) -> ToolResponse:
     """Remove a Python package entry.
 
     Args:

--- a/tools/resources.py
+++ b/tools/resources.py
@@ -9,6 +9,7 @@ signature by name; a **kwargs wrapper fails its func_metadata check.
 import inspect
 import re
 from collections.abc import Callable
+from typing import cast
 
 from server import mcp
 from tools.alert_tools import get_alert, list_alerts
@@ -97,7 +98,10 @@ from tools.workspace_tools import get_current_user, list_workspaces
 
 
 def register_resource(
-    uri: str, fn: Callable, name: str, extra: dict | None = None
+    uri: str,
+    fn: Callable[..., object],
+    name: str,
+    extra: dict[str, object] | None = None,
 ) -> None:
     """Register an alpacon:// resource that proxies a read-only tool.
 
@@ -113,9 +117,11 @@ def register_resource(
     # FastMCP needs a real named signature; a **kwargs wrapper fails func_metadata.
     src = f"async def _wrapper({sig}):\n    return {{'content': await _fn({call})}}\n"
     # __name__/__file__ give the wrapper a real __module__ and traceback frame.
-    ns: dict = {'_fn': fn, '__name__': __name__}
+    ns: dict[str, object] = {'_fn': fn, '__name__': __name__}
     exec(compile(src, __file__, 'exec'), ns)  # noqa: S102
-    wrapper = ns['_wrapper']
+    # exec() builds `wrapper` dynamically; cast the exec namespace lookup back
+    # to a callable so downstream attribute access and registration type-check.
+    wrapper = cast(Callable[..., object], ns['_wrapper'])
     wrapper.__name__ = wrapper.__qualname__ = name
     doc = inspect.getdoc(fn) or name
     if extra:
@@ -126,7 +132,7 @@ def register_resource(
     mcp.resource(uri, name=name, description=doc, mime_type='application/json')(wrapper)
 
 
-RESOURCES: list[tuple[str, Callable, str]] = [
+RESOURCES: list[tuple[str, Callable[..., object], str]] = [
     ('servers_list', list_servers, 'alpacon://servers/{region}/{workspace}'),
     ('server_detail', get_server, 'alpacon://servers/{region}/{workspace}/{server_id}'),
     (
@@ -401,7 +407,8 @@ RESOURCES: list[tuple[str, Callable, str]] = [
 ]
 
 # (name, fn, uri, extra) — extra pins fixed kwargs for the few filtered resources.
-_REGISTRATIONS = [(n, f, u, None) for n, f, u in RESOURCES] + [
+_Registration = tuple[str, Callable[..., object], str, dict[str, object] | None]
+_REGISTRATIONS: list[_Registration] = [(n, f, u, None) for n, f, u in RESOURCES] + [
     (
         'alerts_active',
         list_alerts,

--- a/tools/resources.py
+++ b/tools/resources.py
@@ -119,8 +119,7 @@ def register_resource(
     # __name__/__file__ give the wrapper a real __module__ and traceback frame.
     ns: dict[str, object] = {'_fn': fn, '__name__': __name__}
     exec(compile(src, __file__, 'exec'), ns)  # noqa: S102
-    # exec() builds `wrapper` dynamically; cast the exec namespace lookup back
-    # to a callable so downstream attribute access and registration type-check.
+    # The exec namespace is untyped; restore the wrapper's callable type.
     wrapper = cast(Callable[..., object], ns['_wrapper'])
     wrapper.__name__ = wrapper.__qualname__ = name
     doc = inspect.getdoc(fn) or name

--- a/tools/security_tools.py
+++ b/tools/security_tools.py
@@ -1,7 +1,8 @@
 """Security ACL tools for Alpacon MCP server."""
 
-from typing import Any
+from typing import Unpack
 
+from utils.api_types import ToolKwargs, ToolResponse
 from utils.common import error_response, success_response, unwrap_http_result
 from utils.decorators import mcp_tool_handler
 from utils.http_client import http_client
@@ -37,8 +38,8 @@ async def list_command_acls(
     service_token_id: str | None = None,
     page: int | None = None,
     page_size: int | None = None,
-    **kwargs,
-) -> dict[str, Any]:
+    **kwargs: Unpack[ToolKwargs],
+) -> ToolResponse:
     """List command ACL rules.
 
     Args:
@@ -57,7 +58,7 @@ async def list_command_acls(
 
     token = kwargs.get('token')
 
-    params: dict[str, Any] = {}
+    params: dict[str, object] = {}
     if api_token_id is not None:
         params['api_token'] = api_token_id
     if service_token_id is not None:
@@ -100,8 +101,8 @@ async def create_command_acl(
     username: str = '',
     groupname: str = '',
     region: str = '',
-    **kwargs,
-) -> dict[str, Any]:
+    **kwargs: Unpack[ToolKwargs],
+) -> ToolResponse:
     """Create a command ACL rule.
 
     Exactly one of api_token_id or service_token_id must be provided.
@@ -125,7 +126,7 @@ async def create_command_acl(
 
     token = kwargs.get('token')
 
-    acl_data: dict[str, Any] = {
+    acl_data: dict[str, object] = {
         'command': command,
         'username': username,
         'groupname': groupname,
@@ -167,8 +168,8 @@ async def update_command_acl(
     username: str | None = None,
     groupname: str | None = None,
     region: str = '',
-    **kwargs,
-) -> dict[str, Any]:
+    **kwargs: Unpack[ToolKwargs],
+) -> ToolResponse:
     """Update an existing command ACL rule.
 
     Note: This tool does not support changing the token binding. Delete and recreate to rebind to a different token.
@@ -186,7 +187,7 @@ async def update_command_acl(
     """
     token = kwargs.get('token')
 
-    update_data: dict[str, Any] = {}
+    update_data: dict[str, object] = {}
     if command is not None:
         update_data['command'] = command
     if username is not None:
@@ -226,8 +227,8 @@ async def update_command_acl(
     meta={'anthropic/searchHint': 'command acl delete remove'},
 )
 async def delete_command_acl(
-    acl_id: str, workspace: str, region: str = '', **kwargs
-) -> dict[str, Any]:
+    acl_id: str, workspace: str, region: str = '', **kwargs: Unpack[ToolKwargs]
+) -> ToolResponse:
     """Delete a command ACL rule.
 
     Args:
@@ -274,8 +275,8 @@ async def list_server_acls(
     service_token_id: str | None = None,
     page: int | None = None,
     page_size: int | None = None,
-    **kwargs,
-) -> dict[str, Any]:
+    **kwargs: Unpack[ToolKwargs],
+) -> ToolResponse:
     """List server ACL rules.
 
     Args:
@@ -294,7 +295,7 @@ async def list_server_acls(
 
     token = kwargs.get('token')
 
-    params: dict[str, Any] = {}
+    params: dict[str, object] = {}
     if api_token_id is not None:
         params['api_token'] = api_token_id
     if service_token_id is not None:
@@ -335,8 +336,8 @@ async def create_server_acl(
     api_token_id: str | None = None,
     service_token_id: str | None = None,
     region: str = '',
-    **kwargs,
-) -> dict[str, Any]:
+    **kwargs: Unpack[ToolKwargs],
+) -> ToolResponse:
     """Create a server ACL rule.
 
     Exactly one of api_token_id or service_token_id must be provided.
@@ -359,7 +360,7 @@ async def create_server_acl(
 
     token = kwargs.get('token')
 
-    acl_data: dict[str, Any] = {'server': server_id}
+    acl_data: dict[str, object] = {'server': server_id}
     if api_token_id is not None:
         acl_data['token'] = api_token_id
     else:
@@ -397,8 +398,8 @@ async def update_server_acl(
     api_token_id: str | None = None,
     service_token_id: str | None = None,
     region: str = '',
-    **kwargs,
-) -> dict[str, Any]:
+    **kwargs: Unpack[ToolKwargs],
+) -> ToolResponse:
     """Update an existing server ACL rule.
 
     Note: Token binding can be updated by providing api_token_id or service_token_id.
@@ -419,7 +420,7 @@ async def update_server_acl(
 
     token = kwargs.get('token')
 
-    update_data: dict[str, Any] = {}
+    update_data: dict[str, object] = {}
     if server_id is not None:
         update_data['server'] = server_id
     # When rebinding, null the opposing field explicitly: the server enforces
@@ -463,8 +464,8 @@ async def update_server_acl(
     meta={'anthropic/searchHint': 'server acl delete remove'},
 )
 async def delete_server_acl(
-    acl_id: str, workspace: str, region: str = '', **kwargs
-) -> dict[str, Any]:
+    acl_id: str, workspace: str, region: str = '', **kwargs: Unpack[ToolKwargs]
+) -> ToolResponse:
     """Delete a server ACL rule.
 
     Args:
@@ -512,8 +513,8 @@ async def bulk_server_acl(
     api_token_id: str | None = None,
     service_token_id: str | None = None,
     region: str = '',
-    **kwargs,
-) -> dict[str, Any]:
+    **kwargs: Unpack[ToolKwargs],
+) -> ToolResponse:
     """Bulk add or remove server ACL entries.
 
     Exactly one of api_token_id or service_token_id must be provided.
@@ -546,7 +547,7 @@ async def bulk_server_acl(
 
     token = kwargs.get('token')
 
-    body: dict[str, Any] = {'servers': server_ids}
+    body: dict[str, object] = {'servers': server_ids}
     if api_token_id is not None:
         body['token'] = api_token_id
     else:
@@ -589,8 +590,8 @@ async def list_file_acls(
     service_token_id: str | None = None,
     page: int | None = None,
     page_size: int | None = None,
-    **kwargs,
-) -> dict[str, Any]:
+    **kwargs: Unpack[ToolKwargs],
+) -> ToolResponse:
     """List file ACL rules.
 
     Args:
@@ -609,7 +610,7 @@ async def list_file_acls(
 
     token = kwargs.get('token')
 
-    params: dict[str, Any] = {}
+    params: dict[str, object] = {}
     if api_token_id is not None:
         params['api_token'] = api_token_id
     if service_token_id is not None:
@@ -655,8 +656,8 @@ async def create_file_acl(
     username: str = '',
     groupname: str = '',
     region: str = '',
-    **kwargs,
-) -> dict[str, Any]:
+    **kwargs: Unpack[ToolKwargs],
+) -> ToolResponse:
     """Create a file ACL rule.
 
     Exactly one of api_token_id or service_token_id must be provided.
@@ -685,7 +686,7 @@ async def create_file_acl(
 
     token = kwargs.get('token')
 
-    acl_data: dict[str, Any] = {
+    acl_data: dict[str, object] = {
         'path': path,
         'action': action,
         'username': username,
@@ -729,8 +730,8 @@ async def update_file_acl(
     username: str | None = None,
     groupname: str | None = None,
     region: str = '',
-    **kwargs,
-) -> dict[str, Any]:
+    **kwargs: Unpack[ToolKwargs],
+) -> ToolResponse:
     """Update an existing file ACL rule.
 
     Note: This tool does not support changing the token binding. Delete and recreate to rebind to a different token.
@@ -754,7 +755,7 @@ async def update_file_acl(
 
     token = kwargs.get('token')
 
-    update_data: dict[str, Any] = {}
+    update_data: dict[str, object] = {}
     if path is not None:
         update_data['path'] = path
     if action is not None:
@@ -796,8 +797,8 @@ async def update_file_acl(
     meta={'anthropic/searchHint': 'file acl delete remove'},
 )
 async def delete_file_acl(
-    acl_id: str, workspace: str, region: str = '', **kwargs
-) -> dict[str, Any]:
+    acl_id: str, workspace: str, region: str = '', **kwargs: Unpack[ToolKwargs]
+) -> ToolResponse:
     """Delete a file ACL rule.
 
     Args:

--- a/tools/server_tools.py
+++ b/tools/server_tools.py
@@ -123,7 +123,11 @@ async def get_server(
 
     # Extract the first result from the list if results exist
     payload = cast(ApiPayload, result)
-    if isinstance(payload, dict) and 'results' in payload and len(payload['results']) > 0:
+    if (
+        isinstance(payload, dict)
+        and 'results' in payload
+        and len(payload['results']) > 0
+    ):
         server_data = payload['results'][0]
     else:
         return error_response(
@@ -315,13 +319,10 @@ async def update_server_note(
         update_data['content'] = content
 
     if not update_data:
-        return cast(
-            ToolResponse,
-            format_validation_error(
-                'title or content',
-                None,
-                'At least one of title or content must be provided.',
-            ),
+        return format_validation_error(
+            'title or content',
+            None,
+            'At least one of title or content must be provided.',
         )
 
     result = await http_client.patch(
@@ -692,13 +693,10 @@ async def update_server(
         update_data['description'] = description
 
     if not update_data:
-        return cast(
-            ToolResponse,
-            format_validation_error(
-                'name or description',
-                None,
-                'At least one of name or description must be provided.',
-            ),
+        return format_validation_error(
+            'name or description',
+            None,
+            'At least one of name or description must be provided.',
         )
 
     result = await http_client.patch(
@@ -784,7 +782,11 @@ async def unregister_server(
     meta={'anthropic/searchHint': 'server star pin favorite bookmark personalization'},
 )
 async def star_server(
-    server_id: str, status: bool, workspace: str, region: str = '', **kwargs: Unpack[ToolKwargs]
+    server_id: str,
+    status: bool,
+    workspace: str,
+    region: str = '',
+    **kwargs: Unpack[ToolKwargs],
 ) -> ToolResponse:
     """Set star status on a server.
 
@@ -1057,25 +1059,19 @@ async def get_registration_guide(
 
 def _validate_platform(platform: str) -> ToolResponse | None:
     if platform not in VALID_PLATFORMS:
-        return cast(
-            ToolResponse,
-            format_validation_error(
-                'platform',
-                platform,
-                f'Must be one of: {", ".join(sorted(VALID_PLATFORMS))}',
-            ),
+        return format_validation_error(
+            'platform',
+            platform,
+            f'Must be one of: {", ".join(sorted(VALID_PLATFORMS))}',
         )
     return None
 
 
 def _validate_token_id(token_id: str) -> ToolResponse | None:
     if not validate_server_id_format(token_id):
-        return cast(
-            ToolResponse,
-            format_validation_error(
-                'token_id',
-                token_id,
-                'Must be a valid UUID. Example: 550e8400-e29b-41d4-a716-446655440000',
-            ),
+        return format_validation_error(
+            'token_id',
+            token_id,
+            'Must be a valid UUID. Example: 550e8400-e29b-41d4-a716-446655440000',
         )
     return None

--- a/tools/server_tools.py
+++ b/tools/server_tools.py
@@ -1,7 +1,14 @@
 """Server management tools for Alpacon MCP server - Refactored version."""
 
-from typing import Any
+from typing import Unpack, cast
 
+from utils.api_types import (
+    ApiPayload,
+    ResponseContext,
+    ToolKwargs,
+    ToolResponse,
+    is_api_error,
+)
 from utils.common import error_response, success_response, unwrap_http_result
 from utils.decorators import mcp_tool_handler
 from utils.error_handler import format_validation_error, validate_server_id_format
@@ -24,7 +31,9 @@ _PLATFORM_LIST_STR = ', '.join(f'"{p}"' for p in sorted(VALID_PLATFORMS))
         'anthropic/searchHint': 'server list inventory discover find all',
     },
 )
-async def list_servers(workspace: str, region: str = '', **kwargs) -> dict[str, Any]:
+async def list_servers(
+    workspace: str, region: str = '', **kwargs: Unpack[ToolKwargs]
+) -> ToolResponse:
     """Get list of servers.
 
     Args:
@@ -46,8 +55,8 @@ async def list_servers(workspace: str, region: str = '', **kwargs) -> dict[str, 
     )
 
     # Check if result is an error response from http_client
-    if isinstance(result, dict) and 'error' in result:
-        error_kwargs: dict[str, Any] = {'region': region, 'workspace': workspace}
+    if is_api_error(result):
+        error_kwargs: ResponseContext = {'region': region, 'workspace': workspace}
         status_code = result.get('status_code')
         if status_code is not None:
             error_kwargs['status_code'] = status_code
@@ -72,8 +81,8 @@ async def list_servers(workspace: str, region: str = '', **kwargs) -> dict[str, 
     },
 )
 async def get_server(
-    server_id: str, workspace: str, region: str = '', **kwargs
-) -> dict[str, Any]:
+    server_id: str, workspace: str, region: str = '', **kwargs: Unpack[ToolKwargs]
+) -> ToolResponse:
     """Get detailed information about a specific server.
 
     Args:
@@ -98,8 +107,8 @@ async def get_server(
     )
 
     # Check if result is an error response from http_client
-    if isinstance(result, dict) and 'error' in result:
-        error_kwargs: dict[str, Any] = {
+    if is_api_error(result):
+        error_kwargs: ResponseContext = {
             'server_id': server_id,
             'region': region,
             'workspace': workspace,
@@ -113,8 +122,9 @@ async def get_server(
         )
 
     # Extract the first result from the list if results exist
-    if isinstance(result, dict) and 'results' in result and len(result['results']) > 0:
-        server_data = result['results'][0]
+    payload = cast(ApiPayload, result)
+    if isinstance(payload, dict) and 'results' in payload and len(payload['results']) > 0:
+        server_data = payload['results'][0]
     else:
         return error_response(
             'Server not found', server_id=server_id, region=region, workspace=workspace
@@ -135,8 +145,8 @@ async def get_server(
     meta={'anthropic/searchHint': 'server notes documentation'},
 )
 async def list_server_notes(
-    server_id: str, workspace: str, region: str = '', **kwargs
-) -> dict[str, Any]:
+    server_id: str, workspace: str, region: str = '', **kwargs: Unpack[ToolKwargs]
+) -> ToolResponse:
     """Get list of notes for a specific server.
 
     Args:
@@ -178,8 +188,8 @@ async def create_server_note(
     content: str,
     workspace: str,
     region: str = '',
-    **kwargs,
-) -> dict[str, Any]:
+    **kwargs: Unpack[ToolKwargs],
+) -> ToolResponse:
     """Create a new note for a specific server.
 
     Args:
@@ -196,7 +206,11 @@ async def create_server_note(
     token = kwargs.get('token')
 
     # Prepare note data with server field
-    note_data = {'server': server_id, 'title': title, 'content': content}
+    note_data: dict[str, object] = {
+        'server': server_id,
+        'title': title,
+        'content': content,
+    }
 
     # Make async call to create note
     result = await http_client.post(
@@ -227,8 +241,8 @@ async def create_server_note(
     meta={'anthropic/searchHint': 'server note detail describe single get'},
 )
 async def get_server_note(
-    note_id: str, workspace: str, region: str = '', **kwargs
-) -> dict[str, Any]:
+    note_id: str, workspace: str, region: str = '', **kwargs: Unpack[ToolKwargs]
+) -> ToolResponse:
     """Get a single server note by ID.
 
     Args:
@@ -278,8 +292,8 @@ async def update_server_note(
     title: str | None = None,
     content: str | None = None,
     region: str = '',
-    **kwargs,
-) -> dict[str, Any]:
+    **kwargs: Unpack[ToolKwargs],
+) -> ToolResponse:
     """Update an existing server note.
 
     Args:
@@ -294,17 +308,20 @@ async def update_server_note(
     """
     token = kwargs.get('token')
 
-    update_data: dict[str, Any] = {}
+    update_data: dict[str, object] = {}
     if title is not None:
         update_data['title'] = title
     if content is not None:
         update_data['content'] = content
 
     if not update_data:
-        return format_validation_error(
-            'title or content',
-            None,
-            'At least one of title or content must be provided.',
+        return cast(
+            ToolResponse,
+            format_validation_error(
+                'title or content',
+                None,
+                'At least one of title or content must be provided.',
+            ),
         )
 
     result = await http_client.patch(
@@ -339,8 +356,8 @@ async def update_server_note(
     meta={'anthropic/searchHint': 'server note delete remove'},
 )
 async def delete_server_note(
-    note_id: str, workspace: str, region: str = '', **kwargs
-) -> dict[str, Any]:
+    note_id: str, workspace: str, region: str = '', **kwargs: Unpack[ToolKwargs]
+) -> ToolResponse:
     """Delete a server note.
 
     Args:
@@ -385,8 +402,8 @@ async def delete_server_note(
     meta={'anthropic/searchHint': 'agent restart alpacon process'},
 )
 async def restart_agent(
-    server_id: str, workspace: str, region: str = '', **kwargs
-) -> dict[str, Any]:
+    server_id: str, workspace: str, region: str = '', **kwargs: Unpack[ToolKwargs]
+) -> ToolResponse:
     """Restart the Alpacon agent on a server.
 
     Args:
@@ -422,8 +439,8 @@ async def restart_agent(
     meta={'anthropic/searchHint': 'agent shutdown stop process'},
 )
 async def shutdown_agent(
-    server_id: str, workspace: str, region: str = '', **kwargs
-) -> dict[str, Any]:
+    server_id: str, workspace: str, region: str = '', **kwargs: Unpack[ToolKwargs]
+) -> ToolResponse:
     """Shut down the Alpacon agent on a server.
 
     Args:
@@ -459,8 +476,8 @@ async def shutdown_agent(
     meta={'anthropic/searchHint': 'agent upgrade update version'},
 )
 async def upgrade_agent(
-    server_id: str, workspace: str, region: str = '', **kwargs
-) -> dict[str, Any]:
+    server_id: str, workspace: str, region: str = '', **kwargs: Unpack[ToolKwargs]
+) -> ToolResponse:
     """Upgrade the Alpacon agent on a server to the latest version.
 
     Args:
@@ -496,8 +513,8 @@ async def upgrade_agent(
     meta={'anthropic/searchHint': 'refresh system info hardware OS rescan'},
 )
 async def update_information(
-    server_id: str, workspace: str, region: str = '', **kwargs
-) -> dict[str, Any]:
+    server_id: str, workspace: str, region: str = '', **kwargs: Unpack[ToolKwargs]
+) -> ToolResponse:
     """Trigger system information update on a server.
 
     Args:
@@ -534,8 +551,8 @@ async def update_information(
     meta={'anthropic/searchHint': 'system packages upgrade apt yum update all'},
 )
 async def upgrade_system(
-    server_id: str, workspace: str, region: str = '', **kwargs
-) -> dict[str, Any]:
+    server_id: str, workspace: str, region: str = '', **kwargs: Unpack[ToolKwargs]
+) -> ToolResponse:
     """Upgrade all system packages on a server.
 
     Args:
@@ -571,8 +588,8 @@ async def upgrade_system(
     meta={'anthropic/searchHint': 'server reboot restart machine'},
 )
 async def reboot_system(
-    server_id: str, workspace: str, region: str = '', **kwargs
-) -> dict[str, Any]:
+    server_id: str, workspace: str, region: str = '', **kwargs: Unpack[ToolKwargs]
+) -> ToolResponse:
     """Reboot a server.
 
     Args:
@@ -609,8 +626,8 @@ async def reboot_system(
     meta={'anthropic/searchHint': 'server shutdown power off halt'},
 )
 async def shutdown_system(
-    server_id: str, workspace: str, region: str = '', **kwargs
-) -> dict[str, Any]:
+    server_id: str, workspace: str, region: str = '', **kwargs: Unpack[ToolKwargs]
+) -> ToolResponse:
     """Shut down a server.
 
     Args:
@@ -652,8 +669,8 @@ async def update_server(
     name: str | None = None,
     description: str | None = None,
     region: str = '',
-    **kwargs,
-) -> dict[str, Any]:
+    **kwargs: Unpack[ToolKwargs],
+) -> ToolResponse:
     """Update an existing server record.
 
     Args:
@@ -668,17 +685,20 @@ async def update_server(
     """
     token = kwargs.get('token')
 
-    update_data: dict[str, Any] = {}
+    update_data: dict[str, object] = {}
     if name is not None:
         update_data['name'] = name
     if description is not None:
         update_data['description'] = description
 
     if not update_data:
-        return format_validation_error(
-            'name or description',
-            None,
-            'At least one of name or description must be provided.',
+        return cast(
+            ToolResponse,
+            format_validation_error(
+                'name or description',
+                None,
+                'At least one of name or description must be provided.',
+            ),
         )
 
     result = await http_client.patch(
@@ -717,8 +737,8 @@ async def update_server(
     meta={'anthropic/searchHint': 'server unregister deregister delete remove'},
 )
 async def unregister_server(
-    server_id: str, workspace: str, region: str = '', **kwargs
-) -> dict[str, Any]:
+    server_id: str, workspace: str, region: str = '', **kwargs: Unpack[ToolKwargs]
+) -> ToolResponse:
     """Unregister a server from the workspace.
 
     Args:
@@ -764,8 +784,8 @@ async def unregister_server(
     meta={'anthropic/searchHint': 'server star pin favorite bookmark personalization'},
 )
 async def star_server(
-    server_id: str, status: bool, workspace: str, region: str = '', **kwargs
-) -> dict[str, Any]:
+    server_id: str, status: bool, workspace: str, region: str = '', **kwargs: Unpack[ToolKwargs]
+) -> ToolResponse:
     """Set star status on a server.
 
     Args:
@@ -818,8 +838,8 @@ async def list_registration_tokens(
     region: str = '',
     page: int | None = None,
     page_size: int | None = None,
-    **kwargs,
-) -> dict[str, Any]:
+    **kwargs: Unpack[ToolKwargs],
+) -> ToolResponse:
     """List server registration tokens.
 
     Args:
@@ -833,7 +853,7 @@ async def list_registration_tokens(
     """
     token = kwargs.get('token')
 
-    params: dict[str, Any] = {}
+    params: dict[str, object] = {}
     if page is not None:
         params['page'] = page
     if page_size is not None:
@@ -877,8 +897,8 @@ async def create_registration_token(
     name: str,
     description: str | None = None,
     region: str = '',
-    **kwargs,
-) -> dict[str, Any]:
+    **kwargs: Unpack[ToolKwargs],
+) -> ToolResponse:
     """Create a server registration token.
 
     Args:
@@ -892,7 +912,7 @@ async def create_registration_token(
     """
     token = kwargs.get('token')
 
-    data: dict[str, Any] = {'name': name}
+    data: dict[str, object] = {'name': name}
     if description is not None:
         data['description'] = description
 
@@ -927,8 +947,8 @@ async def create_registration_token(
     meta={'anthropic/searchHint': 'registration token delete revoke rotate invalidate'},
 )
 async def delete_registration_token(
-    token_id: str, workspace: str, region: str = '', **kwargs
-) -> dict[str, Any]:
+    token_id: str, workspace: str, region: str = '', **kwargs: Unpack[ToolKwargs]
+) -> ToolResponse:
     """Delete a server registration token.
 
     Args:
@@ -987,8 +1007,8 @@ async def get_registration_guide(
     platform: str,
     server_name: str | None = None,
     region: str = '',
-    **kwargs,
-) -> dict[str, Any]:
+    **kwargs: Unpack[ToolKwargs],
+) -> ToolResponse:
     """Get agent installation guide for a platform and registration token.
 
     Args:
@@ -1010,7 +1030,7 @@ async def get_registration_guide(
     if err:
         return err
 
-    data: dict[str, Any] = {'platform': platform, 'token': token_id}
+    data: dict[str, object] = {'platform': platform, 'token': token_id}
     if server_name is not None:
         data['server_name'] = server_name
 
@@ -1035,21 +1055,27 @@ async def get_registration_guide(
     return success_response(data=result, region=region, workspace=workspace)
 
 
-def _validate_platform(platform: str) -> dict[str, Any] | None:
+def _validate_platform(platform: str) -> ToolResponse | None:
     if platform not in VALID_PLATFORMS:
-        return format_validation_error(
-            'platform',
-            platform,
-            f'Must be one of: {", ".join(sorted(VALID_PLATFORMS))}',
+        return cast(
+            ToolResponse,
+            format_validation_error(
+                'platform',
+                platform,
+                f'Must be one of: {", ".join(sorted(VALID_PLATFORMS))}',
+            ),
         )
     return None
 
 
-def _validate_token_id(token_id: str) -> dict[str, Any] | None:
+def _validate_token_id(token_id: str) -> ToolResponse | None:
     if not validate_server_id_format(token_id):
-        return format_validation_error(
-            'token_id',
-            token_id,
-            'Must be a valid UUID. Example: 550e8400-e29b-41d4-a716-446655440000',
+        return cast(
+            ToolResponse,
+            format_validation_error(
+                'token_id',
+                token_id,
+                'Must be a valid UUID. Example: 550e8400-e29b-41d4-a716-446655440000',
+            ),
         )
     return None

--- a/tools/system_info_tools.py
+++ b/tools/system_info_tools.py
@@ -499,8 +499,7 @@ async def get_server_overview(
     for i, result in enumerate(results):
         key = task_keys[i]
         if isinstance(result, dict) and result.get('status') == 'success':
-            # .get(), not ['data']: 'data' is NotRequired on SuccessResponse,
-            # and ErrorResponse (a union member) doesn't declare it at all.
+            # .get(): 'data' is NotRequired on SuccessResponse.
             overview[key] = result.get('data')
         else:
             overview[key] = {

--- a/tools/system_info_tools.py
+++ b/tools/system_info_tools.py
@@ -499,7 +499,9 @@ async def get_server_overview(
     for i, result in enumerate(results):
         key = task_keys[i]
         if isinstance(result, dict) and result.get('status') == 'success':
-            overview[key] = result['data']
+            # .get(), not ['data']: 'data' is NotRequired on SuccessResponse,
+            # and ErrorResponse (a union member) doesn't declare it at all.
+            overview[key] = result.get('data')
         else:
             overview[key] = {
                 'error': str(result)

--- a/tools/system_info_tools.py
+++ b/tools/system_info_tools.py
@@ -1,8 +1,9 @@
 """System information tools for Alpacon MCP server."""
 
 import asyncio
-from typing import Any
+from typing import Unpack
 
+from utils.api_types import ApiResult, ToolKwargs, ToolResponse
 from utils.common import success_response, unwrap_http_result
 from utils.decorators import mcp_tool_handler
 from utils.http_client import http_client
@@ -15,8 +16,8 @@ from utils.tool_annotations import READ_ONLY
     meta={'anthropic/searchHint': 'system hardware cpu cores ram architecture specs'},
 )
 async def get_system_info(
-    server_id: str, workspace: str, region: str = '', **kwargs
-) -> dict[str, Any]:
+    server_id: str, workspace: str, region: str = '', **kwargs: Unpack[ToolKwargs]
+) -> ToolResponse:
     """Get detailed system information for a server.
 
     Args:
@@ -59,8 +60,8 @@ async def get_system_info(
     meta={'anthropic/searchHint': 'os operating system version kernel distribution'},
 )
 async def get_os_version(
-    server_id: str, workspace: str, region: str = '', **kwargs
-) -> dict[str, Any]:
+    server_id: str, workspace: str, region: str = '', **kwargs: Unpack[ToolKwargs]
+) -> ToolResponse:
     """Get operating system version information for a server.
 
     Args:
@@ -108,8 +109,8 @@ async def list_system_users(
     username_filter: str | None = None,
     login_enabled_only: bool = False,
     region: str = '',
-    **kwargs,
-) -> dict[str, Any]:
+    **kwargs: Unpack[ToolKwargs],
+) -> ToolResponse:
     """List system users on a server.
 
     Args:
@@ -125,7 +126,7 @@ async def list_system_users(
     token = kwargs.get('token')
 
     # Prepare query parameters
-    params = {'server': server_id}
+    params: dict[str, object] = {'server': server_id}
     if username_filter:
         params['search'] = username_filter
     if login_enabled_only:
@@ -170,8 +171,8 @@ async def list_system_groups(
     workspace: str,
     groupname_filter: str | None = None,
     region: str = '',
-    **kwargs,
-) -> dict[str, Any]:
+    **kwargs: Unpack[ToolKwargs],
+) -> ToolResponse:
     """List system groups on a server.
 
     Args:
@@ -186,7 +187,7 @@ async def list_system_groups(
     token = kwargs.get('token')
 
     # Prepare query parameters
-    params = {'server': server_id}
+    params: dict[str, object] = {'server': server_id}
     if groupname_filter:
         params['search'] = groupname_filter
 
@@ -230,8 +231,8 @@ async def list_system_packages(
     architecture: str | None = None,
     limit: int = 100,
     region: str = '',
-    **kwargs,
-) -> dict[str, Any]:
+    **kwargs: Unpack[ToolKwargs],
+) -> ToolResponse:
     """List installed system packages on a server.
 
     Args:
@@ -248,7 +249,7 @@ async def list_system_packages(
     token = kwargs.get('token')
 
     # Prepare query parameters
-    params = {'server': server_id, 'page_size': limit}
+    params: dict[str, object] = {'server': server_id, 'page_size': limit}
     if package_name:
         params['search'] = package_name
     if architecture:
@@ -290,8 +291,8 @@ async def list_system_packages(
     meta={'anthropic/searchHint': 'network interfaces ip mac address mtu'},
 )
 async def get_network_interfaces(
-    server_id: str, workspace: str, region: str = '', **kwargs
-) -> dict[str, Any]:
+    server_id: str, workspace: str, region: str = '', **kwargs: Unpack[ToolKwargs]
+) -> ToolResponse:
     """Get network interfaces information for a server.
 
     Args:
@@ -334,8 +335,8 @@ async def get_network_interfaces(
     meta={'anthropic/searchHint': 'disk partition mount filesystem storage layout'},
 )
 async def get_disk_info(
-    server_id: str, workspace: str, region: str = '', **kwargs
-) -> dict[str, Any]:
+    server_id: str, workspace: str, region: str = '', **kwargs: Unpack[ToolKwargs]
+) -> ToolResponse:
     """Get disk and partition information for a server.
 
     Args:
@@ -366,9 +367,9 @@ async def get_disk_info(
     )
 
     # Wait for both requests
-    gather_results = await asyncio.gather(
-        disks_task, partitions_task, return_exceptions=True
-    )
+    gather_results: tuple[
+        ApiResult | BaseException, ApiResult | BaseException
+    ] = await asyncio.gather(disks_task, partitions_task, return_exceptions=True)
     disks_result, partitions_result = gather_results
 
     # Re-raise BaseExceptions that are not regular Exceptions (e.g. CancelledError)
@@ -377,7 +378,7 @@ async def get_disk_info(
             raise r
 
     # Prepare response
-    disk_info = {
+    disk_info: dict[str, object] = {
         'server_id': server_id,
         'disks': disks_result
         if not isinstance(disks_result, Exception)
@@ -398,8 +399,8 @@ async def get_disk_info(
     meta={'anthropic/searchHint': 'time timezone uptime clock ntp'},
 )
 async def get_system_time(
-    server_id: str, workspace: str, region: str = '', **kwargs
-) -> dict[str, Any]:
+    server_id: str, workspace: str, region: str = '', **kwargs: Unpack[ToolKwargs]
+) -> ToolResponse:
     """Get system time and uptime information for a server.
 
     Args:
@@ -445,8 +446,8 @@ async def get_system_time(
     },
 )
 async def get_server_overview(
-    server_id: str, workspace: str, region: str = '', **kwargs
-) -> dict[str, Any]:
+    server_id: str, workspace: str, region: str = '', **kwargs: Unpack[ToolKwargs]
+) -> ToolResponse:
     """Get comprehensive overview of server system information.
 
     Args:
@@ -470,7 +471,7 @@ async def get_server_overview(
     results = await asyncio.gather(*tasks, return_exceptions=True)
 
     # Prepare overview
-    overview = {
+    overview: dict[str, object] = {
         'server_id': server_id,
         'region': region,
         'workspace': workspace,

--- a/tools/token_tools.py
+++ b/tools/token_tools.py
@@ -11,7 +11,7 @@ check. The scopes and presets catalog endpoints are not subject to
 this restriction.
 """
 
-from typing import Unpack, cast
+from typing import Unpack
 
 from utils.api_types import ToolKwargs, ToolResponse
 from utils.common import error_response, success_response, unwrap_http_result
@@ -37,13 +37,10 @@ _JWT_REQUIRED_NOTE = (
 
 def _validate_token_id(token_id: str) -> ToolResponse | None:
     if not validate_server_id_format(token_id):
-        return cast(
-            ToolResponse,
-            format_validation_error(
-                'token_id',
-                token_id,
-                'Must be a valid UUID. Example: 550e8400-e29b-41d4-a716-446655440000',
-            ),
+        return format_validation_error(
+            'token_id',
+            token_id,
+            'Must be a valid UUID. Example: 550e8400-e29b-41d4-a716-446655440000',
         )
     return None
 

--- a/tools/token_tools.py
+++ b/tools/token_tools.py
@@ -11,8 +11,9 @@ check. The scopes and presets catalog endpoints are not subject to
 this restriction.
 """
 
-from typing import Any
+from typing import Unpack, cast
 
+from utils.api_types import ToolKwargs, ToolResponse
 from utils.common import error_response, success_response, unwrap_http_result
 from utils.decorators import mcp_tool_handler, require_jwt_auth
 from utils.error_handler import format_validation_error, validate_server_id_format
@@ -34,12 +35,15 @@ _JWT_REQUIRED_NOTE = (
 )
 
 
-def _validate_token_id(token_id: str) -> dict[str, Any] | None:
+def _validate_token_id(token_id: str) -> ToolResponse | None:
     if not validate_server_id_format(token_id):
-        return format_validation_error(
-            'token_id',
-            token_id,
-            'Must be a valid UUID. Example: 550e8400-e29b-41d4-a716-446655440000',
+        return cast(
+            ToolResponse,
+            format_validation_error(
+                'token_id',
+                token_id,
+                'Must be a valid UUID. Example: 550e8400-e29b-41d4-a716-446655440000',
+            ),
         )
     return None
 
@@ -64,8 +68,8 @@ async def list_api_tokens(
     remote_ip: str | None = None,
     search: str | None = None,
     ordering: str | None = None,
-    **kwargs,
-) -> dict[str, Any]:
+    **kwargs: Unpack[ToolKwargs],
+) -> ToolResponse:
     """List API tokens.
 
     Args:
@@ -87,7 +91,7 @@ async def list_api_tokens(
     """
     token = kwargs.get('token')
 
-    params: dict[str, Any] = {}
+    params: dict[str, object] = {}
     if page is not None:
         params['page'] = page
     if page_size is not None:
@@ -136,8 +140,8 @@ async def get_api_token(
     token_id: str,
     workspace: str,
     region: str = '',
-    **kwargs,
-) -> dict[str, Any]:
+    **kwargs: Unpack[ToolKwargs],
+) -> ToolResponse:
     """Get a single API token.
 
     Args:
@@ -195,8 +199,8 @@ async def create_api_token(
     enabled: bool | None = None,
     presets: list[str] | None = None,
     region: str = '',
-    **kwargs,
-) -> dict[str, Any]:
+    **kwargs: Unpack[ToolKwargs],
+) -> ToolResponse:
     """Create a new API token.
 
     Args:
@@ -215,7 +219,7 @@ async def create_api_token(
     """
     token = kwargs.get('token')
 
-    token_data: dict[str, Any] = {'name': name}
+    token_data: dict[str, object] = {'name': name}
     if scopes is not None:
         token_data['scopes'] = scopes
     if expires_at is not None:
@@ -267,8 +271,8 @@ async def update_api_token(
     clear_expires_at: bool = False,
     scopes: list[str] | None = None,
     region: str = '',
-    **kwargs,
-) -> dict[str, Any]:
+    **kwargs: Unpack[ToolKwargs],
+) -> ToolResponse:
     """Update an API token via PATCH.
 
     Only the fields you pass are sent; everything else is left untouched
@@ -300,7 +304,7 @@ async def update_api_token(
     if expires_at is not None and clear_expires_at:
         return error_response('expires_at and clear_expires_at are mutually exclusive')
 
-    update_data: dict[str, Any] = {}
+    update_data: dict[str, object] = {}
     if name is not None:
         update_data['name'] = name
     if enabled is not None:
@@ -352,8 +356,8 @@ async def delete_api_token(
     token_id: str,
     workspace: str,
     region: str = '',
-    **kwargs,
-) -> dict[str, Any]:
+    **kwargs: Unpack[ToolKwargs],
+) -> ToolResponse:
     """Delete an API token.
 
     Args:
@@ -408,8 +412,8 @@ async def duplicate_api_token(
     workspace: str,
     name: str | None = None,
     region: str = '',
-    **kwargs,
-) -> dict[str, Any]:
+    **kwargs: Unpack[ToolKwargs],
+) -> ToolResponse:
     """Duplicate an API token.
 
     The duplicate inherits all configuration (scopes, expiry) from the source
@@ -430,7 +434,7 @@ async def duplicate_api_token(
     if err:
         return err
 
-    data: dict[str, Any] = {}
+    data: dict[str, object] = {}
     if name is not None:
         data['name'] = name
 
@@ -465,8 +469,8 @@ async def duplicate_api_token(
 async def list_api_token_scopes(
     workspace: str,
     region: str = '',
-    **kwargs,
-) -> dict[str, Any]:
+    **kwargs: Unpack[ToolKwargs],
+) -> ToolResponse:
     """List available API token scopes.
 
     Args:
@@ -505,8 +509,8 @@ async def list_api_token_scopes(
 async def list_api_token_presets(
     workspace: str,
     region: str = '',
-    **kwargs,
-) -> dict[str, Any]:
+    **kwargs: Unpack[ToolKwargs],
+) -> ToolResponse:
     """List available API token scope presets.
 
     Args:

--- a/tools/webftp_tools.py
+++ b/tools/webftp_tools.py
@@ -64,7 +64,7 @@ class _LocalSaveError(Exception):
 
 
 def _validation_error(field: str, value: object) -> ToolResponse:
-    """Thin typed wrapper over format_validation_error (declared dict[str, Any])."""
+    """Thin typed wrapper over format_validation_error (declared dict[str, object])."""
     return cast(ToolResponse, format_validation_error(field, value))
 
 

--- a/tools/webftp_tools.py
+++ b/tools/webftp_tools.py
@@ -5,12 +5,14 @@ import base64
 import binascii
 import os
 import shlex
+from collections.abc import AsyncIterator
 from http import HTTPStatus
 from pathlib import Path
-from typing import Any, cast
+from typing import Unpack, cast
 
 import httpx
 
+from utils.api_types import ApiPayload, ToolKwargs, ToolResponse
 from utils.common import (
     error_response,
     resolve_work_session_id,
@@ -59,6 +61,11 @@ class _S3DownloadError(Exception):
 
 class _LocalSaveError(Exception):
     pass
+
+
+def _validation_error(field: str, value: object) -> ToolResponse:
+    """Thin typed wrapper over format_validation_error (declared dict[str, Any])."""
+    return cast(ToolResponse, format_validation_error(field, value))
 
 
 async def _stream_s3_to_file(
@@ -125,7 +132,9 @@ async def _save_stream(response: httpx.Response, local_path: str) -> int:
     return file_size
 
 
-async def _aiter_file(path: str, chunk_size: int = _CHUNK_SIZE):
+async def _aiter_file(
+    path: str, chunk_size: int = _CHUNK_SIZE
+) -> AsyncIterator[bytes]:
     """Yield file chunks for streaming uploads. Single-shot: not replayable on retry."""
     src_file = await asyncio.to_thread(open, path, 'rb')
     try:
@@ -154,13 +163,13 @@ async def _download_remote_mode(
     username: str | None,
     work_session_id: str | None,
     token: str,
-) -> dict[str, Any]:
+) -> ToolResponse:
     """Handle webftp_download_file in remote mode: poll until ready, return presigned URL."""
     file_name = os.path.basename(remote_file_path)
     if resource_type == 'folder':
         file_name += '.zip'
 
-    download_data: dict[str, Any] = {
+    download_data: dict[str, object] = {
         'server': server_id,
         'path': remote_file_path,
         'name': file_name,
@@ -188,10 +197,11 @@ async def _download_remote_mode(
     ):
         return err
 
-    download_url = result.get('download_url')
+    payload = cast(dict[str, object], result)
+    download_url = payload.get('download_url')
 
     if not download_url:
-        file_id = result.get('id')
+        file_id = cast(str, payload.get('id'))
         for _ in range(_REMOTE_DOWNLOAD_TIMEOUT):
             await asyncio.sleep(1)
             status = await http_client.get(
@@ -206,12 +216,13 @@ async def _download_remote_mode(
                 file_id=file_id,
             ):
                 return err
-            if status.get('success') is True:
-                download_url = status.get('download_url')
+            status_payload = cast(dict[str, object], status)
+            if status_payload.get('success') is True:
+                download_url = status_payload.get('download_url')
                 break
-            elif status.get('success') is False:
+            elif status_payload.get('success') is False:
                 return error_response(
-                    f'Server failed to process download: {status.get("message", "unknown error")}',
+                    f'Server failed to process download: {status_payload.get("message", "unknown error")}',
                     file_id=file_id,
                     code='download_failed',
                 )
@@ -229,7 +240,7 @@ async def _download_remote_mode(
         server_id=server_id,
         remote_file_path=remote_file_path,
         resource_type=resource_type,
-        download_url=download_url,
+        download_url=cast(str, download_url),
         expires_in='24 hours',
         tip=f'curl -o {shlex.quote(file_name)} {shlex.quote(cast(str, download_url))}',
         region=region,
@@ -248,12 +259,12 @@ async def webftp_session_create(
     username: str | None = None,
     work_session_id: str | None = None,
     region: str = '',
-    **kwargs,
-) -> dict[str, Any]:
+    **kwargs: Unpack[ToolKwargs],
+) -> ToolResponse:
     """Create a new WebFTP session."""
     token = kwargs.get('token')
 
-    session_data = {'server': server_id}
+    session_data: dict[str, object] = {'server': server_id}
     if username:
         session_data['username'] = username
     if ws_id := resolve_work_session_id(work_session_id):
@@ -291,12 +302,15 @@ async def webftp_session_create(
     meta={'anthropic/searchHint': 'webftp sessions list active file transfer'},
 )
 async def webftp_sessions_list(
-    workspace: str, server_id: str | None = None, region: str = '', **kwargs
-) -> dict[str, Any]:
+    workspace: str,
+    server_id: str | None = None,
+    region: str = '',
+    **kwargs: Unpack[ToolKwargs],
+) -> ToolResponse:
     """Get list of WebFTP sessions."""
     token = kwargs.get('token')
 
-    params = {}
+    params: dict[str, object] = {}
     if server_id:
         params['server'] = server_id
 
@@ -336,8 +350,8 @@ async def webftp_upload_file(
     work_session_id: str | None = None,
     region: str = '',
     allow_overwrite: bool = True,
-    **kwargs,
-) -> dict[str, Any]:
+    **kwargs: Unpack[ToolKwargs],
+) -> ToolResponse:
     """Upload a local file to a server via S3 presigned URL."""
     token = kwargs.get('token')
 
@@ -345,9 +359,9 @@ async def webftp_upload_file(
         return error_response(_REMOTE_MODE_ERROR, code='remote_mode_unsupported')
 
     if not validate_file_path(local_file_path):
-        return format_validation_error('local_file_path', local_file_path)
+        return _validation_error('local_file_path', local_file_path)
     if not validate_file_path(remote_file_path):
-        return format_validation_error('remote_file_path', remote_file_path)
+        return _validation_error('remote_file_path', remote_file_path)
 
     try:
         file_content = await asyncio.to_thread(Path(local_file_path).read_bytes)
@@ -356,7 +370,7 @@ async def webftp_upload_file(
     except Exception as e:
         return error_response(f'Failed to read local file: {str(e)}')
 
-    upload_data = {
+    upload_data: dict[str, object] = {
         'server': server_id,
         'name': os.path.basename(remote_file_path),
         'path': remote_file_path,
@@ -384,15 +398,17 @@ async def webftp_upload_file(
     ):
         return http_err
 
-    if result.get('upload_url'):
-        err = await _upload_bytes_to_s3(result['upload_url'], file_content)
+    payload = cast(dict[str, object], result)
+    if payload.get('upload_url'):
+        upload_url = cast(str, payload['upload_url'])
+        err = await _upload_bytes_to_s3(upload_url, file_content)
         if err:
-            return error_response(err, upload_url=result['upload_url'])
+            return error_response(err, upload_url=upload_url)
 
         upload_trigger = await http_client.get(
             region=region,
             workspace=workspace,
-            endpoint=f'{_API_UPLOADS}{result["id"]}/upload/',
+            endpoint=f'{_API_UPLOADS}{payload["id"]}/upload/',
             token=token,
         )
 
@@ -412,8 +428,8 @@ async def webftp_upload_file(
             local_file_path=local_file_path,
             remote_file_path=remote_file_path,
             file_size=len(file_content),
-            upload_url=result['upload_url'],
-            download_url=result.get('download_url'),
+            upload_url=upload_url,
+            download_url=cast(str | None, payload.get('download_url')),
             region=region,
             workspace=workspace,
         )
@@ -451,8 +467,8 @@ async def webftp_upload_content(
     work_session_id: str | None = None,
     region: str = '',
     allow_overwrite: bool = True,
-    **kwargs,
-) -> dict[str, Any]:
+    **kwargs: Unpack[ToolKwargs],
+) -> ToolResponse:
     """Upload base64-encoded file content to a server via WebFTP."""
     token = kwargs.get('token')
 
@@ -462,11 +478,11 @@ async def webftp_upload_content(
         return error_response(f'Invalid base64 content: {exc}', code='invalid_content')
 
     if not validate_file_path(remote_file_path):
-        return format_validation_error('remote_file_path', remote_file_path)
+        return _validation_error('remote_file_path', remote_file_path)
 
     name = file_name or os.path.basename(remote_file_path)
 
-    upload_data: dict[str, Any] = {
+    upload_data: dict[str, object] = {
         'server': server_id,
         'name': name,
         'path': remote_file_path,
@@ -494,15 +510,17 @@ async def webftp_upload_content(
     ):
         return http_err
 
-    if result.get('upload_url'):
-        err = await _upload_bytes_to_s3(result['upload_url'], raw_bytes)
+    payload = cast(dict[str, object], result)
+    if payload.get('upload_url'):
+        upload_url = cast(str, payload['upload_url'])
+        err = await _upload_bytes_to_s3(upload_url, raw_bytes)
         if err:
-            return error_response(err, upload_url=result['upload_url'])
+            return error_response(err, upload_url=upload_url)
 
         upload_trigger = await http_client.get(
             region=region,
             workspace=workspace,
-            endpoint=f'{_API_UPLOADS}{result["id"]}/upload/',
+            endpoint=f'{_API_UPLOADS}{payload["id"]}/upload/',
             token=token,
         )
 
@@ -521,7 +539,7 @@ async def webftp_upload_content(
             server_id=server_id,
             remote_file_path=remote_file_path,
             file_size=len(raw_bytes),
-            upload_url=result['upload_url'],
+            upload_url=upload_url,
             region=region,
             workspace=workspace,
         )
@@ -565,15 +583,15 @@ async def webftp_download_file(
     username: str | None = None,
     work_session_id: str | None = None,
     region: str = '',
-    **kwargs,
-) -> dict[str, Any]:
+    **kwargs: Unpack[ToolKwargs],
+) -> ToolResponse:
     """Download a file or folder from a server via S3 presigned URL."""
     token = kwargs.get('token')
     if not isinstance(token, str) or not token:
         raise RuntimeError('token must be injected by mcp_tool_handler')
 
     if not validate_file_path(remote_file_path):
-        return format_validation_error('remote_file_path', remote_file_path)
+        return _validation_error('remote_file_path', remote_file_path)
 
     if _is_auth_enabled():
         return await _download_remote_mode(
@@ -590,13 +608,13 @@ async def webftp_download_file(
     if local_file_path is None:
         return error_response('local_file_path is required in local mode')
     if not validate_file_path(local_file_path):
-        return format_validation_error('local_file_path', local_file_path)
+        return _validation_error('local_file_path', local_file_path)
 
     file_name = os.path.basename(remote_file_path)
     if resource_type == 'folder':
         file_name += '.zip'
 
-    download_data = {
+    download_data: dict[str, object] = {
         'server': server_id,
         'path': remote_file_path,
         'name': file_name,
@@ -625,15 +643,15 @@ async def webftp_download_file(
     ):
         return err
 
-    if result.get('download_url'):
+    payload = cast(dict[str, object], result)
+    if payload.get('download_url'):
+        download_url = cast(str, payload['download_url'])
         try:
-            file_size = await _stream_s3_to_file(
-                result['download_url'], cast(str, local_file_path)
-            )
+            file_size = await _stream_s3_to_file(download_url, local_file_path)
         except _S3DownloadError as e:
             return error_response(
                 f'Failed to download from S3: {e}',
-                download_url=result['download_url'],
+                download_url=download_url,
             )
         except _LocalSaveError as e:
             return error_response(f'Failed to save file locally: {e}')
@@ -646,7 +664,7 @@ async def webftp_download_file(
             local_file_path=local_file_path,
             resource_type=resource_type,
             file_size=file_size,
-            download_url=result.get('download_url'),
+            download_url=download_url,
             region=region,
             workspace=workspace,
         )
@@ -668,12 +686,15 @@ async def webftp_download_file(
     meta={'anthropic/searchHint': 'webftp uploads history list files'},
 )
 async def webftp_uploads_list(
-    workspace: str, server_id: str | None = None, region: str = '', **kwargs
-) -> dict[str, Any]:
+    workspace: str,
+    server_id: str | None = None,
+    region: str = '',
+    **kwargs: Unpack[ToolKwargs],
+) -> ToolResponse:
     """List uploaded files (upload history)."""
     token = kwargs.get('token')
 
-    params = {}
+    params: dict[str, object] = {}
     if server_id:
         params['server'] = server_id
 
@@ -705,12 +726,15 @@ async def webftp_uploads_list(
     meta={'anthropic/searchHint': 'webftp downloads history list files'},
 )
 async def webftp_downloads_list(
-    workspace: str, server_id: str | None = None, region: str = '', **kwargs
-) -> dict[str, Any]:
+    workspace: str,
+    server_id: str | None = None,
+    region: str = '',
+    **kwargs: Unpack[ToolKwargs],
+) -> ToolResponse:
     """List download requests (download history)."""
     token = kwargs.get('token')
 
-    params = {}
+    params: dict[str, object] = {}
     if server_id:
         params['server'] = server_id
 
@@ -750,8 +774,8 @@ async def webftp_bulk_upload(
     work_session_id: str | None = None,
     region: str = '',
     allow_overwrite: bool = True,
-    **kwargs,
-) -> dict[str, Any]:
+    **kwargs: Unpack[ToolKwargs],
+) -> ToolResponse:
     """Upload multiple files to a server using bulk WebFTP API."""
     token = kwargs.get('token')
 
@@ -763,16 +787,16 @@ async def webftp_bulk_upload(
 
     for path in local_file_paths:
         if not validate_file_path(path):
-            return format_validation_error('local_file_paths', path)
+            return _validation_error('local_file_paths', path)
         if not await asyncio.to_thread(Path(path).is_file):
             return error_response(f'Local file is not a regular file: {path}')
         if not await asyncio.to_thread(os.access, path, os.R_OK):
             return error_response(f'Local file is not readable: {path}')
     if not validate_file_path(remote_directory):
-        return format_validation_error('remote_directory', remote_directory)
+        return _validation_error('remote_directory', remote_directory)
 
     file_names = [os.path.basename(p) for p in local_file_paths]
-    bulk_data: dict[str, Any] = {
+    bulk_data: dict[str, object] = {
         'server': server_id,
         'path': remote_directory,
         'names': file_names,
@@ -800,10 +824,9 @@ async def webftp_bulk_upload(
     ):
         return err
 
-    file_ids = []
-    upload_items = (
-        result if isinstance(result, list) else result.get('results', [result])
-    )
+    file_ids: list[object] = []
+    payload = cast(ApiPayload, result)
+    upload_items = payload if isinstance(payload, list) else payload.get('results', [payload])
 
     for item in upload_items:
         file_id = item.get('id')
@@ -815,10 +838,10 @@ async def webftp_bulk_upload(
     async def _upload_one(
         client: httpx.AsyncClient,
         idx: int,
-        item: dict,
-    ) -> dict[str, Any]:
+        item: dict[str, object],
+    ) -> _UploadResult:
         upload_url = item.get('upload_url')
-        file_id = item.get('id')
+        file_id = cast(str | int | None, item.get('id'))
         name = file_names[idx] if idx < len(file_names) else _UNKNOWN_FILE
 
         if not upload_url or idx >= len(local_file_paths):
@@ -827,7 +850,7 @@ async def webftp_bulk_upload(
         async with semaphore:
             try:
                 resp = await client.put(
-                    upload_url,
+                    cast(str, upload_url),
                     content=_aiter_file(local_file_paths[idx]),
                 )
                 file_size = (
@@ -911,8 +934,8 @@ async def webftp_bulk_download(
     username: str | None = None,
     work_session_id: str | None = None,
     region: str = '',
-    **kwargs,
-) -> dict[str, Any]:
+    **kwargs: Unpack[ToolKwargs],
+) -> ToolResponse:
     """Download multiple files/folders as a ZIP archive."""
     token = kwargs.get('token')
 
@@ -924,9 +947,9 @@ async def webftp_bulk_download(
 
     for path in remote_paths:
         if not validate_file_path(path):
-            return format_validation_error('remote_paths', path)
+            return _validation_error('remote_paths', path)
     if not validate_file_path(local_file_path):
-        return format_validation_error('local_file_path', local_file_path)
+        return _validation_error('local_file_path', local_file_path)
 
     if len(remote_paths) > 1:
         base_dir = os.path.dirname(remote_paths[0])
@@ -937,7 +960,7 @@ async def webftp_bulk_download(
                     remote_paths=remote_paths,
                 )
 
-    download_data: dict[str, Any] = {
+    download_data: dict[str, object] = {
         'server': server_id,
         'path': remote_paths,
     }
@@ -963,7 +986,12 @@ async def webftp_bulk_download(
     ):
         return err
 
-    download_url = result.get('download_url') if isinstance(result, dict) else None
+    payload = cast(dict[str, object], result)
+    download_url = (
+        cast(str | None, payload.get('download_url'))
+        if isinstance(payload, dict)
+        else None
+    )
     if download_url:
         try:
             file_size = await _stream_s3_to_file(
@@ -1009,8 +1037,8 @@ async def webftp_check_status(
     transfer_type: str,
     workspace: str,
     region: str = '',
-    **kwargs,
-) -> dict[str, Any]:
+    **kwargs: Unpack[ToolKwargs],
+) -> ToolResponse:
     """Check status of a WebFTP file transfer."""
     token = kwargs.get('token')
 

--- a/tools/webftp_tools.py
+++ b/tools/webftp_tools.py
@@ -63,11 +63,6 @@ class _LocalSaveError(Exception):
     pass
 
 
-def _validation_error(field: str, value: object) -> ToolResponse:
-    """Thin typed wrapper over format_validation_error (declared dict[str, object])."""
-    return cast(ToolResponse, format_validation_error(field, value))
-
-
 async def _stream_s3_to_file(
     url: str,
     local_path: str,
@@ -132,9 +127,7 @@ async def _save_stream(response: httpx.Response, local_path: str) -> int:
     return file_size
 
 
-async def _aiter_file(
-    path: str, chunk_size: int = _CHUNK_SIZE
-) -> AsyncIterator[bytes]:
+async def _aiter_file(path: str, chunk_size: int = _CHUNK_SIZE) -> AsyncIterator[bytes]:
     """Yield file chunks for streaming uploads. Single-shot: not replayable on retry."""
     src_file = await asyncio.to_thread(open, path, 'rb')
     try:
@@ -359,9 +352,9 @@ async def webftp_upload_file(
         return error_response(_REMOTE_MODE_ERROR, code='remote_mode_unsupported')
 
     if not validate_file_path(local_file_path):
-        return _validation_error('local_file_path', local_file_path)
+        return format_validation_error('local_file_path', local_file_path)
     if not validate_file_path(remote_file_path):
-        return _validation_error('remote_file_path', remote_file_path)
+        return format_validation_error('remote_file_path', remote_file_path)
 
     try:
         file_content = await asyncio.to_thread(Path(local_file_path).read_bytes)
@@ -478,7 +471,7 @@ async def webftp_upload_content(
         return error_response(f'Invalid base64 content: {exc}', code='invalid_content')
 
     if not validate_file_path(remote_file_path):
-        return _validation_error('remote_file_path', remote_file_path)
+        return format_validation_error('remote_file_path', remote_file_path)
 
     name = file_name or os.path.basename(remote_file_path)
 
@@ -591,7 +584,7 @@ async def webftp_download_file(
         raise RuntimeError('token must be injected by mcp_tool_handler')
 
     if not validate_file_path(remote_file_path):
-        return _validation_error('remote_file_path', remote_file_path)
+        return format_validation_error('remote_file_path', remote_file_path)
 
     if _is_auth_enabled():
         return await _download_remote_mode(
@@ -608,7 +601,7 @@ async def webftp_download_file(
     if local_file_path is None:
         return error_response('local_file_path is required in local mode')
     if not validate_file_path(local_file_path):
-        return _validation_error('local_file_path', local_file_path)
+        return format_validation_error('local_file_path', local_file_path)
 
     file_name = os.path.basename(remote_file_path)
     if resource_type == 'folder':
@@ -787,13 +780,13 @@ async def webftp_bulk_upload(
 
     for path in local_file_paths:
         if not validate_file_path(path):
-            return _validation_error('local_file_paths', path)
+            return format_validation_error('local_file_paths', path)
         if not await asyncio.to_thread(Path(path).is_file):
             return error_response(f'Local file is not a regular file: {path}')
         if not await asyncio.to_thread(os.access, path, os.R_OK):
             return error_response(f'Local file is not readable: {path}')
     if not validate_file_path(remote_directory):
-        return _validation_error('remote_directory', remote_directory)
+        return format_validation_error('remote_directory', remote_directory)
 
     file_names = [os.path.basename(p) for p in local_file_paths]
     bulk_data: dict[str, object] = {
@@ -826,7 +819,9 @@ async def webftp_bulk_upload(
 
     file_ids: list[object] = []
     payload = cast(ApiPayload, result)
-    upload_items = payload if isinstance(payload, list) else payload.get('results', [payload])
+    upload_items = (
+        payload if isinstance(payload, list) else payload.get('results', [payload])
+    )
 
     for item in upload_items:
         file_id = item.get('id')
@@ -947,9 +942,9 @@ async def webftp_bulk_download(
 
     for path in remote_paths:
         if not validate_file_path(path):
-            return _validation_error('remote_paths', path)
+            return format_validation_error('remote_paths', path)
     if not validate_file_path(local_file_path):
-        return _validation_error('local_file_path', local_file_path)
+        return format_validation_error('local_file_path', local_file_path)
 
     if len(remote_paths) > 1:
         base_dir = os.path.dirname(remote_paths[0])
@@ -986,7 +981,7 @@ async def webftp_bulk_download(
     ):
         return err
 
-    payload = cast(dict[str, object], result)
+    payload = cast(ApiPayload, result)
     download_url = (
         cast(str | None, payload.get('download_url'))
         if isinstance(payload, dict)

--- a/tools/webhook_tools.py
+++ b/tools/webhook_tools.py
@@ -1,7 +1,8 @@
 """Webhook and event subscription tools for Alpacon MCP server."""
 
-from typing import Any
+from typing import Unpack
 
+from utils.api_types import ToolKwargs, ToolResponse
 from utils.common import error_response, success_response, unwrap_http_result
 from utils.decorators import mcp_tool_handler
 from utils.http_client import http_client
@@ -22,8 +23,8 @@ async def list_event_subscriptions(
     region: str = '',
     page: int | None = None,
     page_size: int | None = None,
-    **kwargs,
-) -> dict[str, Any]:
+    **kwargs: Unpack[ToolKwargs],
+) -> ToolResponse:
     """List event subscriptions.
 
     Args:
@@ -37,7 +38,7 @@ async def list_event_subscriptions(
     """
     token = kwargs.get('token')
 
-    params: dict[str, Any] = {}
+    params: dict[str, object] = {}
     if page is not None:
         params['page'] = page
     if page_size is not None:
@@ -65,8 +66,8 @@ async def create_event_subscription(
     event_type: str,
     target_id: str | None = None,
     region: str = '',
-    **kwargs,
-) -> dict[str, Any]:
+    **kwargs: Unpack[ToolKwargs],
+) -> ToolResponse:
     """Create an event subscription.
 
     Args:
@@ -81,7 +82,7 @@ async def create_event_subscription(
     """
     token = kwargs.get('token')
 
-    subscription_data: dict[str, Any] = {
+    subscription_data: dict[str, object] = {
         'channel': channel,
         'event_type': event_type,
     }
@@ -106,8 +107,11 @@ async def create_event_subscription(
     meta={'anthropic/searchHint': 'event subscription delete remove'},
 )
 async def delete_event_subscription(
-    subscription_id: str, workspace: str, region: str = '', **kwargs
-) -> dict[str, Any]:
+    subscription_id: str,
+    workspace: str,
+    region: str = '',
+    **kwargs: Unpack[ToolKwargs],
+) -> ToolResponse:
     """Delete an event subscription.
 
     Args:
@@ -150,8 +154,8 @@ async def list_webhooks(
     region: str = '',
     page: int | None = None,
     page_size: int | None = None,
-    **kwargs,
-) -> dict[str, Any]:
+    **kwargs: Unpack[ToolKwargs],
+) -> ToolResponse:
     """List webhooks.
 
     Args:
@@ -165,7 +169,7 @@ async def list_webhooks(
     """
     token = kwargs.get('token')
 
-    params: dict[str, Any] = {}
+    params: dict[str, object] = {}
     if page is not None:
         params['page'] = page
     if page_size is not None:
@@ -193,8 +197,8 @@ async def list_webhooks(
     meta={'anthropic/searchHint': 'webhook detail describe single get'},
 )
 async def get_webhook(
-    webhook_id: str, workspace: str, region: str = '', **kwargs
-) -> dict[str, Any]:
+    webhook_id: str, workspace: str, region: str = '', **kwargs: Unpack[ToolKwargs]
+) -> ToolResponse:
     """Get a single webhook by ID.
 
     Args:
@@ -241,8 +245,8 @@ async def create_webhook(
     ssl_verify: bool = True,
     enabled: bool = True,
     region: str = '',
-    **kwargs,
-) -> dict[str, Any]:
+    **kwargs: Unpack[ToolKwargs],
+) -> ToolResponse:
     """Create a webhook.
 
     Args:
@@ -258,7 +262,7 @@ async def create_webhook(
     """
     token = kwargs.get('token')
 
-    webhook_data: dict[str, Any] = {
+    webhook_data: dict[str, object] = {
         'name': name,
         'url': url,
         'ssl_verify': ssl_verify,
@@ -289,8 +293,8 @@ async def update_webhook(
     ssl_verify: bool | None = None,
     enabled: bool | None = None,
     region: str = '',
-    **kwargs,
-) -> dict[str, Any]:
+    **kwargs: Unpack[ToolKwargs],
+) -> ToolResponse:
     """Update an existing webhook.
 
     Args:
@@ -307,7 +311,7 @@ async def update_webhook(
     """
     token = kwargs.get('token')
 
-    update_data: dict[str, Any] = {}
+    update_data: dict[str, object] = {}
     if name is not None:
         update_data['name'] = name
     if url is not None:
@@ -339,8 +343,8 @@ async def update_webhook(
     meta={'anthropic/searchHint': 'webhook delete remove'},
 )
 async def delete_webhook(
-    webhook_id: str, workspace: str, region: str = '', **kwargs
-) -> dict[str, Any]:
+    webhook_id: str, workspace: str, region: str = '', **kwargs: Unpack[ToolKwargs]
+) -> ToolResponse:
     """Delete a webhook.
 
     Args:

--- a/tools/work_session_tools.py
+++ b/tools/work_session_tools.py
@@ -81,7 +81,7 @@ async def work_session_create(
     # to run commands against a session that is not yet active.
     payload = cast(ApiPayload, result)
     if isinstance(payload, dict) and payload.get('status') == 'pending':
-        session_id = cast('str | None', payload.get('id'))
+        session_id = cast(str | None, payload.get('id'))
         return pending_approval_response(
             'This Work Session was created but is pending human approval. A '
             'human must approve it out-of-band (Alpacon web console or Slack) '

--- a/tools/work_session_tools.py
+++ b/tools/work_session_tools.py
@@ -1,7 +1,8 @@
 """Work Session management tools for Alpacon MCP server."""
 
-from typing import Any
+from typing import Unpack, cast
 
+from utils.api_types import ApiPayload, ToolKwargs, ToolResponse
 from utils.common import (
     error_response,
     pending_approval_response,
@@ -42,12 +43,12 @@ async def work_session_create(
     description: str,
     title: str | None = None,
     region: str = '',
-    **kwargs,
-) -> dict[str, Any]:
+    **kwargs: Unpack[ToolKwargs],
+) -> ToolResponse:
     """Create a Work Session for auditable, approval-gated infrastructure access."""
     token = kwargs.get('token')
 
-    data: dict[str, str | list[str]] = {
+    data: dict[str, object] = {
         'requester_type': 'agent',
         'scopes': scopes,
         'servers': servers,
@@ -78,8 +79,9 @@ async def work_session_create(
     # transfer) is allowed (ADR 0015). Surface that as a structured
     # pending-approval signal so the agent waits/escalates instead of proceeding
     # to run commands against a session that is not yet active.
-    if isinstance(result, dict) and result.get('status') == 'pending':
-        session_id = result.get('id')
+    payload = cast(ApiPayload, result)
+    if isinstance(payload, dict) and payload.get('status') == 'pending':
+        session_id = cast('str | None', payload.get('id'))
         return pending_approval_response(
             'This Work Session was created but is pending human approval. A '
             'human must approve it out-of-band (Alpacon web console or Slack) '
@@ -108,8 +110,8 @@ async def work_session_close(
     session_id: str,
     workspace: str,
     region: str = '',
-    **kwargs,
-) -> dict[str, Any]:
+    **kwargs: Unpack[ToolKwargs],
+) -> ToolResponse:
     """Complete a Work Session."""
     token = kwargs.get('token')
 
@@ -148,8 +150,8 @@ async def work_session_get(
     session_id: str,
     workspace: str,
     region: str = '',
-    **kwargs,
-) -> dict[str, Any]:
+    **kwargs: Unpack[ToolKwargs],
+) -> ToolResponse:
     """Get detailed information about a specific Work Session."""
     token = kwargs.get('token')
 
@@ -191,12 +193,12 @@ async def work_session_list(
     requester_type: str | None = None,
     limit: int = 20,
     region: str = '',
-    **kwargs,
-) -> dict[str, Any]:
+    **kwargs: Unpack[ToolKwargs],
+) -> ToolResponse:
     """List Work Sessions with optional status and requester_type filtering."""
     token = kwargs.get('token')
 
-    params: dict[str, str | int] = {'page_size': limit}
+    params: dict[str, object] = {'page_size': limit}
     if status:
         params['status'] = status
     if requester_type:
@@ -249,12 +251,12 @@ async def work_session_update(
     servers: list[str] | None = None,
     expires_at: str | None = None,
     region: str = '',
-    **kwargs,
-) -> dict[str, Any]:
+    **kwargs: Unpack[ToolKwargs],
+) -> ToolResponse:
     """Partially update a Work Session."""
     token = kwargs.get('token')
 
-    data: dict[str, str | list[str]] = {}
+    data: dict[str, object] = {}
     if title is not None:
         data['title'] = title
     if description is not None:
@@ -293,7 +295,10 @@ async def work_session_update(
         return err
 
     # Queued modification (server 202): http_client hides 2xx status codes, so branch on the body marker (ADR 0015).
-    if isinstance(result, dict) and result.get('pending_modification_request'):
+    update_payload = cast(ApiPayload, result)
+    if isinstance(update_payload, dict) and update_payload.get(
+        'pending_modification_request'
+    ):
         return pending_approval_response(
             'This update was queued as a modification request and is pending '
             'human approval. A human must approve it out-of-band (Alpacon web '
@@ -328,8 +333,8 @@ async def work_session_extend(
     workspace: str,
     expires_at: str,
     region: str = '',
-    **kwargs,
-) -> dict[str, Any]:
+    **kwargs: Unpack[ToolKwargs],
+) -> ToolResponse:
     """Extend a Work Session's expiry time."""
     token = kwargs.get('token')
 
@@ -373,8 +378,8 @@ async def work_session_timeline(
     workspace: str,
     include_records: bool = True,
     region: str = '',
-    **kwargs,
-) -> dict[str, Any]:
+    **kwargs: Unpack[ToolKwargs],
+) -> ToolResponse:
     """Get the unified timeline of a Work Session."""
     token = kwargs.get('token')
 
@@ -420,8 +425,8 @@ async def work_session_analyze(
     workspace: str,
     force: bool = False,
     region: str = '',
-    **kwargs,
-) -> dict[str, Any]:
+    **kwargs: Unpack[ToolKwargs],
+) -> ToolResponse:
     """Manually trigger AI analysis for a terminal Work Session."""
     token = kwargs.get('token')
 

--- a/tools/workspace_tools.py
+++ b/tools/workspace_tools.py
@@ -1,20 +1,30 @@
 """Workspace management tools for Alpacon MCP server."""
 
-from typing import Any
+from typing import TypedDict, Unpack
 
 from mcp.types import ToolAnnotations
 
 from server import mcp
+from utils.api_types import ToolKwargs, ToolResponse
 from utils.common import error_response, success_response, unwrap_http_result
 from utils.decorators import mcp_tool_handler
 from utils.http_client import http_client
 from utils.tool_annotations import READ_ONLY
 
 
+class WorkspaceEntry(TypedDict):
+    """Single workspace entry derived from token.json data."""
+
+    workspace: str
+    region: str
+    has_token: bool
+    domain: str
+
+
 def _collect_workspaces_from_tokens(
-    all_tokens: dict[str, Any],
+    all_tokens: dict[str, object],
     target_region: str = '',
-) -> list[dict[str, Any]]:
+) -> list[WorkspaceEntry]:
     """Collect workspace info from token.json data.
 
     Args:
@@ -24,7 +34,7 @@ def _collect_workspaces_from_tokens(
     Returns:
         List of workspace info dicts
     """
-    workspaces = []
+    workspaces: list[WorkspaceEntry] = []
     for region_key, region_data in all_tokens.items():
         if target_region and region_key != target_region:
             continue
@@ -64,7 +74,7 @@ def _collect_workspaces_from_tokens(
         'anthropic/searchHint': 'workspace list regions configured available',
     },
 )
-async def list_workspaces(region: str = '') -> dict[str, Any]:
+async def list_workspaces(region: str = '') -> ToolResponse:
     """Get list of available workspaces.
 
     In local (stdio/SSE) mode, reads from token.json. If region is not specified,
@@ -90,13 +100,13 @@ async def list_workspaces(region: str = '') -> dict[str, Any]:
             )
         # Server mode: extract workspaces from JWT claims
         jwt_workspaces = _get_jwt_workspaces(jwt_token)
-        workspaces = []
+        jwt_ws_list: list[dict[str, str]] = []
         for ws in jwt_workspaces:
             ws_name = ws.get('schema_name', '')
             ws_region = ws.get('region', '')
             if region and ws_region != region:
                 continue
-            workspaces.append(
+            jwt_ws_list.append(
                 {
                     'workspace': ws_name,
                     'region': ws_region,
@@ -107,7 +117,7 @@ async def list_workspaces(region: str = '') -> dict[str, Any]:
 
         return success_response(
             data={
-                'workspaces': workspaces,
+                'workspaces': jwt_ws_list,
                 'source': 'jwt',
                 'region': region or 'all',
             },
@@ -144,8 +154,8 @@ async def list_workspaces(region: str = '') -> dict[str, Any]:
     },
 )
 async def get_current_user(
-    workspace: str, region: str = '', **kwargs
-) -> dict[str, Any]:
+    workspace: str, region: str = '', **kwargs: Unpack[ToolKwargs]
+) -> ToolResponse:
     """Get the currently authenticated user.
 
     Args:

--- a/utils/api_types.py
+++ b/utils/api_types.py
@@ -1,0 +1,158 @@
+"""Shared type definitions for tool responses and API-boundary payloads.
+
+``Any`` is quarantined in this module: ``ApiPayload`` (and the other
+aliases below) are the only sanctioned appearances of ``Any`` in the
+codebase. Every other module imports these aliases instead of using
+``Any`` directly, so untyped data can only enter through named boundary
+functions typed with these aliases.
+"""
+
+from collections.abc import MutableMapping
+from typing import Any, Literal, NotRequired, TypedDict, TypeGuard
+
+# Raw JSON crossing the Alpacon API boundary. The single sanctioned Any.
+type ApiPayload = dict[str, Any] | list[Any]
+
+# Decoded JWT claims from Auth0 (external schema, not ours).
+type JwtClaims = dict[str, Any]
+
+# ASGI protocol messages (key set varies by message type).
+type AsgiMessage = MutableMapping[str, Any]
+
+
+class ApiErrorEnvelope(TypedDict):
+    """Standardized error shape AlpaconHTTPClient returns on failure."""
+
+    error: str
+    message: str
+    status_code: NotRequired[int]
+    response: NotRequired[str]
+    mfa_required: NotRequired[bool]
+    request_index: NotRequired[int]
+
+
+type ApiResult = ApiPayload | ApiErrorEnvelope
+
+
+def is_api_error(result: object) -> TypeGuard[ApiErrorEnvelope]:
+    """Narrow an ApiResult to the standardized error envelope."""
+    return isinstance(result, dict) and 'error' in result
+
+
+class ToolKwargs(TypedDict, total=False):
+    """Keyword args injected into tool functions by with_token_validation."""
+
+    token: str
+
+
+class ResponseContext(TypedDict, total=False):
+    """Superset of context keys tool code attaches to response envelopes.
+
+    Field list is the exhaustive result of an AST-based scan (Task 2 Step 1)
+    over every keyword argument passed to success_response, error_response,
+    pending_approval_response, work_session_gate_response, and
+    unwrap_http_result across tools/ and utils/. Kept alphabetical.
+
+    ``data`` and ``message`` are deliberately not listed here even though both
+    are attached to response envelopes: each is instead an explicit named
+    parameter on the response-builder functions that need it (mypy's Unpack
+    machinery rejects a function whose own parameter name overlaps with a key
+    of its ``**kwargs: Unpack[ResponseContext]`` type).
+    """
+
+    acl_id: str
+    action: str
+    alert_id: str
+    analysis_id: str
+    app_id: str
+    app_name: str
+    architecture: str | None
+    ca_id: str
+    certificate_id: str
+    code: str
+    command: str
+    command_id: str
+    csr_id: str
+    deploy_shell_results: dict[str, object]
+    details: object
+    device: str | None
+    download_url: str | None
+    email: str
+    end_date: str | None
+    entry_id: str
+    error_type: str
+    event_id: str
+    execution_type: str
+    expires_in: str
+    failed_count: int
+    file_id: str
+    file_size: int
+    group_id: str
+    group_name: str
+    groupname_filter: str | None
+    limit: int
+    local_file_path: str
+    log_id: str
+    login_enabled_only: bool
+    membership_id: str
+    metric_type: str
+    metric_types: list[str]
+    next_action: str
+    note_id: str
+    note_title: str
+    package_name: str | None
+    region: str
+    remote_directory: str
+    remote_file_path: str
+    remote_paths: list[str]
+    reporter: str | None
+    request_id: str
+    requires_human_approval: bool
+    resource_type: str
+    revoke_id: str
+    rule_id: str
+    search_query: str
+    server_id: str | None
+    session_id: str | None
+    shell: str
+    start_date: str | None
+    status_code: int
+    subscription_id: str
+    successful_count: int
+    tip: str
+    token_id: str
+    total_files: int
+    total_servers: int
+    transfer_type: str
+    upload_url: str
+    user_id: str
+    username: str | None
+    username_filter: str | None
+    webhook_id: str
+    workspace: str
+
+
+class SuccessResponse(ResponseContext):
+    status: Literal['success']
+    data: NotRequired[object]
+    message: NotRequired[str]
+
+
+class ErrorResponse(ResponseContext):
+    status: Literal['error']
+    message: str
+
+
+class PendingApprovalResponse(ResponseContext):
+    status: Literal['pending_approval']
+    category: str
+    message: str
+    approvable_by_agent: bool
+    data: NotRequired[object]
+    # requires_human_approval / next_action are inherited (NotRequired) from
+    # ResponseContext rather than re-declared here: mypy rejects narrowing an
+    # inherited field from NotRequired to Required in a TypedDict subclass.
+    # pending_approval_response() always sets both at runtime regardless.
+
+
+type ToolResponse = SuccessResponse | ErrorResponse | PendingApprovalResponse

--- a/utils/api_types.py
+++ b/utils/api_types.py
@@ -119,6 +119,8 @@ class ResponseContext(TypedDict, total=False):
     status_code: int
     subscription_id: str
     successful_count: int
+    sudo_denial: object
+    sudo_hint: str
     tip: str
     token_id: str
     total_files: int

--- a/utils/api_types.py
+++ b/utils/api_types.py
@@ -110,12 +110,12 @@ class ResponseContext(TypedDict, total=False):
     note_id: str
     note_title: str
     package_name: str | None
+    recovery_hints: list[str]
     region: str
+    related_tools: list[str]
     remote_directory: str
     remote_file_path: str
     remote_paths: list[str]
-    recovery_hints: list[str]
-    related_tools: list[str]
     reporter: str | None
     request_id: str
     requires_human_approval: bool
@@ -156,16 +156,28 @@ class ErrorResponse(ResponseContext):
     message: str
 
 
+class ValidationErrorResponse(ErrorResponse):
+    """Error envelope produced by format_validation_error().
+
+    A structural subtype of ErrorResponse, so it satisfies ToolResponse;
+    kept separate so ErrorResponse literals built from **ResponseContext
+    spreads don't have to account for these keys.
+    """
+
+    error_code: NotRequired[str]
+    field: NotRequired[str]
+    value: NotRequired[str]
+    suggestion: NotRequired[str]
+
+
 class PendingApprovalResponse(ResponseContext):
     status: Literal['pending_approval']
     category: str
     message: str
     approvable_by_agent: bool
     data: NotRequired[object]
-    # requires_human_approval / next_action are inherited (NotRequired) from
-    # ResponseContext rather than re-declared here: mypy rejects narrowing an
-    # inherited field from NotRequired to Required in a TypedDict subclass.
-    # pending_approval_response() always sets both at runtime regardless.
+    # requires_human_approval / next_action stay inherited (NotRequired): mypy
+    # rejects narrowing them to Required here; the builder always sets both.
 
 
 type ToolResponse = SuccessResponse | ErrorResponse | PendingApprovalResponse

--- a/utils/api_types.py
+++ b/utils/api_types.py
@@ -19,6 +19,15 @@ type JwtClaims = dict[str, Any]
 # ASGI protocol messages (key set varies by message type).
 type AsgiMessage = MutableMapping[str, Any]
 
+# FastMCP's own `mcp.tool(meta=...)` parameter is typed `dict[str, Any] | None`
+# upstream; mirrored here so callers never need to import `Any` themselves.
+type ToolMeta = dict[str, Any] | None
+
+# Arbitrary externally sourced JSON object whose schema isn't ours to define
+# (Auth0 JWKS documents, account-service security-settings payloads). Narrower
+# than ApiPayload: always a dict, never a top-level list.
+type JsonObject = dict[str, Any]
+
 
 class ApiErrorEnvelope(TypedDict):
     """Standardized error shape AlpaconHTTPClient returns on failure."""
@@ -105,6 +114,8 @@ class ResponseContext(TypedDict, total=False):
     remote_directory: str
     remote_file_path: str
     remote_paths: list[str]
+    recovery_hints: list[str]
+    related_tools: list[str]
     reporter: str | None
     request_id: str
     requires_human_approval: bool

--- a/utils/auth.py
+++ b/utils/auth.py
@@ -3,18 +3,19 @@
 import asyncio
 import os
 import time
-from typing import Any
 
 import httpx
 import jwt
+from cryptography.hazmat.primitives.asymmetric.rsa import RSAPublicKey
 from mcp.server.auth.provider import AccessToken
 
+from utils.api_types import JsonObject, JwtClaims
 from utils.logger import get_logger
 
 logger = get_logger('auth')
 
 # JWKS cache: stores fetched keys and expiry time
-_jwks_cache: dict[str, Any] = {}
+_jwks_cache: JsonObject = {}
 _jwks_cache_expiry: float = 0
 _JWKS_CACHE_TTL = 3600  # 1 hour
 _jwks_lock: asyncio.Lock | None = None
@@ -46,7 +47,7 @@ def _get_auth0_config() -> dict[str, str]:
     }
 
 
-async def _fetch_jwks(jwks_url: str) -> dict[str, Any]:
+async def _fetch_jwks(jwks_url: str) -> JsonObject:
     """Fetch JWKS from Auth0 endpoint with caching.
 
     Uses an async lock to prevent concurrent fetches from racing
@@ -75,7 +76,7 @@ async def _fetch_jwks(jwks_url: str) -> dict[str, Any]:
         return _jwks_cache
 
 
-def _get_signing_key(jwks: dict[str, Any], token: str) -> Any | None:
+def _get_signing_key(jwks: JsonObject, token: str) -> RSAPublicKey | None:
     """Extract the signing key from JWKS matching the token's kid."""
     try:
         unverified_header = jwt.get_unverified_header(token)
@@ -92,15 +93,21 @@ def _get_signing_key(jwks: dict[str, Any], token: str) -> Any | None:
         if key.get('kid') == kid:
             import json
 
-            return jwt.algorithms.RSAAlgorithm.from_jwk(json.dumps(key))
+            # from_jwk()'s declared return type also covers RSA private keys,
+            # but a JWKS document (public keyset) only ever yields public ones.
+            signing_key = jwt.algorithms.RSAAlgorithm.from_jwk(json.dumps(key))
+            if isinstance(signing_key, RSAPublicKey):
+                return signing_key
+            logger.error(f'JWKS key for kid {kid} is not an RSA public key')
+            return None
 
     logger.error(f'No matching key found for kid: {kid}')
     return None
 
 
 def decode_jwt(
-    token: str, public_key: Any, config: dict[str, str]
-) -> dict[str, Any] | None:
+    token: str, public_key: RSAPublicKey, config: dict[str, str]
+) -> JwtClaims | None:
     """Decode and verify a JWT token.
 
     Args:
@@ -131,7 +138,7 @@ def decode_jwt(
     return None
 
 
-def extract_workspaces(claims: dict[str, Any], namespace: str) -> list[dict[str, str]]:
+def extract_workspaces(claims: JwtClaims, namespace: str) -> list[dict[str, str]]:
     """Extract workspaces from JWT claims.
 
     Args:
@@ -178,7 +185,7 @@ class Auth0TokenVerifier:
     workspace claims for authorization.
     """
 
-    def __init__(self):
+    def __init__(self) -> None:
         """Initialize with Auth0 config from environment variables."""
         self._config = _get_auth0_config()
         logger.info(

--- a/utils/auth_error_middleware.py
+++ b/utils/auth_error_middleware.py
@@ -24,11 +24,10 @@ Only active in remote (streamable-http) mode where OAuth is enabled.
 
 import json
 import time
-from collections.abc import MutableMapping
-from typing import Any
 
 from starlette.types import ASGIApp, Receive, Scope, Send
 
+from utils.api_types import AsgiMessage
 from utils.error_handler import (
     UpstreamAuthError,
     consume_upstream_auth_error,
@@ -116,9 +115,9 @@ class UpstreamAuthErrorMiddleware:
         )
 
         # Buffer the response so we can replace it if needed
-        buffered: list[MutableMapping[str, Any]] = []
+        buffered: list[AsgiMessage] = []
 
-        async def buffer_send(message: MutableMapping[str, Any]) -> None:
+        async def buffer_send(message: AsgiMessage) -> None:
             buffered.append(message)
 
         try:

--- a/utils/common.py
+++ b/utils/common.py
@@ -77,11 +77,9 @@ def success_response(
     Returns:
         Standardized success response dict
     """
-    # Plain dict[str, object] intermediate: SuccessResponse declares its own
-    # NotRequired fields (data, message) beyond ResponseContext, and mypy's
-    # TypedDict construction requires every NotRequired key of the target to
-    # be accounted for in a **-spread literal, which a bare ResponseContext
-    # kwargs can't satisfy. Cast back once fully assembled.
+    # mypy requires a **-spread TypedDict literal to account for every
+    # NotRequired key of the target (here: data/message), which bare
+    # ResponseContext kwargs can't; build untyped, cast once assembled.
     response: dict[str, object] = {'status': 'success', **kwargs}
     if data is not None:
         response['data'] = data
@@ -257,13 +255,10 @@ def work_session_gate_response(
             category='WORK_SESSION_PENDING',
             **kwargs,
         )
-    # Built as a literal (not via error_response(**kwargs)) because kwargs is
-    # typed Unpack[ResponseContext], which structurally may already contain
-    # code/next_action/requires_human_approval—mypy rejects passing those as
-    # both explicit keywords and part of a forwarded **kwargs of that type.
-    # Annotated as ErrorResponse (not the function's ErrorResponse |
-    # PendingApprovalResponse return type) so mypy doesn't also require
-    # PendingApprovalResponse's own NotRequired 'data' key to be accounted for.
+    # A literal, not error_response(**kwargs): kwargs may structurally already
+    # contain code/next_action/requires_human_approval, and mypy rejects keys
+    # passed both explicitly and via a forwarded **kwargs. Annotated as plain
+    # ErrorResponse so the union's other member isn't demanded in the spread.
     gate_error: ErrorResponse = {
         'status': 'error',
         'message': f'Operation blocked by the Work Session gate: {gate_code}.',

--- a/utils/common.py
+++ b/utils/common.py
@@ -4,8 +4,17 @@ import importlib.metadata
 import json
 import os
 import platform
-from typing import Any
+from typing import Unpack, cast
 
+from utils.api_types import (
+    ApiErrorEnvelope,
+    ApiResult,
+    ErrorResponse,
+    PendingApprovalResponse,
+    ResponseContext,
+    SuccessResponse,
+    is_api_error,
+)
 from utils.logger import get_logger
 from utils.token_manager import get_token_manager
 
@@ -40,7 +49,7 @@ def validate_token(region: str, workspace: str) -> str | None:
     return token
 
 
-def error_response(message: str, **kwargs) -> dict[str, Any]:
+def error_response(message: str, **kwargs: Unpack[ResponseContext]) -> ErrorResponse:
     """Create standardized error response.
 
     Args:
@@ -50,26 +59,35 @@ def error_response(message: str, **kwargs) -> dict[str, Any]:
     Returns:
         Standardized error response dict
     """
-    response = {'status': 'error', 'message': message}
-    response.update(kwargs)
-    return response
+    return {'status': 'error', 'message': message, **kwargs}
 
 
-def success_response(data: Any = None, **kwargs) -> dict[str, Any]:
+def success_response(
+    data: object = None,
+    message: str | None = None,
+    **kwargs: Unpack[ResponseContext],
+) -> SuccessResponse:
     """Create standardized success response.
 
     Args:
         data: Response data
+        message: Optional human-readable message to attach
         **kwargs: Additional fields to include in response
 
     Returns:
         Standardized success response dict
     """
-    response = {'status': 'success'}
+    # Plain dict[str, object] intermediate: SuccessResponse declares its own
+    # NotRequired fields (data, message) beyond ResponseContext, and mypy's
+    # TypedDict construction requires every NotRequired key of the target to
+    # be accounted for in a **-spread literal, which a bare ResponseContext
+    # kwargs can't satisfy. Cast back once fully assembled.
+    response: dict[str, object] = {'status': 'success', **kwargs}
     if data is not None:
         response['data'] = data
-    response.update(kwargs)
-    return response
+    if message is not None:
+        response['message'] = message
+    return cast(SuccessResponse, response)
 
 
 # The human-resolvable next action differs by category: SUDO_APPROVAL_REQUIRED /
@@ -111,8 +129,9 @@ def pending_approval_response(
     message: str,
     *,
     category: str,
-    **kwargs: Any,
-) -> dict[str, Any]:
+    data: object = None,
+    **kwargs: Unpack[ResponseContext],
+) -> PendingApprovalResponse:
     """Create a structured "pending human approval" result (ADR 0015).
 
     AI agents reaching Alpacon through MCP are a request/execution surface and
@@ -133,29 +152,32 @@ def pending_approval_response(
         message: Human-readable explanation of what is pending and what to do.
         category: Stable machine code for the denial/pending category
             (e.g. ``SUDO_APPROVAL_REQUIRED``, ``WORK_SESSION_PENDING``).
-        **kwargs: Additional context fields (region, workspace, ids, raw data).
+        data: Optional raw payload to attach (e.g. the pending Work Session).
+        **kwargs: Additional context fields (region, workspace, ids).
 
     Returns:
         Structured pending-approval response dict.
     """
     # Apply caller context first so the fixed, security-relevant fields below
     # (the flags and category) always win and cannot be overridden by a kwarg.
-    response: dict[str, Any] = {**kwargs}
-    response.update(
-        {
-            'status': 'pending_approval',
-            'category': category,
-            'message': message,
-            # Machine-actionable flags: the agent must wait/escalate, not act.
-            'requires_human_approval': True,
-            'approvable_by_agent': False,
-            'next_action': _NEXT_ACTION_BY_CATEGORY.get(category, _DEFAULT_NEXT_ACTION),
-        }
-    )
-    return response
+    # Plain dict[str, object] intermediate: see success_response for why (own
+    # NotRequired 'data' field beyond ResponseContext). Cast back once assembled.
+    response: dict[str, object] = {
+        **kwargs,
+        'status': 'pending_approval',
+        'category': category,
+        'message': message,
+        # Machine-actionable flags: the agent must wait/escalate, not act.
+        'requires_human_approval': True,
+        'approvable_by_agent': False,
+        'next_action': _NEXT_ACTION_BY_CATEGORY.get(category, _DEFAULT_NEXT_ACTION),
+    }
+    if data is not None:
+        response['data'] = data
+    return cast(PendingApprovalResponse, response)
 
 
-def token_error_response(region: str, workspace: str) -> dict[str, Any]:
+def token_error_response(region: str, workspace: str) -> ErrorResponse:
     """Create standardized token error response.
 
     Args:
@@ -212,15 +234,22 @@ _WORK_SESSION_GATE_CODES: frozenset[str] = frozenset(_WORK_SESSION_GATE_NEXT_ACT
 }
 
 
-def work_session_gate_response(code: str, **kwargs: Any) -> dict[str, Any]:
+def work_session_gate_response(
+    gate_code: str, **kwargs: Unpack[ResponseContext]
+) -> ErrorResponse | PendingApprovalResponse:
     """Translate a server WorkSession gate error code into an agent-actionable result.
 
     ``work_session_not_active`` becomes a pending-approval result (a human must
     approve the existing session). Every other gate code becomes an error result
     carrying the gate ``code`` and a ``next_action`` describing how to get inside
     a valid session. See ADR 0014 (zero standing privilege).
+
+    Note: the parameter is named ``gate_code`` (not ``code``) because ``code``
+    is itself a ``ResponseContext`` field attached via ``**kwargs``—mypy's
+    Unpack machinery rejects a function whose own parameter name overlaps
+    with a key of its ``**kwargs: Unpack[ResponseContext]`` type.
     """
-    if code == _WORK_SESSION_PENDING_CODE:
+    if gate_code == _WORK_SESSION_PENDING_CODE:
         return pending_approval_response(
             'The attached Work Session is not active yet. A human must approve '
             'it out-of-band (Alpacon web console or Slack) before this operation '
@@ -228,21 +257,30 @@ def work_session_gate_response(code: str, **kwargs: Any) -> dict[str, Any]:
             category='WORK_SESSION_PENDING',
             **kwargs,
         )
-    return error_response(
-        f'Operation blocked by the Work Session gate: {code}.',
-        code=code,
-        next_action=_WORK_SESSION_GATE_NEXT_ACTION[code],
-        requires_human_approval=False,
+    # Built as a literal (not via error_response(**kwargs)) because kwargs is
+    # typed Unpack[ResponseContext], which structurally may already contain
+    # code/next_action/requires_human_approval—mypy rejects passing those as
+    # both explicit keywords and part of a forwarded **kwargs of that type.
+    # Annotated as ErrorResponse (not the function's ErrorResponse |
+    # PendingApprovalResponse return type) so mypy doesn't also require
+    # PendingApprovalResponse's own NotRequired 'data' key to be accounted for.
+    gate_error: ErrorResponse = {
+        'status': 'error',
+        'message': f'Operation blocked by the Work Session gate: {gate_code}.',
         **kwargs,
-    )
+        'code': gate_code,
+        'next_action': _WORK_SESSION_GATE_NEXT_ACTION[gate_code],
+        'requires_human_approval': False,
+    }
+    return gate_error
 
 
 def unwrap_http_result(
-    result: Any,
+    result: ApiResult,
     *,
     default_message: str,
-    **id_context: Any,
-) -> dict[str, Any] | None:
+    **id_context: Unpack[ResponseContext],
+) -> ErrorResponse | PendingApprovalResponse | None:
     """Convert an http_client error-dict into an error_response.
 
     Returns the error_response dict if `result` is the error envelope produced
@@ -256,12 +294,14 @@ def unwrap_http_result(
             into the error response for caller debugging.
 
     Returns:
-        error_response dict if result is an error envelope, else None.
+        error_response dict if result is an error envelope, else None. Can also
+        be a pending_approval_response dict when the gate code is the
+        WorkSession-pending code (see work_session_gate_response).
     """
-    if not (isinstance(result, dict) and 'error' in result):
+    if not is_api_error(result):
         return None
 
-    error_kwargs: dict[str, Any] = dict(id_context)
+    error_kwargs: ResponseContext = {**id_context}
     status_code = result.get('status_code')
     if status_code is not None:
         error_kwargs['status_code'] = status_code
@@ -276,7 +316,7 @@ def unwrap_http_result(
     )
 
 
-def _extract_work_session_gate_code(result: dict[str, Any]) -> str | None:
+def _extract_work_session_gate_code(result: ApiErrorEnvelope) -> str | None:
     """Return the WorkSession gate code carried by an http error envelope, if any.
 
     alpacon-server's exception handler returns 4xx bodies shaped as

--- a/utils/decorators.py
+++ b/utils/decorators.py
@@ -373,9 +373,16 @@ def with_token_validation(func: Callable) -> Callable:
         # both positional and keyword region correctly
         return await func(*bound_args.args, **bound_args.kwargs)
 
-    # Remove _token parameter from the wrapper signature
+    # Strip internal params from the exposed signature: _token is an
+    # internal marker (MCP forbids leading underscores) and VAR_KEYWORD
+    # would otherwise surface as a bogus required "kwargs" field in the
+    # FastMCP-generated JSON schema (func_metadata ignores param.kind).
     original_sig = inspect.signature(func)
-    new_params = [p for p in original_sig.parameters.values() if p.name != '_token']
+    new_params = [
+        p
+        for p in original_sig.parameters.values()
+        if p.name != '_token' and p.kind is not inspect.Parameter.VAR_KEYWORD
+    ]
     wrapper.__signature__ = original_sig.replace(parameters=new_params)  # type: ignore[attr-defined]
 
     return wrapper

--- a/utils/decorators.py
+++ b/utils/decorators.py
@@ -251,6 +251,11 @@ def with_token_validation[R, **P](
         Decorated async function with modified signature (removes _token parameter)
     """
 
+    def _fail(resp: ToolResponse) -> R:
+        # Concrete R is always ToolResponse, which the generic decorator
+        # can't express; every validation early-exit shares this one cast.
+        return cast(R, resp)
+
     @wraps(func)
     async def wrapper(*args: P.args, **kwargs: P.kwargs) -> R:
         # Remove _token from kwargs if present (MCP doesn't allow _ prefix)
@@ -268,11 +273,11 @@ def with_token_validation[R, **P](
 
         # Validate workspace is present
         if not workspace:
-            return cast(R, error_response('workspace parameter is required'))
+            return _fail(error_response('workspace parameter is required'))
 
         # Validate workspace format
         if not validate_workspace_format(workspace):
-            return cast(R, format_validation_error('workspace', workspace))
+            return _fail(format_validation_error('workspace', workspace))
 
         auth_enabled = _is_auth_enabled()
 
@@ -281,8 +286,7 @@ def with_token_validation[R, **P](
         if auth_enabled:
             jwt_token = _get_jwt_token()
             if not jwt_token:
-                return cast(
-                    R,
+                return _fail(
                     error_response(
                         'Authentication required. No JWT token found in request context.'
                     ),
@@ -291,8 +295,7 @@ def with_token_validation[R, **P](
         # Auto-detect region if not provided
         if not region:
             if auth_enabled:
-                # jwt_token is narrowed to str above, but mypy can't carry
-                # that across the unrelated statements in between.
+                # jwt_token was narrowed to str above; mypy can't carry it here.
                 resolved_region, err_msg = _resolve_region_jwt(
                     cast(str, jwt_token), workspace
                 )
@@ -300,25 +303,24 @@ def with_token_validation[R, **P](
                 resolved_region, err_msg = _resolve_region_local(workspace)
 
             if err_msg:
-                return cast(R, error_response(err_msg))
+                return _fail(error_response(err_msg))
             region = resolved_region
             bound_args.arguments['region'] = region
 
         # Validate region format
         if not validate_region_format(region):
-            return cast(R, format_validation_error('region', region))
+            return _fail(format_validation_error('region', region))
 
         # Validate server_id format if present
         server_id = arguments.get('server_id')
         if server_id is not None and not validate_server_id_format(server_id):
-            return cast(R, format_validation_error('server_id', server_id))
+            return _fail(format_validation_error('server_id', server_id))
 
         # Validate server_ids list if present
         server_ids = arguments.get('server_ids')
         if server_ids is not None:
             if not isinstance(server_ids, list):
-                return cast(
-                    R,
+                return _fail(
                     format_validation_error(
                         'server_ids',
                         server_ids,
@@ -329,8 +331,7 @@ def with_token_validation[R, **P](
                 sid for sid in server_ids if not validate_server_id_format(sid)
             ]
             if invalid_ids:
-                return cast(
-                    R,
+                return _fail(
                     format_validation_error(
                         'server_ids',
                         invalid_ids,
@@ -342,8 +343,7 @@ def with_token_validation[R, **P](
         servers = arguments.get('servers')
         if servers is not None:
             if not isinstance(servers, list):
-                return cast(
-                    R,
+                return _fail(
                     format_validation_error(
                         'servers',
                         servers,
@@ -354,8 +354,7 @@ def with_token_validation[R, **P](
                 sid for sid in servers if not validate_server_id_format(sid)
             ]
             if invalid_servers:
-                return cast(
-                    R,
+                return _fail(
                     format_validation_error(
                         'servers',
                         invalid_servers,
@@ -366,7 +365,7 @@ def with_token_validation[R, **P](
         # session_id is interpolated into URL paths, so reject non-UUID values that could retarget the request.
         session_id = arguments.get('session_id')
         if session_id is not None and not validate_server_id_format(session_id):
-            return cast(R, format_validation_error('session_id', session_id))
+            return _fail(format_validation_error('session_id', session_id))
 
         # Get the **kwargs dict from bound arguments to inject token
         extra_kwargs = bound_args.arguments.get('kwargs', {})
@@ -374,8 +373,7 @@ def with_token_validation[R, **P](
         if auth_enabled:
             # Streamable-HTTP mode — JWT auth only
             if not _validate_jwt_workspace(cast(str, jwt_token), region, workspace):
-                return cast(
-                    R,
+                return _fail(
                     error_response(
                         f'Workspace {workspace}.{region} not authorized by JWT',
                         region=region,
@@ -392,7 +390,7 @@ def with_token_validation[R, **P](
             # stdio mode — token.json only
             token = validate_token(region, workspace)
             if not token:
-                return cast(R, token_error_response(region, workspace))
+                return _fail(token_error_response(region, workspace))
             extra_kwargs['token'] = token
 
         bound_args.arguments['kwargs'] = extra_kwargs
@@ -445,9 +443,8 @@ def with_error_handling[R, **P](
             # Call the original function
             result = await func(*args, **kwargs)
 
-            # Enrich error responses with recovery hints. `result` is
-            # statically R (the tool's own ToolResponse), so the enrich
-            # call and its result both need a boundary cast.
+            # result is statically the generic R, so the enrich call and
+            # its result both need boundary casts.
             if isinstance(result, dict):
                 enriched = enrich_error_response(
                     cast(ToolResponse, result), tool_name=func_name
@@ -480,8 +477,7 @@ def with_error_handling[R, **P](
             resp = error_response(
                 f'Failed in {func_name}: {str(e)}', workspace=workspace, region=region
             )
-            # resp is ErrorResponse; func's actual return is ToolResponse at
-            # runtime, but the decorator's static type is the generic R.
+            # resp is ErrorResponse; the decorator's static return is the generic R.
             return cast(R, enrich_error_response(resp, tool_name=func_name))
 
     return wrapper
@@ -605,9 +601,8 @@ def mcp_tool_handler(
             annotations=annotations,
             meta=meta,
         )(func)
-        # FastMCP's decorator is typed Callable[[Callable[..., Any]], Callable[..., Any]]
-        # (an external library boundary), so the specific P/R is lost statically
-        # even though add_tool() returns the same object unchanged at runtime.
+        # mcp.tool() is typed with bare Callables upstream, dropping P/R even
+        # though it returns the same object unchanged at runtime.
         return cast(Callable[P, Awaitable[R]], registered)
 
     return decorator

--- a/utils/decorators.py
+++ b/utils/decorators.py
@@ -4,12 +4,13 @@ from __future__ import annotations
 
 import inspect
 import os
-from collections.abc import Callable
+from collections.abc import Awaitable, Callable
 from functools import wraps
-from typing import Any
+from typing import ParamSpec, TypeVar, cast
 
 from mcp.types import ToolAnnotations
 
+from utils.api_types import JwtClaims, ToolMeta, ToolResponse
 from utils.common import error_response, token_error_response, validate_token
 from utils.error_handler import (
     UpstreamAuthError,
@@ -22,6 +23,9 @@ from utils.http_client import AlpaconHTTPClient
 from utils.logger import get_logger
 
 logger = get_logger('decorators')
+
+P = ParamSpec('P')
+R = TypeVar('R')
 
 
 def _is_auth_enabled() -> bool:
@@ -50,7 +54,7 @@ def _get_jwt_token() -> str | None:
     return None
 
 
-def _decode_jwt_claims(jwt_token: str) -> dict | None:
+def _decode_jwt_claims(jwt_token: str) -> JwtClaims | None:
     """Decode JWT claims without verification (already verified by middleware)."""
     try:
         import jwt as pyjwt
@@ -229,7 +233,9 @@ async def _check_mfa_requirement(
         logger.debug('MFA pre-check failed (non-fatal): %s', e)
 
 
-def with_token_validation(func: Callable) -> Callable:
+def with_token_validation[R, **P](
+    func: Callable[P, Awaitable[R]],
+) -> Callable[P, Awaitable[R]]:
     """Decorator to add automatic token validation to MCP tools.
 
     Transport mode is determined by ALPACON_MCP_AUTH_ENABLED env var:
@@ -246,7 +252,7 @@ def with_token_validation(func: Callable) -> Callable:
     """
 
     @wraps(func)
-    async def wrapper(*args, **kwargs):
+    async def wrapper(*args: P.args, **kwargs: P.kwargs) -> R:
         # Remove _token from kwargs if present (MCP doesn't allow _ prefix)
         kwargs.pop('_token', None)
 
@@ -262,11 +268,11 @@ def with_token_validation(func: Callable) -> Callable:
 
         # Validate workspace is present
         if not workspace:
-            return error_response('workspace parameter is required')
+            return cast(R, error_response('workspace parameter is required'))
 
         # Validate workspace format
         if not validate_workspace_format(workspace):
-            return format_validation_error('workspace', workspace)
+            return cast(R, format_validation_error('workspace', workspace))
 
         auth_enabled = _is_auth_enabled()
 
@@ -275,96 +281,118 @@ def with_token_validation(func: Callable) -> Callable:
         if auth_enabled:
             jwt_token = _get_jwt_token()
             if not jwt_token:
-                return error_response(
-                    'Authentication required. No JWT token found in request context.'
+                return cast(
+                    R,
+                    error_response(
+                        'Authentication required. No JWT token found in request context.'
+                    ),
                 )
 
         # Auto-detect region if not provided
         if not region:
             if auth_enabled:
-                resolved_region, err_msg = _resolve_region_jwt(jwt_token, workspace)
+                # jwt_token is narrowed to str above, but mypy can't carry
+                # that across the unrelated statements in between.
+                resolved_region, err_msg = _resolve_region_jwt(
+                    cast(str, jwt_token), workspace
+                )
             else:
                 resolved_region, err_msg = _resolve_region_local(workspace)
 
             if err_msg:
-                return error_response(err_msg)
+                return cast(R, error_response(err_msg))
             region = resolved_region
             bound_args.arguments['region'] = region
 
         # Validate region format
         if not validate_region_format(region):
-            return format_validation_error('region', region)
+            return cast(R, format_validation_error('region', region))
 
         # Validate server_id format if present
         server_id = arguments.get('server_id')
         if server_id is not None and not validate_server_id_format(server_id):
-            return format_validation_error('server_id', server_id)
+            return cast(R, format_validation_error('server_id', server_id))
 
         # Validate server_ids list if present
         server_ids = arguments.get('server_ids')
         if server_ids is not None:
             if not isinstance(server_ids, list):
-                return format_validation_error(
-                    'server_ids',
-                    server_ids,
-                    'Must be a list of server UUIDs.',
+                return cast(
+                    R,
+                    format_validation_error(
+                        'server_ids',
+                        server_ids,
+                        'Must be a list of server UUIDs.',
+                    ),
                 )
             invalid_ids = [
                 sid for sid in server_ids if not validate_server_id_format(sid)
             ]
             if invalid_ids:
-                return format_validation_error(
-                    'server_ids',
-                    invalid_ids,
-                    'Each server ID must be in UUID format. (e.g., 550e8400-e29b-41d4-a716-446655440000)',
+                return cast(
+                    R,
+                    format_validation_error(
+                        'server_ids',
+                        invalid_ids,
+                        'Each server ID must be in UUID format. (e.g., 550e8400-e29b-41d4-a716-446655440000)',
+                    ),
                 )
 
         # Validate servers list if present (server UUIDs sent in request bodies)
         servers = arguments.get('servers')
         if servers is not None:
             if not isinstance(servers, list):
-                return format_validation_error(
-                    'servers',
-                    servers,
-                    'Must be a list of server UUIDs.',
+                return cast(
+                    R,
+                    format_validation_error(
+                        'servers',
+                        servers,
+                        'Must be a list of server UUIDs.',
+                    ),
                 )
             invalid_servers = [
                 sid for sid in servers if not validate_server_id_format(sid)
             ]
             if invalid_servers:
-                return format_validation_error(
-                    'servers',
-                    invalid_servers,
-                    'Each server ID must be in UUID format. (e.g., 550e8400-e29b-41d4-a716-446655440000)',
+                return cast(
+                    R,
+                    format_validation_error(
+                        'servers',
+                        invalid_servers,
+                        'Each server ID must be in UUID format. (e.g., 550e8400-e29b-41d4-a716-446655440000)',
+                    ),
                 )
 
         # session_id is interpolated into URL paths, so reject non-UUID values that could retarget the request.
         session_id = arguments.get('session_id')
         if session_id is not None and not validate_server_id_format(session_id):
-            return format_validation_error('session_id', session_id)
+            return cast(R, format_validation_error('session_id', session_id))
 
         # Get the **kwargs dict from bound arguments to inject token
         extra_kwargs = bound_args.arguments.get('kwargs', {})
 
         if auth_enabled:
             # Streamable-HTTP mode — JWT auth only
-            if not _validate_jwt_workspace(jwt_token, region, workspace):
-                return error_response(
-                    f'Workspace {workspace}.{region} not authorized by JWT',
-                    region=region,
-                    workspace=workspace,
+            if not _validate_jwt_workspace(cast(str, jwt_token), region, workspace):
+                return cast(
+                    R,
+                    error_response(
+                        f'Workspace {workspace}.{region} not authorized by JWT',
+                        region=region,
+                        workspace=workspace,
+                    ),
                 )
             extra_kwargs['token'] = jwt_token
 
             # MFA pre-check: verify MFA completion for actions that require it.
             # Raises UpstreamAuthError if MFA is required but not satisfied.
             # The ASGI middleware catches this and returns HTTP 401.
-            await _check_mfa_requirement(func.__name__, jwt_token, workspace)
+            await _check_mfa_requirement(func.__name__, cast(str, jwt_token), workspace)
         else:
             # stdio mode — token.json only
             token = validate_token(region, workspace)
             if not token:
-                return token_error_response(region, workspace)
+                return cast(R, token_error_response(region, workspace))
             extra_kwargs['token'] = token
 
         bound_args.arguments['kwargs'] = extra_kwargs
@@ -388,7 +416,9 @@ def with_token_validation(func: Callable) -> Callable:
     return wrapper
 
 
-def with_error_handling(func: Callable) -> Callable:
+def with_error_handling[R, **P](
+    func: Callable[P, Awaitable[R]],
+) -> Callable[P, Awaitable[R]]:
     """Decorator to add consistent error handling to MCP tools.
 
     This decorator:
@@ -405,7 +435,7 @@ def with_error_handling(func: Callable) -> Callable:
     """
 
     @wraps(func)
-    async def wrapper(*args, **kwargs):
+    async def wrapper(*args: P.args, **kwargs: P.kwargs) -> R:
         from utils.recovery_hints import enrich_error_response
 
         # Extract function name for logging
@@ -415,9 +445,14 @@ def with_error_handling(func: Callable) -> Callable:
             # Call the original function
             result = await func(*args, **kwargs)
 
-            # Enrich error responses with recovery hints
+            # Enrich error responses with recovery hints. `result` is
+            # statically R (the tool's own ToolResponse), so the enrich
+            # call and its result both need a boundary cast.
             if isinstance(result, dict):
-                result = enrich_error_response(result, tool_name=func_name)
+                enriched = enrich_error_response(
+                    cast(ToolResponse, result), tool_name=func_name
+                )
+                result = cast(R, enriched)
 
             return result
 
@@ -445,12 +480,14 @@ def with_error_handling(func: Callable) -> Callable:
             resp = error_response(
                 f'Failed in {func_name}: {str(e)}', workspace=workspace, region=region
             )
-            return enrich_error_response(resp, tool_name=func_name)
+            # resp is ErrorResponse; func's actual return is ToolResponse at
+            # runtime, but the decorator's static type is the generic R.
+            return cast(R, enrich_error_response(resp, tool_name=func_name))
 
     return wrapper
 
 
-def with_logging(func: Callable) -> Callable:
+def with_logging[R, **P](func: Callable[P, Awaitable[R]]) -> Callable[P, Awaitable[R]]:
     """Decorator to add automatic logging to MCP tools.
 
     This decorator:
@@ -466,7 +503,7 @@ def with_logging(func: Callable) -> Callable:
     """
 
     @wraps(func)
-    async def wrapper(*args, **kwargs):
+    async def wrapper(*args: P.args, **kwargs: P.kwargs) -> R:
         func_name = func.__name__
 
         # Get function arguments for logging
@@ -497,7 +534,9 @@ def with_logging(func: Callable) -> Callable:
     return wrapper
 
 
-def require_jwt_auth(func: Callable) -> Callable:
+def require_jwt_auth[R, **P](
+    func: Callable[P, Awaitable[R]],
+) -> Callable[P, Awaitable[R]]:
     """Reject non-JWT (API) tokens before any upstream call.
 
     Stack INSIDE ``@mcp_tool_handler`` so the resolved token is already
@@ -514,13 +553,16 @@ def require_jwt_auth(func: Callable) -> Callable:
     """
 
     @wraps(func)
-    async def wrapper(*args, **kwargs):
+    async def wrapper(*args: P.args, **kwargs: P.kwargs) -> R:
         token = kwargs.get('token')
-        if token and not AlpaconHTTPClient._is_jwt(token):
-            return error_response(
-                f'{func.__name__} requires JWT (OAuth/SSO) authentication; '
-                'API tokens cannot manage other API tokens. '
-                'Re-authenticate via browser-based SSO and retry.'
+        if token and not AlpaconHTTPClient._is_jwt(cast(str, token)):
+            return cast(
+                R,
+                error_response(
+                    f'{func.__name__} requires JWT (OAuth/SSO) authentication; '
+                    'API tokens cannot manage other API tokens. '
+                    'Re-authenticate via browser-based SSO and retry.'
+                ),
             )
         return await func(*args, **kwargs)
 
@@ -530,8 +572,8 @@ def require_jwt_auth(func: Callable) -> Callable:
 def mcp_tool_handler(
     description: str,
     annotations: ToolAnnotations | None = None,
-    meta: dict[str, Any] | None = None,
-):
+    meta: ToolMeta = None,
+) -> Callable[[Callable[P, Awaitable[R]]], Callable[P, Awaitable[R]]]:
     """Combined decorator for MCP tools that adds all common functionality.
 
     This decorator combines:
@@ -549,7 +591,7 @@ def mcp_tool_handler(
         Decorator function
     """
 
-    def decorator(func: Callable) -> Callable:
+    def decorator(func: Callable[P, Awaitable[R]]) -> Callable[P, Awaitable[R]]:
         # Apply decorators in order (innermost first)
         func = with_error_handling(func)
         func = with_token_validation(func)
@@ -558,10 +600,14 @@ def mcp_tool_handler(
         # Register with MCP
         from server import mcp
 
-        return mcp.tool(
+        registered = mcp.tool(
             description=description,
             annotations=annotations,
             meta=meta,
         )(func)
+        # FastMCP's decorator is typed Callable[[Callable[..., Any]], Callable[..., Any]]
+        # (an external library boundary), so the specific P/R is lost statically
+        # even though add_tool() returns the same object unchanged at runtime.
+        return cast(Callable[P, Awaitable[R]], registered)
 
     return decorator

--- a/utils/error_handler.py
+++ b/utils/error_handler.py
@@ -4,18 +4,26 @@ import hashlib
 import re
 import threading
 import uuid
-from typing import Any
+from typing import TypedDict
 
 from utils.logger import get_logger
 
 logger = get_logger('error_handler')
+
+
+class UpstreamAuthErrorInfo(TypedDict):
+    """Fixed-shape payload signaled between http_client and the ASGI middleware."""
+
+    mfa_required: bool
+    source: str
+
 
 # Module-level thread-safe dict for signaling upstream auth errors between
 # the ASGI middleware and MCP tool handlers. Uses a module-level dict
 # instead of contextvars because MCP streamable-http transport runs tool
 # handlers in a separate anyio task context where ContextVar mutations
 # are invisible to the middleware's parent context.
-_upstream_auth_errors: dict[str, dict] = {}
+_upstream_auth_errors: dict[str, UpstreamAuthErrorInfo] = {}
 _upstream_auth_lock = threading.Lock()
 
 
@@ -28,7 +36,9 @@ def make_auth_error_key(token: str) -> str:
     return hashlib.sha256(token.encode()).hexdigest()[:16]
 
 
-def signal_upstream_auth_error(token_key: str, error_info: dict) -> None:
+def signal_upstream_auth_error(
+    token_key: str, error_info: UpstreamAuthErrorInfo
+) -> None:
     """Signal that an upstream 401 was received for the given token.
 
     Called by http_client when the Alpacon API returns 401 in remote mode.
@@ -51,7 +61,7 @@ def signal_upstream_auth_error(token_key: str, error_info: dict) -> None:
         _upstream_auth_errors[token_key] = merged
 
 
-def consume_upstream_auth_error(token_key: str) -> dict | None:
+def consume_upstream_auth_error(token_key: str) -> UpstreamAuthErrorInfo | None:
     """Check and consume an upstream auth error for the given token.
 
     Called by the ASGI middleware after the request completes.
@@ -90,7 +100,7 @@ class UpstreamAuthError(Exception):
 class ValidationError(Exception):
     """Custom exception for input validation errors."""
 
-    def __init__(self, field: str, value: Any, message: str):
+    def __init__(self, field: str, value: object, message: str):
         self.field = field
         self.value = value
         self.message = message
@@ -182,8 +192,8 @@ def validate_file_path(file_path: str, allow_relative: bool = False) -> bool:
 
 
 def format_user_friendly_error(
-    error_code: str, context: dict[str, Any] | None = None
-) -> dict[str, Any]:
+    error_code: str, context: dict[str, object] | None = None
+) -> dict[str, object]:
     """Format technical errors into user-friendly messages.
 
     Args:
@@ -253,7 +263,7 @@ def format_user_friendly_error(
     elif error_code == '404' and context.get('workspace'):
         error_info['message'] = f"Workspace '{context['workspace']}' not found."
 
-    result: dict[str, Any] = {
+    result: dict[str, object] = {
         'status': 'error',
         'error_code': error_code,
         'message': error_info['message'],
@@ -268,8 +278,8 @@ def format_user_friendly_error(
 
 
 def format_validation_error(
-    field: str, value: Any, expected_format: str | None = None
-) -> dict[str, Any]:
+    field: str, value: object, expected_format: str | None = None
+) -> dict[str, object]:
     """Format validation error with helpful message.
 
     Args:

--- a/utils/error_handler.py
+++ b/utils/error_handler.py
@@ -6,6 +6,7 @@ import threading
 import uuid
 from typing import TypedDict
 
+from utils.api_types import ValidationErrorResponse
 from utils.logger import get_logger
 
 logger = get_logger('error_handler')
@@ -279,7 +280,7 @@ def format_user_friendly_error(
 
 def format_validation_error(
     field: str, value: object, expected_format: str | None = None
-) -> dict[str, object]:
+) -> ValidationErrorResponse:
     """Format validation error with helpful message.
 
     Args:

--- a/utils/health.py
+++ b/utils/health.py
@@ -2,7 +2,6 @@
 
 import os
 import time
-from typing import Any
 
 from utils.logger import get_logger
 
@@ -17,7 +16,7 @@ def _is_remote_mode() -> bool:
     return os.getenv('ALPACON_MCP_AUTH_ENABLED', '').lower() == 'true'
 
 
-def _get_auth_info_remote() -> dict[str, Any]:
+def _get_auth_info_remote() -> dict[str, object]:
     """Get auth info for remote (JWT) mode."""
     return {
         'mode': 'jwt',
@@ -25,7 +24,7 @@ def _get_auth_info_remote() -> dict[str, Any]:
     }
 
 
-def _get_auth_info_local() -> dict[str, Any]:
+def _get_auth_info_local() -> dict[str, object]:
     """Get auth info for local (token.json) mode."""
     from utils.token_manager import get_token_manager
 
@@ -39,7 +38,7 @@ def _get_auth_info_local() -> dict[str, Any]:
     }
 
 
-async def get_health_info() -> dict[str, Any]:
+async def get_health_info() -> dict[str, object]:
     """Collect health information for the MCP server.
 
     Returns a sanitized health status dict that never exposes

--- a/utils/http_client.py
+++ b/utils/http_client.py
@@ -4,21 +4,45 @@ import asyncio
 import json
 import os
 import time
-from typing import Any
+from types import TracebackType
+from typing import NotRequired, Self, TypedDict, cast
 from urllib.parse import urljoin
 
 import httpx
 
+from utils.api_types import ApiErrorEnvelope, ApiPayload, ApiResult
 from utils.common import MCP_USER_AGENT
 from utils.logger import get_logger
 
 logger = get_logger('http_client')
 
 
+def _parse_json_body(response: httpx.Response) -> ApiPayload:
+    """Boundary: the only place raw upstream JSON enters typed code.
+
+    The upstream API returns either a JSON object or a JSON array;
+    anything else is coerced into an error-shaped dict by the caller.
+    """
+    parsed: ApiPayload = response.json()
+    return parsed
+
+
+class BatchRequestItem(TypedDict):
+    """Single request descriptor consumed by ``batch_request``."""
+
+    method: str
+    region: str
+    workspace: str
+    endpoint: str
+    token: str | None
+    params: NotRequired[dict[str, object] | None]
+    data: NotRequired[dict[str, object] | None]
+
+
 class AlpaconHTTPClient:
     """Async HTTP client for Alpacon API with connection pooling and caching."""
 
-    def __init__(self):
+    def __init__(self) -> None:
         """Initialize HTTP client."""
         self.base_timeout = httpx.Timeout(10.0, connect=5.0)
         self.max_retries = 3
@@ -30,7 +54,7 @@ class AlpaconHTTPClient:
         self._client_lock = asyncio.Lock()
 
         # Simple TTL cache
-        self._cache: dict[str, dict[str, Any]] = {}
+        self._cache: dict[str, ApiPayload] = {}
         self._cache_ttl: dict[str, float] = {}
         self.default_cache_ttl = 300  # 5 minutes
 
@@ -57,7 +81,7 @@ class AlpaconHTTPClient:
                 logger.debug('Created new HTTP client with connection pooling')
             return self._client
 
-    async def close(self):
+    async def close(self) -> None:
         """Close the HTTP client and clear caches.
 
         This is the primary public method for cleanup. Safe to call
@@ -71,7 +95,7 @@ class AlpaconHTTPClient:
             self._cache_ttl.clear()
         logger.info('HTTP client closed and caches cleared')
 
-    async def _close_client(self):
+    async def _close_client(self) -> None:
         """Close the shared client. Alias for close() for backward compatibility."""
         await self.close()
 
@@ -85,7 +109,9 @@ class AlpaconHTTPClient:
         """Number of entries in the response cache."""
         return len(self._cache)
 
-    def _get_cache_key(self, method: str, url: str, params: dict | None = None) -> str:
+    def _get_cache_key(
+        self, method: str, url: str, params: dict[str, object] | None = None
+    ) -> str:
         """Generate cache key for request."""
         key_parts = [method, url]
         if params:
@@ -110,7 +136,7 @@ class AlpaconHTTPClient:
 
         return any(endpoint.startswith(cacheable) for cacheable in cacheable_endpoints)
 
-    def _get_cached_response(self, cache_key: str) -> dict[str, Any] | None:
+    def _get_cached_response(self, cache_key: str) -> ApiPayload | None:
         """Get cached response if still valid.
 
         Uses .get() for resilient reads to avoid KeyError if close()
@@ -128,8 +154,8 @@ class AlpaconHTTPClient:
         return result
 
     def _set_cached_response(
-        self, cache_key: str, response: dict[str, Any], ttl: float | None = None
-    ):
+        self, cache_key: str, response: ApiPayload, ttl: float | None = None
+    ) -> None:
         """Cache response with TTL."""
         self._cache[cache_key] = response
         self._cache_ttl[cache_key] = time.time() + (ttl or self.default_cache_ttl)
@@ -144,7 +170,7 @@ class AlpaconHTTPClient:
     @staticmethod
     def _handle_upstream_401(
         exc: httpx.HTTPStatusError, token: str | None = None
-    ) -> dict[str, Any]:
+    ) -> ApiErrorEnvelope:
         """Handle upstream API 401 responses.
 
         Detects MFA-required errors from the Alpacon API response body
@@ -167,7 +193,7 @@ class AlpaconHTTPClient:
         source = ''
 
         try:
-            body = exc.response.json()
+            body = _parse_json_body(exc.response)
             if isinstance(body, dict) and body.get('code') == 'auth_mfa_required':
                 mfa_required = True
                 source = body.get('source', '')
@@ -229,7 +255,7 @@ class AlpaconHTTPClient:
             is_jwt,
         )
         error_msg = 'MFA verification required' if mfa_required else str(exc)
-        error_response = {
+        error_response: ApiErrorEnvelope = {
             'error': 'MFA Required' if mfa_required else 'HTTP Error',
             'status_code': 401,
             'message': error_msg,
@@ -262,10 +288,10 @@ class AlpaconHTTPClient:
         url: str,
         token: str | None = None,
         headers: dict[str, str] | None = None,
-        json_data: dict[str, Any] | None = None,
-        params: dict[str, Any] | None = None,
+        json_data: dict[str, object] | None = None,
+        params: dict[str, object] | None = None,
         timeout: float | None = None,
-    ) -> dict[str, Any]:
+    ) -> ApiResult:
         """Execute HTTP request with retry logic.
 
         Args:
@@ -278,7 +304,7 @@ class AlpaconHTTPClient:
             timeout: Request timeout in seconds
 
         Returns:
-            Response data as dictionary
+            Parsed JSON payload on success, or a standardized error envelope.
 
         Raises:
             httpx.HTTPError: If request fails after retries
@@ -332,7 +358,12 @@ class AlpaconHTTPClient:
                     url=url,
                     headers=request_headers,
                     json=json_data,
-                    params=params,
+                    # httpx's query-param stub is narrower (primitives only) than our
+                    # dict[str, object] boundary type; callers only ever pass
+                    # primitives here (verified: no tool constructs nested params).
+                    params=cast(
+                        dict[str, str | int | float | bool | None] | None, params
+                    ),
                     timeout=request_timeout,
                 )
 
@@ -347,7 +378,7 @@ class AlpaconHTTPClient:
 
                 # Return JSON response
                 if response.text:
-                    result = response.json()
+                    result = _parse_json_body(response)
                     logger.debug(f'Response body: {result}')
 
                     # Cache successful GET responses
@@ -389,7 +420,7 @@ class AlpaconHTTPClient:
                     if e.response.status_code == 401:
                         return self._handle_upstream_401(e, token=token)
 
-                    error_response = {
+                    error_response: ApiErrorEnvelope = {
                         'error': 'HTTP Error',
                         'status_code': e.response.status_code,
                         'message': str(e),
@@ -409,12 +440,12 @@ class AlpaconHTTPClient:
                     retry_delay = min(retry_delay * 2, self.max_retry_delay)
                     continue
                 else:
-                    error_response = {
+                    timeout_error: ApiErrorEnvelope = {
                         'error': 'Timeout',
                         'message': f'Request timed out after {self.max_retries} retries',
                     }
-                    logger.error(f'Request timeout after all retries: {error_response}')
-                    return error_response
+                    logger.error(f'Request timeout after all retries: {timeout_error}')
+                    return timeout_error
 
             except httpx.RequestError as e:
                 # Network error - retry
@@ -427,27 +458,31 @@ class AlpaconHTTPClient:
                     retry_delay = min(retry_delay * 2, self.max_retry_delay)
                     continue
                 else:
-                    error_response = {'error': 'Request Error', 'message': str(e)}
-                    logger.error(f'Network error after all retries: {error_response}')
-                    return error_response
+                    network_error: ApiErrorEnvelope = {
+                        'error': 'Request Error',
+                        'message': str(e),
+                    }
+                    logger.error(f'Network error after all retries: {network_error}')
+                    return network_error
 
             except Exception as e:
                 # Unexpected error - don't retry
-                error_response = {'error': 'Unexpected Error', 'message': str(e)}
-                logger.error(f'Unexpected error: {error_response}', exc_info=True)
-                return error_response
+                unexpected_error: ApiErrorEnvelope = {
+                    'error': 'Unexpected Error',
+                    'message': str(e),
+                }
+                logger.error(f'Unexpected error: {unexpected_error}', exc_info=True)
+                return unexpected_error
 
         # Should not reach here, but just in case
-        error_response = {
+        max_retries_error: ApiErrorEnvelope = {
             'error': 'Max retries exceeded',
             'message': f'Failed after {self.max_retries} attempts',
         }
-        logger.error(f'Unexpected fallback - max retries exceeded: {error_response}')
-        return error_response
+        logger.error(f'Unexpected fallback - max retries exceeded: {max_retries_error}')
+        return max_retries_error
 
-    async def batch_request(
-        self, requests: list[dict[str, Any]]
-    ) -> list[dict[str, Any]]:
+    async def batch_request(self, requests: list[BatchRequestItem]) -> list[ApiResult]:
         """Execute multiple requests in parallel.
 
         Args:
@@ -505,16 +540,15 @@ class AlpaconHTTPClient:
         results = await asyncio.gather(*tasks, return_exceptions=True)
 
         # Convert exceptions to error dictionaries
-        processed_results: list[dict[str, Any]] = []
+        processed_results: list[ApiResult] = []
         for i, result in enumerate(results):
             if isinstance(result, Exception):
-                processed_results.append(
-                    {
-                        'error': 'Request Exception',
-                        'message': str(result),
-                        'request_index': i,
-                    }
-                )
+                exception_envelope: ApiErrorEnvelope = {
+                    'error': 'Request Exception',
+                    'message': str(result),
+                    'request_index': i,
+                }
+                processed_results.append(exception_envelope)
             elif isinstance(result, BaseException):
                 raise result  # Re-raise CancelledError, KeyboardInterrupt, etc.
             else:
@@ -529,8 +563,8 @@ class AlpaconHTTPClient:
         workspace: str,
         endpoint: str,
         token: str | None = None,
-        params: dict[str, Any] | None = None,
-    ) -> dict[str, Any]:
+        params: dict[str, object] | None = None,
+    ) -> ApiResult:
         """Execute GET request.
 
         Args:
@@ -556,9 +590,9 @@ class AlpaconHTTPClient:
         workspace: str,
         endpoint: str,
         token: str | None = None,
-        data: dict[str, Any] | None = None,
-        params: dict[str, Any] | None = None,
-    ) -> dict[str, Any]:
+        data: dict[str, object] | None = None,
+        params: dict[str, object] | None = None,
+    ) -> ApiResult:
         """Execute POST request.
 
         Args:
@@ -585,8 +619,8 @@ class AlpaconHTTPClient:
         workspace: str,
         endpoint: str,
         token: str | None = None,
-        data: dict[str, Any] | None = None,
-    ) -> dict[str, Any]:
+        data: dict[str, object] | None = None,
+    ) -> ApiResult:
         """Execute PUT request.
 
         Args:
@@ -612,8 +646,8 @@ class AlpaconHTTPClient:
         workspace: str,
         endpoint: str,
         token: str | None = None,
-        data: dict[str, Any] | None = None,
-    ) -> dict[str, Any]:
+        data: dict[str, object] | None = None,
+    ) -> ApiResult:
         """Execute PATCH request.
 
         Args:
@@ -635,7 +669,7 @@ class AlpaconHTTPClient:
 
     async def delete(
         self, region: str, workspace: str, endpoint: str, token: str | None = None
-    ) -> dict[str, Any]:
+    ) -> ApiResult:
         """Execute DELETE request.
 
         Args:
@@ -652,11 +686,16 @@ class AlpaconHTTPClient:
 
         return await self.request(method='DELETE', url=full_url, token=token)
 
-    async def __aenter__(self):
+    async def __aenter__(self) -> Self:
         """Async context manager entry."""
         return self
 
-    async def __aexit__(self, exc_type, exc_val, exc_tb):
+    async def __aexit__(
+        self,
+        exc_type: type[BaseException] | None,
+        exc_val: BaseException | None,
+        exc_tb: TracebackType | None,
+    ) -> None:
         """Async context manager exit - close client."""
         await self._close_client()
 

--- a/utils/logger.py
+++ b/utils/logger.py
@@ -9,11 +9,11 @@ from pathlib import Path
 class AlpaconLogger:
     """Centralized logging configuration for Alpacon MCP Server."""
 
-    def __init__(self):
-        self._loggers: dict[str, logging.LoggerAdapter] = {}
+    def __init__(self) -> None:
+        self._loggers: dict[str, logging.LoggerAdapter[logging.Logger]] = {}
         self._setup_logging()
 
-    def _setup_logging(self):
+    def _setup_logging(self) -> None:
         """Setup logging configuration."""
         # Get log level from environment variable
         log_level = os.getenv('ALPACON_MCP_LOG_LEVEL', 'INFO').upper()
@@ -33,7 +33,7 @@ class AlpaconLogger:
             ],
         )
 
-    def get_logger(self, name: str) -> logging.LoggerAdapter:
+    def get_logger(self, name: str) -> logging.LoggerAdapter[logging.Logger]:
         """Get logger for specific module.
 
         Args:
@@ -56,7 +56,7 @@ class AlpaconLogger:
 logger_manager = AlpaconLogger()
 
 
-def get_logger(name: str) -> logging.LoggerAdapter:
+def get_logger(name: str) -> logging.LoggerAdapter[logging.Logger]:
     """Get logger for module.
 
     Args:

--- a/utils/oauth.py
+++ b/utils/oauth.py
@@ -153,7 +153,9 @@ def register_oauth_routes(mcp_server: FastMCP) -> None:
         mcp_server: FastMCP server instance
     """
 
-    @typed_custom_route(mcp_server, '/.well-known/oauth-authorization-server', methods=['GET'])
+    @typed_custom_route(
+        mcp_server, '/.well-known/oauth-authorization-server', methods=['GET']
+    )
     async def oauth_metadata(request: Request) -> Response:
         """OAuth 2.0 Authorization Server Metadata (RFC 8414).
 

--- a/utils/oauth.py
+++ b/utils/oauth.py
@@ -9,14 +9,37 @@ which bypasses MCP authentication — appropriate for OAuth flow endpoints.
 """
 
 import base64
+import binascii
 import json
 import os
+from collections.abc import Awaitable, Callable
+from typing import cast
 
 import httpx
+from mcp.server.fastmcp import FastMCP
+from starlette.requests import Request
+from starlette.responses import Response
 
 from utils.logger import get_logger
 
 logger = get_logger('oauth')
+
+RouteHandler = Callable[[Request], Awaitable[Response]]
+
+
+def typed_custom_route(
+    mcp_server: FastMCP, path: str, methods: list[str]
+) -> Callable[[RouteHandler], RouteHandler]:
+    """Type-safe wrapper around FastMCP.custom_route.
+
+    FastMCP.custom_route has no return type annotation upstream, so mypy
+    infers the decorator (and anything decorated by it) as Any. This wrapper
+    restores the real Callable[[Request], Awaitable[Response]] signature.
+    """
+    return cast(
+        Callable[[RouteHandler], RouteHandler],
+        mcp_server.custom_route(path, methods=methods),
+    )
 
 
 _ALLOWED_LOOPBACK_HOSTS = ('localhost', '127.0.0.1', '::1')
@@ -30,7 +53,7 @@ _DEFAULT_REDIRECT_DOMAINS = (
 )
 
 
-def _get_server_url(request) -> str:
+def _get_server_url(request: Request) -> str:
     """Build the MCP server's base URL from config or request.
 
     Prefers ALPACON_MCP_RESOURCE_URL env var to avoid relying on
@@ -82,7 +105,7 @@ def _is_allowed_redirect_url(url: str) -> bool:
     return hostname in allowed_domains
 
 
-def _build_redirect_url(base_url: str, extra_params: dict) -> str:
+def _build_redirect_url(base_url: str, extra_params: dict[str, str]) -> str:
     """Safely merge query params into a URL, preserving existing params."""
     from urllib.parse import parse_qs, urlencode, urlparse, urlunparse
 
@@ -123,15 +146,15 @@ def _get_oauth_config() -> dict[str, str]:
     }
 
 
-def register_oauth_routes(mcp_server):
+def register_oauth_routes(mcp_server: FastMCP) -> None:
     """Register OAuth proxy routes on the FastMCP server.
 
     Args:
         mcp_server: FastMCP server instance
     """
 
-    @mcp_server.custom_route('/.well-known/oauth-authorization-server', methods=['GET'])
-    async def oauth_metadata(request):
+    @typed_custom_route(mcp_server, '/.well-known/oauth-authorization-server', methods=['GET'])
+    async def oauth_metadata(request: Request) -> Response:
         """OAuth 2.0 Authorization Server Metadata (RFC 8414).
 
         Returns metadata advertising this MCP server as the OAuth
@@ -175,8 +198,8 @@ def register_oauth_routes(mcp_server):
             },
         )
 
-    @mcp_server.custom_route('/oauth/authorize', methods=['GET'])
-    async def oauth_authorize(request):
+    @typed_custom_route(mcp_server, '/oauth/authorize', methods=['GET'])
+    async def oauth_authorize(request: Request) -> Response:
         """Redirect to Auth0's authorization endpoint.
 
         Proxies the OAuth authorize request to Auth0, adding the
@@ -301,8 +324,8 @@ def register_oauth_routes(mcp_server):
             logger.info('Redirecting to Auth0 authorize endpoint')
         return RedirectResponse(url=auth0_url, status_code=302)
 
-    @mcp_server.custom_route('/oauth/token', methods=['POST'])
-    async def oauth_token(request):
+    @typed_custom_route(mcp_server, '/oauth/token', methods=['POST'])
+    async def oauth_token(request: Request) -> Response:
         """Proxy token exchange to Auth0.
 
         Forwards the token request to Auth0's /oauth/token endpoint.
@@ -474,8 +497,8 @@ def register_oauth_routes(mcp_server):
                 status_code=502,
             )
 
-    @mcp_server.custom_route('/oauth/register', methods=['POST'])
-    async def oauth_register(request):
+    @typed_custom_route(mcp_server, '/oauth/register', methods=['POST'])
+    async def oauth_register(request: Request) -> Response:
         """Dynamic Client Registration endpoint (RFC 7591).
 
         Auth0 does not support Dynamic Client Registration on non-Enterprise
@@ -564,8 +587,8 @@ def register_oauth_routes(mcp_server):
             },
         )
 
-    @mcp_server.custom_route('/oauth/callback', methods=['GET'])
-    async def oauth_callback(request):
+    @typed_custom_route(mcp_server, '/oauth/callback', methods=['GET'])
+    async def oauth_callback(request: Request) -> Response:
         """Handle Auth0 callback after authorization.
 
         Supports two-stage MFA flow:
@@ -588,7 +611,7 @@ def register_oauth_routes(mcp_server):
         original_state = ''
         stage = ''
         original_scope = ''
-        authorize_params: dict = {}
+        authorize_params: dict[str, str] = {}
         if composite_state:
             try:
                 state_data = json.loads(
@@ -602,7 +625,7 @@ def register_oauth_routes(mcp_server):
             except (
                 json.JSONDecodeError,
                 UnicodeDecodeError,
-                base64.binascii.Error,
+                binascii.Error,
             ) as e:
                 logger.warning(f'Failed to decode composite state: {e}')
                 # Fall back to treating the raw state as the original opaque state
@@ -748,8 +771,8 @@ def register_oauth_routes(mcp_server):
             result['state'] = original_state
         return JSONResponse(result)
 
-    @mcp_server.custom_route('/token', methods=['POST'])
-    async def oauth_token_fallback(request):
+    @typed_custom_route(mcp_server, '/token', methods=['POST'])
+    async def oauth_token_fallback(request: Request) -> Response:
         """Fallback token endpoint at /token.
 
         MCP SDK clients fall back to /token (instead of /oauth/token) when
@@ -760,8 +783,8 @@ def register_oauth_routes(mcp_server):
         logger.info('/token fallback hit — delegating to /oauth/token handler')
         return await oauth_token(request)
 
-    @mcp_server.custom_route('/authorize', methods=['GET'])
-    async def oauth_authorize_fallback(request):
+    @typed_custom_route(mcp_server, '/authorize', methods=['GET'])
+    async def oauth_authorize_fallback(request: Request) -> Response:
         """Fallback authorize endpoint at /authorize.
 
         MCP SDK clients fall back to /authorize when oauth_metadata
@@ -770,8 +793,8 @@ def register_oauth_routes(mcp_server):
         logger.info('/authorize fallback hit — delegating to /oauth/authorize handler')
         return await oauth_authorize(request)
 
-    @mcp_server.custom_route('/register', methods=['POST'])
-    async def oauth_register_fallback(request):
+    @typed_custom_route(mcp_server, '/register', methods=['POST'])
+    async def oauth_register_fallback(request: Request) -> Response:
         """Fallback register endpoint at /register.
 
         MCP SDK clients fall back to /register when oauth_metadata

--- a/utils/recovery_hints.py
+++ b/utils/recovery_hints.py
@@ -219,12 +219,11 @@ def enrich_error_response(
     if 'recovery_hints' in response:
         return response
 
-    # Some callers (format_validation_error) produce a legacy 'error_code'
-    # key outside the ToolResponse schema; read through a dict[str, object]
-    # view of the same underlying dict rather than widening ToolResponse.
+    # 'error_code' comes from ValidationErrorResponse, which this function's
+    # ToolResponse parameter type doesn't declare; read via an untyped view.
     raw = cast(dict[str, object], response)
     status_code = cast(
-        'int | str | None', raw.get('status_code') or raw.get('error_code')
+        int | str | None, raw.get('status_code') or raw.get('error_code')
     )
     message = cast(str, raw.get('message', ''))
 

--- a/utils/recovery_hints.py
+++ b/utils/recovery_hints.py
@@ -1,6 +1,8 @@
 """Recovery hints for error responses to help LLM self-recover."""
 
-from typing import Any
+from typing import cast
+
+from utils.api_types import ToolResponse
 
 # Hint registry: (status_code, domain) -> {recovery_hints, related_tools}
 _HINT_REGISTRY: dict[tuple[int, str], dict[str, list[str]]] = {
@@ -188,10 +190,10 @@ def get_recovery_hints(
 
 
 def enrich_error_response(
-    response: dict[str, Any],
+    response: ToolResponse,
     tool_name: str | None = None,
     endpoint: str | None = None,
-) -> dict[str, Any]:
+) -> ToolResponse:
     """Add recovery hints to an error response dict.
 
     Only modifies dicts that look like error responses (have status='error'
@@ -217,8 +219,14 @@ def enrich_error_response(
     if 'recovery_hints' in response:
         return response
 
-    status_code = response.get('status_code') or response.get('error_code')
-    message = response.get('message', '')
+    # Some callers (format_validation_error) produce a legacy 'error_code'
+    # key outside the ToolResponse schema; read through a dict[str, object]
+    # view of the same underlying dict rather than widening ToolResponse.
+    raw = cast(dict[str, object], response)
+    status_code = cast(
+        'int | str | None', raw.get('status_code') or raw.get('error_code')
+    )
+    message = cast(str, raw.get('message', ''))
 
     hints = get_recovery_hints(
         status_code=status_code,

--- a/utils/security_settings.py
+++ b/utils/security_settings.py
@@ -10,10 +10,10 @@ import hashlib
 import os
 import time
 from datetime import UTC, datetime
-from typing import Any
 
 import httpx
 
+from utils.api_types import JsonObject, JwtClaims
 from utils.logger import get_logger
 
 logger = get_logger('security_settings')
@@ -24,7 +24,7 @@ _CACHE_TTL = 300  # 5 minutes
 class WorkspaceSecuritySettings:
     """Parsed security settings for a single workspace."""
 
-    def __init__(self, data: dict[str, Any]) -> None:
+    def __init__(self, data: JsonObject) -> None:
         self.mfa_required: bool = data.get('mfa_required', False)
         self.mfa_timeout: int = data.get('mfa_timeout', 3600)
         self.mfa_required_actions: list[str] = data.get('mfa_required_actions', [])
@@ -49,7 +49,9 @@ class SecuritySettingsCache:
         # {token_key: {workspace: (settings, expiry_time)}}
         self._cache: dict[str, dict[str, tuple[WorkspaceSecuritySettings, float]]] = {}
         # Per-token in-flight deduplication to prevent thundering herd
-        self._inflight: dict[str, asyncio.Task] = {}
+        self._inflight: dict[
+            str, asyncio.Task[dict[str, WorkspaceSecuritySettings]]
+        ] = {}
         # Timestamp of last global prune (max once per TTL period)
         self._last_prune: float = 0
 
@@ -199,7 +201,7 @@ class SecuritySettingsCache:
 
 
 def check_mfa_completed(
-    jwt_claims: dict[str, Any],
+    jwt_claims: JwtClaims,
     settings: WorkspaceSecuritySettings,
 ) -> bool:
     """Check if JWT has valid (non-expired) MFA completion.

--- a/utils/setup_wizard.py
+++ b/utils/setup_wizard.py
@@ -33,7 +33,8 @@ def load_existing_config(config_path: Path) -> dict[str, dict[str, str]]:
     if config_path.exists():
         try:
             with open(config_path) as f:
-                return json.load(f)
+                data: dict[str, dict[str, str]] = json.load(f)
+                return data
         except json.JSONDecodeError:
             return {}
     return {}
@@ -52,7 +53,7 @@ def test_connection(region: str, workspace: str, token: str) -> bool:
 
         from .http_client import AlpaconHTTPClient
 
-        async def _test():
+        async def _test() -> bool:
             client = AlpaconHTTPClient()
             result = await client.get(
                 region=region,

--- a/utils/token_manager.py
+++ b/utils/token_manager.py
@@ -3,11 +3,32 @@
 import json
 import os
 from pathlib import Path
-from typing import Any
+from typing import TypedDict, cast
 
 from utils.logger import get_logger
 
 logger = get_logger('token_manager')
+
+# token.json structure: region -> workspace -> token (string only).
+type TokenStore = dict[str, dict[str, str]]
+
+
+class RegionTokenSummary(TypedDict):
+    """Per-region token count entry within AuthStatus."""
+
+    region: str
+    workspaces: list[str]
+    count: int
+
+
+class AuthStatus(TypedDict):
+    """Return shape of TokenManager.get_auth_status()."""
+
+    authenticated: bool
+    total_tokens: int
+    regions: list[RegionTokenSummary]
+    config_dir: str
+    token_file: str
 
 
 class TokenManager:
@@ -59,7 +80,7 @@ class TokenManager:
 
         self.tokens = self._load_tokens()
 
-    def _load_tokens(self) -> dict[str, Any]:
+    def _load_tokens(self) -> TokenStore:
         """Load tokens from configuration file.
 
         Returns:
@@ -72,7 +93,9 @@ class TokenManager:
                 logger.info(
                     f'Loaded tokens from {self.token_file}: {len(tokens)} regions'
                 )
-                return tokens
+                # json.load() returns Any; the on-disk shape is region ->
+                # workspace -> token, asserted here at the file-read boundary.
+                return cast(TokenStore, tokens)
             except json.JSONDecodeError as e:
                 logger.error(f'JSON decode error in {self.token_file}: {e}')
             except OSError as e:
@@ -83,7 +106,7 @@ class TokenManager:
         )
         return {}
 
-    def _save_tokens_to_file(self, tokens: dict[str, Any], file_path: Path) -> None:
+    def _save_tokens_to_file(self, tokens: TokenStore, file_path: Path) -> None:
         """Save tokens to specific file.
 
         Args:
@@ -154,13 +177,15 @@ class TokenManager:
         logger.warning(f'No token found for {workspace}.{region}')
         return None
 
-    def get_all_tokens(self) -> dict[str, Any]:
+    def get_all_tokens(self) -> dict[str, object]:
         """Get all stored tokens.
 
         Returns:
             All token data
         """
-        return self.tokens
+        # dict is invariant, so TokenStore (dict[str, dict[str, str]]) isn't
+        # directly a dict[str, object]; callers only ever read this generically.
+        return cast(dict[str, object], self.tokens)
 
     def get_available_regions(self) -> list[str]:
         """Get list of regions that have configured tokens.
@@ -228,7 +253,7 @@ class TokenManager:
             'message': f'No token found for {workspace}.{region}',
         }
 
-    def get_auth_status(self) -> dict[str, Any]:
+    def get_auth_status(self) -> AuthStatus:
         """Get authentication status for all stored tokens.
 
         Returns:
@@ -236,7 +261,7 @@ class TokenManager:
         """
         total_tokens = sum(len(workspaces) for workspaces in self.tokens.values())
 
-        regions = []
+        regions: list[RegionTokenSummary] = []
         for region, workspaces in self.tokens.items():
             regions.append(
                 {
@@ -254,7 +279,7 @@ class TokenManager:
             'token_file': str(self.token_file),
         }
 
-    def get_config_info(self) -> dict[str, Any]:
+    def get_config_info(self) -> dict[str, object]:
         """Get configuration directory information.
 
         Returns:


### PR DESCRIPTION
## Background

The codebase handled most API responses and tool return values as `dict[str, Any]`, so mypy verified essentially nothing. The CI mypy step was also gated with `continue-on-error: true`, so type errors passed silently. This PR removes `Any` across the codebase, quarantines it into a single boundary module, and promotes mypy strict to a CI gate that actually fails.

## What changed

Adds a new module `utils/api_types.py` that confines the unavoidable `Any` to this one file. Untrusted JSON crossing the API boundary is expressed only through explicit boundary aliases such as `ApiPayload`, `JwtClaims`, `AsgiMessage`, and `JsonObject`, and every other module imports these aliases instead of using `Any` directly. All `Any` used as an actual type annotation now lives in this module; the 3 remaining `Any` tokens in other files are all text inside comments.

Formalizes the tool response envelope with TypedDicts. Defines `SuccessResponse`, `ErrorResponse`, `ValidationErrorResponse`, `PendingApprovalResponse`, and their union `ToolResponse`. The context keys each tool attaches to a response were enumerated via an AST scan of every keyword argument passed to the response builders and collected into the `ResponseContext` TypedDict. The builders accept `**kwargs: Unpack[ResponseContext]`, so an invalid key is caught at type-check time.

Narrows raw JSON parsing in the HTTP client to a single `_parse_json_body()` boundary function, and aligns every method to return `ApiResult` (either a valid payload or the standardized error envelope). Tool code branches on errors via the `is_api_error()` TypeGuard.

Applies PEP 695 generics and ParamSpec to the decorators so that the original tool signature is preserved after `mcp_tool_handler` and friends wrap it. While doing this we found a bug where FastMCP's `func_metadata()` did not filter out the token-injection `**kwargs`, exposing a required `kwargs: string` field in every tool's input schema. Fixed by stripping the VAR_KEYWORD parameter from the exposed signature.

Sets `[tool.mypy] strict = true` in `pyproject.toml` and removes `continue-on-error` from the CI mypy step. Type errors now fail CI.

## Safety

The guiding principle was no runtime behavior change. The only observable change is the FastMCP schema bug fix above: the erroneously exposed `kwargs` field disappears from tool input schemas. This is pinned by the regression test `tests/test_tool_schemas.py`.

## Testing

Locally: ruff check passes, ruff format verified (83 files), mypy strict reports no issues across 39 source files, pytest 868 passed. Added unit tests for `api_types.py` and a tool-schema regression test.

## Checklist

- [x] mypy strict passes (39 files)
- [x] full test suite passes (868 passed)
- [x] ruff lint/format passes
- [x] no runtime behavior change (except the FastMCP schema bug fix)
