### PR TITLE
fix(tools): return the requested server and expose list pagination

### DIFF
--- a/tests/integration/conftest.py
+++ b/tests/integration/conftest.py
@@ -122,23 +122,15 @@ def sample_api_responses():
                 ],
             },
             'server_detail': {
-                'count': 1,
-                'results': [
-                    {
-                        'id': '550e8400-e29b-41d4-a716-446655440001',
-                        'name': 'web-server-01',
-                        'ip': '10.0.1.10',
-                        'status': 'running',
-                        'os': 'Ubuntu 22.04',
-                        'cpu': 4,
-                        'memory': 8192,
-                    },
-                ],
+                'id': '550e8400-e29b-41d4-a716-446655440001',
+                'name': 'web-server-01',
+                'ip': '10.0.1.10',
+                'status': 'running',
+                'os': 'Ubuntu 22.04',
+                'cpu': 4,
+                'memory': 8192,
             },
-            'server_not_found': {
-                'count': 0,
-                'results': [],
-            },
+            'server_not_found': {'detail': 'Not found.'},
             'server_note_created': {
                 'id': 'note-001',
                 'server': '550e8400-e29b-41d4-a716-446655440001',

--- a/tests/integration/test_tool_end_to_end.py
+++ b/tests/integration/test_tool_end_to_end.py
@@ -59,8 +59,8 @@ class TestServerToolsEndToEnd:
         api_data = sample_api_responses()
 
         def handler(request: httpx.Request) -> httpx.Response:
-            # Verify the request has the server ID filter
-            assert 'id' in str(request.url)
+            # The server must be addressed by URL path, not a list filter
+            assert request.url.path.endswith(f'/api/servers/servers/{SERVER_UUID}/')
             return httpx.Response(200, json=api_data['server_detail'])
 
         patched_http_client.set_handler(handler)
@@ -80,7 +80,7 @@ class TestServerToolsEndToEnd:
         api_data = sample_api_responses()
 
         def handler(request: httpx.Request) -> httpx.Response:
-            return httpx.Response(200, json=api_data['server_not_found'])
+            return httpx.Response(404, json=api_data['server_not_found'])
 
         patched_http_client.set_handler(handler)
 
@@ -91,7 +91,8 @@ class TestServerToolsEndToEnd:
         )
 
         assert result['status'] == 'error'
-        assert 'Server not found' in result['message']
+        assert result['status_code'] == 404
+        assert result['server_id'] == '99999999-9999-9999-9999-999999999999'
 
     async def test_create_server_note_post_body(
         self, patched_http_client, mock_token_for_integration, sample_api_responses

--- a/tests/test_server_tools.py
+++ b/tests/test_server_tools.py
@@ -128,6 +128,27 @@ class TestListServers:
             workspace='testworkspace',
             endpoint='/api/servers/servers/',
             token='test-token',
+            params={},
+        )
+
+    @pytest.mark.asyncio
+    async def test_list_servers_pagination(
+        self, mock_http_client, mock_token_manager, sample_servers_list
+    ):
+        """Test servers list forwards pagination params to the API."""
+        mock_http_client.get.return_value = sample_servers_list
+
+        result = await list_servers(
+            workspace='testworkspace', region='ap1', page=2, page_size=100
+        )
+
+        assert result['status'] == 'success'
+        mock_http_client.get.assert_called_once_with(
+            region='ap1',
+            workspace='testworkspace',
+            endpoint='/api/servers/servers/',
+            token='test-token',
+            params={'page': 2, 'page_size': 100},
         )
 
     @pytest.mark.asyncio
@@ -156,6 +177,7 @@ class TestListServers:
             workspace='testworkspace',
             endpoint='/api/servers/servers/',
             token='test-token',
+            params={},
         )
 
     @pytest.mark.asyncio
@@ -177,7 +199,7 @@ class TestGetServer:
         self, mock_http_client, mock_token_manager, sample_server
     ):
         """Test successful server details retrieval."""
-        mock_http_client.get.return_value = {'count': 1, 'results': [sample_server]}
+        mock_http_client.get.return_value = sample_server
 
         result = await get_server(
             server_id='550e8400-e29b-41d4-a716-446655440123', workspace='testworkspace'
@@ -187,12 +209,13 @@ class TestGetServer:
         assert result['data'] == sample_server
         assert result['server_id'] == '550e8400-e29b-41d4-a716-446655440123'
 
+        # Must address the server directly: the list endpoint ignores an 'id'
+        # filter and would return the first server of the default ordering.
         mock_http_client.get.assert_called_once_with(
             region='ap1',
             workspace='testworkspace',
-            endpoint='/api/servers/servers/',
+            endpoint='/api/servers/servers/550e8400-e29b-41d4-a716-446655440123/',
             token='test-token',
-            params={'id': '550e8400-e29b-41d4-a716-446655440123'},
         )
 
     @pytest.mark.asyncio
@@ -211,21 +234,27 @@ class TestGetServer:
     @pytest.mark.asyncio
     async def test_get_server_not_found(self, mock_http_client, mock_token_manager):
         """Test server details with non-existent server."""
-        mock_http_client.get.return_value = {'count': 0, 'results': []}
+        mock_http_client.get.return_value = {
+            'error': 'HTTP Error',
+            'status_code': 404,
+            'message': 'Not found.',
+            'response': '{"detail":"Not found."}',
+        }
 
         result = await get_server(
             server_id='99999999-9999-9999-9999-999999999999', workspace='testworkspace'
         )
 
         assert result['status'] == 'error'
-        assert 'Server not found' in result['message']
+        assert result['status_code'] == 404
+        assert result['server_id'] == '99999999-9999-9999-9999-999999999999'
 
     @pytest.mark.asyncio
     async def test_get_server_different_region(
         self, mock_http_client, mock_token_manager, sample_server
     ):
         """Test server details with different region."""
-        mock_http_client.get.return_value = {'count': 1, 'results': [sample_server]}
+        mock_http_client.get.return_value = sample_server
 
         result = await get_server(
             server_id='550e8400-e29b-41d4-a716-446655440123',
@@ -237,9 +266,8 @@ class TestGetServer:
         mock_http_client.get.assert_called_once_with(
             region='eu1',
             workspace='testworkspace',
-            endpoint='/api/servers/servers/',
+            endpoint='/api/servers/servers/550e8400-e29b-41d4-a716-446655440123/',
             token='test-token',
-            params={'id': '550e8400-e29b-41d4-a716-446655440123'},
         )
 
     @pytest.mark.asyncio
@@ -428,6 +456,7 @@ class TestParameterValidation:
             workspace='test-workspace_123',
             endpoint='/api/servers/servers/',
             token='test-token',
+            params={},
         )
 
     @pytest.mark.asyncio
@@ -477,6 +506,7 @@ class TestRegionHandling:
             workspace='testworkspace',
             endpoint='/api/servers/servers/',
             token='test-token',
+            params={},
         )
 
 

--- a/tools/server_tools.py
+++ b/tools/server_tools.py
@@ -114,13 +114,14 @@ async def get_server(
         token=token,
     )
 
-    if err := unwrap_http_result(
+    err = unwrap_http_result(
         result,
         default_message='Failed to get server details',
         server_id=server_id,
         region=region,
         workspace=workspace,
-    ):
+    )
+    if err:
         return err
 
     return success_response(

--- a/tools/server_tools.py
+++ b/tools/server_tools.py
@@ -16,6 +16,9 @@ _PLATFORM_LIST_STR = ', '.join(f'"{p}"' for p in sorted(VALID_PLATFORMS))
     description=(
         'List all servers in a workspace. Returns server names, UUIDs, status, OS, and connection info. '
         'Use this to discover available servers and obtain server IDs required by other tools. '
+        'Results are paginated: 15 per page by default. Compare the response `count` against the '
+        'number of `results` and follow the `next` page number—or pass page_size (max 100)—to see '
+        'every server. '
         'Related: get_server (single server details), get_server_overview (full system info).'
     ),
     annotations=READ_ONLY,
@@ -24,12 +27,20 @@ _PLATFORM_LIST_STR = ', '.join(f'"{p}"' for p in sorted(VALID_PLATFORMS))
         'anthropic/searchHint': 'server list inventory discover find all',
     },
 )
-async def list_servers(workspace: str, region: str = '', **kwargs) -> dict[str, Any]:
+async def list_servers(
+    workspace: str,
+    region: str = '',
+    page: int | None = None,
+    page_size: int | None = None,
+    **kwargs,
+) -> dict[str, Any]:
     """Get list of servers.
 
     Args:
         workspace: Workspace name. Required parameter
         region: Region (ap1, us1, eu1). Auto-detected if not provided
+        page: Page number for pagination (optional)
+        page_size: Number of results per page, up to 100 (optional)
 
     Returns:
         Server list response
@@ -37,12 +48,19 @@ async def list_servers(workspace: str, region: str = '', **kwargs) -> dict[str, 
     # Get token (injected by decorator)
     token = kwargs.get('token')
 
+    params: dict[str, Any] = {}
+    if page is not None:
+        params['page'] = page
+    if page_size is not None:
+        params['page_size'] = page_size
+
     # Make async call to servers endpoint
     result = await http_client.get(
         region=region,
         workspace=workspace,
         endpoint='/api/servers/servers/',
         token=token,
+        params=params,
     )
 
     # Check if result is an error response from http_client
@@ -87,41 +105,26 @@ async def get_server(
     # Get token (injected by decorator)
     token = kwargs.get('token')
 
-    # Make async call to server detail endpoint
-    # Use servers/servers/ endpoint with ID filter instead of direct ID endpoint
+    # The list endpoint has no 'id' filter, so filtering there is silently ignored
+    # and returns the first server of the default ordering. Address the server directly.
     result = await http_client.get(
         region=region,
         workspace=workspace,
-        endpoint='/api/servers/servers/',
+        endpoint=f'/api/servers/servers/{server_id}/',
         token=token,
-        params={'id': server_id},
     )
 
-    # Check if result is an error response from http_client
-    if isinstance(result, dict) and 'error' in result:
-        error_kwargs: dict[str, Any] = {
-            'server_id': server_id,
-            'region': region,
-            'workspace': workspace,
-        }
-        status_code = result.get('status_code')
-        if status_code is not None:
-            error_kwargs['status_code'] = status_code
-        return error_response(
-            result.get('message', 'Failed to get server details'),
-            **error_kwargs,
-        )
-
-    # Extract the first result from the list if results exist
-    if isinstance(result, dict) and 'results' in result and len(result['results']) > 0:
-        server_data = result['results'][0]
-    else:
-        return error_response(
-            'Server not found', server_id=server_id, region=region, workspace=workspace
-        )
+    if err := unwrap_http_result(
+        result,
+        default_message='Failed to get server details',
+        server_id=server_id,
+        region=region,
+        workspace=workspace,
+    ):
+        return err
 
     return success_response(
-        data=server_data, server_id=server_id, region=region, workspace=workspace
+        data=result, server_id=server_id, region=region, workspace=workspace
     )
 
 


### PR DESCRIPTION
## Background

Two bugs in `tools/server_tools.py` made server discovery through MCP unreliable. Both were found while investigating a report that server listing and command execution felt intermittently broken, and both were reproduced live against the dev workspace through the deployed connector.

`get_server` sent the server UUID as an `id` query parameter to the list endpoint (`tools/server_tools.py:97`, before this change), with a comment stating this was deliberate: "Use servers/servers/ endpoint with ID filter instead of direct ID endpoint". But `ServerFilter.Meta.fields` in alpacon-server (`servers/api/filters.py:116`) does not declare an `id` field, so django-filter silently ignores the parameter. The tool then took `results[0]`, which is the first server of the default ordering (`-starred, starredserver__ordering, name`). The result: every UUID returned the same server. Requesting `7e6cf167-eb9d-4bb5-b38e-2048d695f1fa` against dev returned `gangnam-gl-runner` (`dc1fb917-...`) with `status="success"`. Nothing in the response signalled the mismatch, so an agent could report the wrong server's state and act on it.

`list_servers` sent no query parameters at all, so it always got the DRF default of 15 results per page (`PAGE_SIZE: 15` in `alpacon/settings.py:450`). The dev workspace has 18 servers: the response carried `count: 18` and `next: 2`, but the tool exposed no way to request page 2, and passing `page` was dropped by the MCP argument model. Three servers were unreachable through MCP with no error surfaced.

## Changes

`get_server` now addresses the server by URL path (`/api/servers/servers/{server_id}/`). The detail route already exists — `ServerViewSet` is a `ModelViewSet` registered via router (`servers/api/urls.py:17`) — so this needs no server-side change, and it uses `ServerSerializer` rather than the list serializer, returning a superset of the previous fields. Error handling moves from a hand-rolled branch to the `unwrap_http_result()` helper used by the rest of the repo, so a 404 now surfaces as an error carrying its `status_code` instead of a generic "Server not found". `server_id` is validated as a UUID by `with_token_validation` before it reaches the path, so the interpolation is safe.

`list_servers` accepts optional `page` and `page_size` and forwards them, following the convention already used by `list_registration_tokens` (`tools/server_tools.py:848`). The server-side default of 15 is unchanged; the tool description now states the pagination contract so an agent knows to compare `count` against the number of `results` and follow `next` or pass `page_size` (max 100).

## Tests

Four existing tests pinned the buggy behaviour (asserting `params={'id': ...}` and the `results[0]` unwrapping) and were updated to assert the detail route and the bare-object response. The not-found tests now model a real 404 rather than an empty result list, and assert `status_code` is preserved. One test was added covering that `page` and `page_size` reach the API.

Full suite: 881 passed, 2 failed. Both failures (`tests/test_basic.py::test_import_main`, `tests/test_simple_integration.py::TestMCPServerConfiguration::test_main_entry_point`) are pre-existing and were confirmed to fail identically on a clean tree at `1022ef4`.

Not verified live: the local API token in `~/.alpacon-mcp/token.json` returns 401 (`Authentication credentials were not provided`), and the deployed connector runs released code, so neither path can exercise this branch. The header format the client sends (`token=...`) does match the server's parser (`api/apitoken/auth.py:26`), so the token itself appears stale rather than the scheme being wrong. Verification here rests on the test suite plus the routing and filter definitions in alpacon-server cited above; a live check is worth doing after deploy.

## Checklist

- [x] `get_server` no longer depends on a query filter the API does not implement
- [x] `list_servers` can reach every server in a workspace larger than one page
- [x] Tests that pinned the old behaviour updated rather than deleted; regression test added for pagination
- [x] Pre-existing test failures confirmed unrelated to this branch
