### PR TITLE
feat(host): support pinned workspace API base URL for slug-change safety

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -162,6 +162,34 @@ This MCP server provides a **pure HTTP API bridge** to Alpacon's infrastructure 
 }
 ```
 
+**Host derivation and pinning a base URL** (slug-change safety, ADR 0027):
+
+By default the API host is derived from the workspace label as
+`https://{workspace}.{region}.alpacon.io` on every call (`http_client.get_base_url`).
+Because a workspace's URL slug is a mutable label — a freed slug can later be
+reused by a different workspace — re-deriving the host from a stale label could
+resolve to the wrong host. To pin a workspace's resolved base URL, use the
+object form of a token entry (the old host stays alive as an alias, so the
+pinned URL keeps working across a slug change):
+
+```json
+{
+  "us1": {
+    "workspace-name": {
+      "token": "your-api-token-from-web-interface",
+      "url": "https://workspace-name.us1.alpacon.io"
+    }
+  }
+}
+```
+
+The bare-string form (`"workspace-name": "token"`) remains fully supported and
+derives the default host. A pinned URL can also be supplied via the
+`ALPACON_MCP_<REGION>_<WORKSPACE>_URL` env var (mirrors the token env override
+`ALPACON_MCP_<REGION>_<WORKSPACE>_TOKEN`); the env var wins over the config file.
+`TokenManager.get_base_url_override()` resolves the pinned URL and
+`get_base_url` falls back to derivation when none is configured.
+
 **MFA re-authentication flow** (remote/streamable-http mode only):
 
 When the Alpacon API returns 401 (e.g., MFA timeout with `code: "auth_mfa_required"`), the system triggers a two-stage OAuth re-authentication via the browser:

--- a/README.md
+++ b/README.md
@@ -231,6 +231,29 @@ export ALPACON_MCP_AP1_PRODUCTION_TOKEN="alpat-ABC123xyz789..."
 uvx alpacon-mcp
 ```
 
+**Pinning a workspace API host** (optional):
+
+By default the API host is derived from the workspace name as
+`https://{workspace}.{region}.alpacon.io`. To pin a fixed base URL instead —
+so a workspace stays reachable even if its URL label later changes — use the
+object form of a token entry:
+
+```bash
+echo '{
+  "us1": {
+    "production": {
+      "token": "alpat-ABC123xyz789...",
+      "url": "https://production.us1.alpacon.io"
+    }
+  }
+}' > ~/.alpacon-mcp/token.json
+```
+
+Or via environment variable (wins over the config file):
+```bash
+export ALPACON_MCP_US1_PRODUCTION_URL="https://production.us1.alpacon.io"
+```
+
 ### Option C: development installation
 ```bash
 git clone https://github.com/alpacax/alpacon-mcp.git

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -40,6 +40,10 @@ def mock_region_auto_detect():
     mock_tm.find_region_for_workspace.return_value = 'ap1'
     mock_tm.get_default_region.return_value = 'ap1'
     mock_tm.get_available_regions.return_value = ['ap1']
+    # No pinned host override by default: http_client.get_base_url derives the
+    # default Alpacon Cloud host. (get_base_url also type-guards this, but being
+    # explicit keeps the mock's behavior obvious.)
+    mock_tm.get_base_url_override.return_value = None
 
     with patch('utils.token_manager.get_token_manager', return_value=mock_tm):
         yield mock_tm

--- a/tests/test_http_client.py
+++ b/tests/test_http_client.py
@@ -266,6 +266,80 @@ class TestURLConstruction:
         for i, expected_url in enumerate(expected_urls):
             assert calls[i][1]['url'] == expected_url
 
+    @pytest.mark.asyncio
+    async def test_configured_base_url_override_is_used(self, mock_httpx_client):
+        """A pinned base URL is used verbatim instead of the derived host.
+
+        This keeps a workspace addressable across a URL slug change (ADR 0027):
+        the host is a persisted value, not re-derived from the workspace label.
+        """
+        mock_response = create_mock_response(status_code=200, json_data={'ok': True})
+        mock_httpx_client.request.return_value = mock_response
+
+        fake_tm = MagicMock()
+        fake_tm.get_base_url_override.return_value = 'https://old-slug.us1.alpacon.io'
+        with patch(
+            'utils.token_manager.get_token_manager', return_value=fake_tm
+        ):
+            await http_client.get(
+                region='us1',
+                workspace='renamed-workspace',
+                endpoint='/api/test/',
+                token='test-token',
+            )
+
+        call = mock_httpx_client.request.call_args_list[-1]
+        assert call[1]['url'] == 'https://old-slug.us1.alpacon.io/api/test/'
+        fake_tm.get_base_url_override.assert_called_once_with(
+            'us1', 'renamed-workspace'
+        )
+
+    def test_get_base_url_default_derivation(self):
+        """With no override configured, the default Alpacon Cloud host is derived."""
+        fake_tm = MagicMock()
+        fake_tm.get_base_url_override.return_value = None
+        with patch(
+            'utils.token_manager.get_token_manager', return_value=fake_tm
+        ):
+            assert (
+                http_client.get_base_url('ap1', 'myws')
+                == 'https://myws.ap1.alpacon.io'
+            )
+
+    @pytest.mark.asyncio
+    async def test_pinned_base_url_override_used(self, mock_httpx_client):
+        """A configured base-URL override replaces the derived host (ADR 0027)."""
+        mock_response = create_mock_response(status_code=200, json_data={'ok': True})
+        mock_httpx_client.request.return_value = mock_response
+
+        mock_tm = MagicMock()
+        mock_tm.get_base_url_override.return_value = 'https://pinned.us1.alpacon.io'
+        with patch(
+            'utils.token_manager.get_token_manager', return_value=mock_tm
+        ):
+            await http_client.get(
+                region='ap1',
+                workspace='oldlabel',
+                endpoint='/api/test/',
+                token='test-token',
+            )
+
+        call = mock_httpx_client.request.call_args
+        # The stale workspace/region label is ignored in favor of the pinned host.
+        assert call[1]['url'] == 'https://pinned.us1.alpacon.io/api/test/'
+
+    def test_get_base_url_falls_back_when_no_override(self):
+        """With no override configured, the default Alpacon Cloud host is derived."""
+        mock_tm = MagicMock()
+        mock_tm.get_base_url_override.return_value = None
+        with patch(
+            'utils.token_manager.get_token_manager', return_value=mock_tm
+        ):
+            assert (
+                http_client.get_base_url('ap1', 'myws')
+                == 'https://myws.ap1.alpacon.io'
+            )
+
 
 class TestErrorHandling:
     """Test error handling scenarios."""

--- a/tests/test_token_manager.py
+++ b/tests/test_token_manager.py
@@ -1,0 +1,102 @@
+"""Unit tests for TokenManager token and base-URL resolution.
+
+Covers the legacy bare-string token form, the object form
+``{"token": "...", "url": "..."}`` (used to pin a workspace's API host across a
+slug change, ADR 0027), and the environment-variable overrides for both token
+and base URL.
+"""
+
+import json
+
+import pytest
+
+from utils.token_manager import TokenManager
+
+
+@pytest.fixture
+def token_file(tmp_path):
+    """Return a path factory that writes token.json content and builds a TokenManager."""
+
+    def _make(config: dict) -> TokenManager:
+        path = tmp_path / 'token.json'
+        path.write_text(json.dumps(config))
+        return TokenManager(config_file=str(path))
+
+    return _make
+
+
+class TestGetTokenForms:
+    """Both the legacy string form and the object form yield the token string."""
+
+    def test_bare_string_token(self, token_file):
+        tm = token_file({'ap1': {'production': 'plain-token'}})
+        assert tm.get_token('ap1', 'production') == 'plain-token'
+
+    def test_object_form_token(self, token_file):
+        tm = token_file(
+            {'ap1': {'production': {'token': 'obj-token', 'url': 'https://x'}}}
+        )
+        assert tm.get_token('ap1', 'production') == 'obj-token'
+
+    def test_object_form_without_token_returns_none(self, token_file):
+        tm = token_file({'ap1': {'production': {'url': 'https://x'}}})
+        assert tm.get_token('ap1', 'production') is None
+
+    def test_missing_workspace_returns_none(self, token_file):
+        tm = token_file({'ap1': {'production': 'plain-token'}})
+        assert tm.get_token('ap1', 'staging') is None
+
+    def test_env_var_token_wins(self, token_file, monkeypatch):
+        tm = token_file({'ap1': {'production': 'config-token'}})
+        monkeypatch.setenv('ALPACON_MCP_AP1_PRODUCTION_TOKEN', 'env-token')
+        assert tm.get_token('ap1', 'production') == 'env-token'
+
+
+class TestGetBaseURLOverride:
+    """A pinned base URL is preferred over the derived host."""
+
+    def test_no_override_by_default(self, token_file):
+        tm = token_file({'ap1': {'production': 'plain-token'}})
+        assert tm.get_base_url_override('ap1', 'production') is None
+
+    def test_object_form_url_override(self, token_file):
+        tm = token_file(
+            {
+                'ap1': {
+                    'production': {'token': 't', 'url': 'https://acme.us1.alpacon.io'}
+                }
+            }
+        )
+        assert (
+            tm.get_base_url_override('ap1', 'production')
+            == 'https://acme.us1.alpacon.io'
+        )
+
+    def test_url_override_normalizes_scheme_and_trailing_slash(self, token_file):
+        tm = token_file(
+            {'ap1': {'production': {'token': 't', 'url': 'acme.us1.alpacon.io/'}}}
+        )
+        assert (
+            tm.get_base_url_override('ap1', 'production')
+            == 'https://acme.us1.alpacon.io'
+        )
+
+    def test_env_var_url_override_wins(self, token_file, monkeypatch):
+        tm = token_file(
+            {'ap1': {'production': {'token': 't', 'url': 'https://from-config'}}}
+        )
+        monkeypatch.setenv(
+            'ALPACON_MCP_AP1_PRODUCTION_URL', 'https://from-env.us1.alpacon.io'
+        )
+        assert (
+            tm.get_base_url_override('ap1', 'production')
+            == 'https://from-env.us1.alpacon.io'
+        )
+
+    def test_bare_string_entry_has_no_override(self, token_file):
+        tm = token_file({'ap1': {'production': 'plain-token'}})
+        assert tm.get_base_url_override('ap1', 'production') is None
+
+    def test_missing_workspace_has_no_override(self, token_file):
+        tm = token_file({'ap1': {'production': {'token': 't', 'url': 'https://x'}}})
+        assert tm.get_base_url_override('ap1', 'staging') is None

--- a/tests/test_workspace_tools.py
+++ b/tests/test_workspace_tools.py
@@ -32,6 +32,9 @@ def mock_token_manager():
         },
         'eu1': {'compliance': {'token': 'token6'}},
     }
+    # No pinned host override by default; list_workspaces falls back to the
+    # derived {workspace}.{region}.alpacon.io host.
+    mock_manager.get_base_url_override.return_value = None
 
     with (
         patch('utils.token_manager.get_token_manager', return_value=mock_manager),
@@ -143,27 +146,53 @@ class TestListWorkspaces:
         assert development_ws['has_token'] is False
 
     @pytest.mark.asyncio
-    async def test_list_workspaces_reports_pinned_url_domain(self, mock_token_manager):
-        """A pinned base URL (object form) is reported as the workspace domain."""
+    async def test_list_workspaces_reports_pinned_url_domain(
+        self, tmp_path, monkeypatch
+    ):
+        """The reported domain resolves through get_base_url_override.
+
+        Uses a real TokenManager so the displayed host gets the same
+        precedence (env var over config) and normalization (scheme added,
+        trailing slash dropped) as actual request routing.
+        """
+        import json
+
         from tools.workspace_tools import list_workspaces
+        from utils.token_manager import TokenManager
 
-        mock_token_manager.get_all_tokens.return_value = {
-            'us1': {
-                'acme': {'token': 'token1', 'url': 'https://acme.us1.alpacon.io'},
-                'plain': 'bare-token',
-            }
-        }
+        config_path = tmp_path / 'token.json'
+        config_path.write_text(
+            json.dumps(
+                {
+                    'us1': {
+                        # Scheme-less with trailing slash: display must be normalized.
+                        'acme': {'token': 'token1', 'url': 'acme.us1.alpacon.io/'},
+                        # Bare string: derived host, unless the env var pins one.
+                        'plain': 'bare-token',
+                    }
+                }
+            )
+        )
+        monkeypatch.setenv(
+            'ALPACON_MCP_US1_PLAIN_URL', 'https://pinned-by-env.us1.alpacon.io'
+        )
+        real_manager = TokenManager(config_file=str(config_path))
 
-        result = await list_workspaces(region='us1')
+        with (
+            patch('utils.token_manager.get_token_manager', return_value=real_manager),
+            patch('utils.decorators._get_jwt_token', return_value=None),
+        ):
+            result = await list_workspaces(region='us1')
 
         workspaces = result['data']['workspaces']
         acme_ws = next(ws for ws in workspaces if ws['workspace'] == 'acme')
         plain_ws = next(ws for ws in workspaces if ws['workspace'] == 'plain')
 
-        # Pinned URL wins; bare-string entry falls back to derived host.
+        # Config URL is normalized exactly as http_client.get_base_url uses it.
         assert acme_ws['domain'] == 'https://acme.us1.alpacon.io'
         assert acme_ws['has_token'] is True
-        assert plain_ws['domain'] == 'plain.us1.alpacon.io'
+        # Env-var override applies to display too, even for bare-string entries.
+        assert plain_ws['domain'] == 'https://pinned-by-env.us1.alpacon.io'
 
     @pytest.mark.asyncio
     async def test_list_workspaces_default_region(self, mock_token_manager):

--- a/tests/test_workspace_tools.py
+++ b/tests/test_workspace_tools.py
@@ -143,6 +143,29 @@ class TestListWorkspaces:
         assert development_ws['has_token'] is False
 
     @pytest.mark.asyncio
+    async def test_list_workspaces_reports_pinned_url_domain(self, mock_token_manager):
+        """A pinned base URL (object form) is reported as the workspace domain."""
+        from tools.workspace_tools import list_workspaces
+
+        mock_token_manager.get_all_tokens.return_value = {
+            'us1': {
+                'acme': {'token': 'token1', 'url': 'https://acme.us1.alpacon.io'},
+                'plain': 'bare-token',
+            }
+        }
+
+        result = await list_workspaces(region='us1')
+
+        workspaces = result['data']['workspaces']
+        acme_ws = next(ws for ws in workspaces if ws['workspace'] == 'acme')
+        plain_ws = next(ws for ws in workspaces if ws['workspace'] == 'plain')
+
+        # Pinned URL wins; bare-string entry falls back to derived host.
+        assert acme_ws['domain'] == 'https://acme.us1.alpacon.io'
+        assert acme_ws['has_token'] is True
+        assert plain_ws['domain'] == 'plain.us1.alpacon.io'
+
+    @pytest.mark.asyncio
     async def test_list_workspaces_default_region(self, mock_token_manager):
         """Test workspace listing without region returns all regions."""
         from tools.workspace_tools import list_workspaces

--- a/tools/workspace_tools.py
+++ b/tools/workspace_tools.py
@@ -31,8 +31,13 @@ def _collect_workspaces_from_tokens(
 
         if isinstance(region_data, dict):
             for workspace_key, workspace_data in region_data.items():
+                pinned_url = None
                 if isinstance(workspace_data, dict):
                     has_token = bool(workspace_data.get('token'))
+                    # A pinned base URL (object form) is the authoritative host;
+                    # report it instead of the derived one for consistency with
+                    # how requests are actually routed (ADR 0027 slug safety).
+                    pinned_url = workspace_data.get('url')
                 else:
                     has_token = bool(workspace_data)
 
@@ -41,7 +46,8 @@ def _collect_workspaces_from_tokens(
                         'workspace': workspace_key,
                         'region': region_key,
                         'has_token': has_token,
-                        'domain': f'{workspace_key}.{region_key}.alpacon.io',
+                        'domain': pinned_url
+                        or f'{workspace_key}.{region_key}.alpacon.io',
                     }
                 )
         else:

--- a/tools/workspace_tools.py
+++ b/tools/workspace_tools.py
@@ -8,39 +8,42 @@ from server import mcp
 from utils.common import error_response, success_response, unwrap_http_result
 from utils.decorators import mcp_tool_handler
 from utils.http_client import http_client
+from utils.token_manager import TokenManager
 from utils.tool_annotations import READ_ONLY
 
 
 def _collect_workspaces_from_tokens(
-    all_tokens: dict[str, Any],
+    token_manager: TokenManager,
     target_region: str = '',
 ) -> list[dict[str, Any]]:
     """Collect workspace info from token.json data.
 
     Args:
-        all_tokens: Token data from TokenManager
+        token_manager: TokenManager to read entries and pinned URL overrides from.
         target_region: If provided, filter to this region only. Empty means all regions.
 
     Returns:
         List of workspace info dicts
     """
     workspaces = []
-    for region_key, region_data in all_tokens.items():
+    for region_key, region_data in token_manager.get_all_tokens().items():
         if target_region and region_key != target_region:
             continue
 
         if isinstance(region_data, dict):
             for workspace_key, workspace_data in region_data.items():
-                pinned_url = None
                 if isinstance(workspace_data, dict):
                     has_token = bool(workspace_data.get('token'))
-                    # A pinned base URL (object form) is the authoritative host;
-                    # report it instead of the derived one for consistency with
-                    # how requests are actually routed (ADR 0027 slug safety).
-                    pinned_url = workspace_data.get('url')
                 else:
                     has_token = bool(workspace_data)
 
+                # Resolve the displayed host through the same helper request
+                # routing uses (env-var precedence + normalization), so the
+                # reported domain always matches http_client.get_base_url()
+                # (ADR 0027 slug safety).
+                pinned_url = token_manager.get_base_url_override(
+                    region_key, workspace_key
+                )
                 workspaces.append(
                     {
                         'workspace': workspace_key,
@@ -124,8 +127,7 @@ async def list_workspaces(region: str = '') -> dict[str, Any]:
     from utils.token_manager import get_token_manager
 
     token_manager = get_token_manager()
-    all_tokens = token_manager.get_all_tokens()
-    workspaces = _collect_workspaces_from_tokens(all_tokens, target_region=region)
+    workspaces = _collect_workspaces_from_tokens(token_manager, target_region=region)
 
     return success_response(
         data={

--- a/utils/http_client.py
+++ b/utils/http_client.py
@@ -245,6 +245,13 @@ class AlpaconHTTPClient:
     def get_base_url(self, region: str, workspace: str) -> str:
         """Get base URL for API calls.
 
+        Prefers an explicitly configured base URL (token.json object form or the
+        ``ALPACON_MCP_<REGION>_<WORKSPACE>_URL`` env var) so the host is a pinned,
+        persisted value rather than one re-derived from the workspace label on
+        every call. This keeps a workspace addressable across a URL slug change
+        (ADR 0027), where a freed slug can later be reused by another workspace.
+        Falls back to the default Alpacon Cloud host derivation.
+
         Args:
             region: Region (ap1, us1, eu1, etc.)
             workspace: Workspace name
@@ -252,6 +259,16 @@ class AlpaconHTTPClient:
         Returns:
             Base URL for API calls
         """
+        # Local import keeps the singleton lazy and lets tests patch
+        # get_token_manager; the isinstance guard tolerates a mocked manager
+        # whose override method returns a non-string sentinel.
+        from utils.token_manager import get_token_manager
+
+        override = get_token_manager().get_base_url_override(region, workspace)
+        if isinstance(override, str) and override:
+            logger.debug(f'Using configured base URL override: {override}')
+            return override
+
         base_url = f'https://{workspace}.{region}.alpacon.io'
         logger.debug(f'Generated base URL: {base_url}')
         return base_url

--- a/utils/token_manager.py
+++ b/utils/token_manager.py
@@ -125,6 +125,21 @@ class TokenManager:
             'workspace': workspace,
         }
 
+    @staticmethod
+    def _entry_token(entry: Any) -> str | None:
+        """Extract the token string from a config entry.
+
+        An entry is either a bare token string (legacy form) or an object
+        ``{"token": "...", "url": "..."}`` (used to pin a workspace's API host;
+        see ``get_base_url_override``). Returns None when no token is present.
+        """
+        if isinstance(entry, dict):
+            token = entry.get('token')
+            return token if isinstance(token, str) and token else None
+        if isinstance(entry, str) and entry:
+            return entry
+        return None
+
     def get_token(self, region: str, workspace: str) -> str | None:
         """Get token for specific region and workspace.
 
@@ -146,12 +161,57 @@ class TokenManager:
             )
             return env_token
 
-        # Fall back to config file
+        # Fall back to config file. An entry may be a bare token string or an
+        # object ``{"token": "...", "url": "..."}``; unwrap either form.
         if region in self.tokens and workspace in self.tokens[region]:
-            logger.info(f'Found token for {workspace}.{region} from config file')
-            return self.tokens[region][workspace]
+            token = self._entry_token(self.tokens[region][workspace])
+            if token:
+                logger.info(f'Found token for {workspace}.{region} from config file')
+                return token
 
         logger.warning(f'No token found for {workspace}.{region}')
+        return None
+
+    @staticmethod
+    def _normalize_base_url(url: str) -> str:
+        """Normalize a configured base URL: add https:// if scheme-less, drop trailing '/'."""
+        url = url.strip().rstrip('/')
+        if url and '://' not in url:
+            url = 'https://' + url
+        return url
+
+    def get_base_url_override(self, region: str, workspace: str) -> str | None:
+        """Get an explicitly configured API base URL for a region/workspace.
+
+        Alpacon Cloud hosts are normally derived as
+        ``https://{workspace}.{region}.alpacon.io``. That derivation re-builds
+        the host from the workspace label on every call, which is unsafe once a
+        workspace's URL slug becomes mutable (ADR 0027): a freed slug can later
+        be reused by a different workspace, so a stale label could resolve to
+        the wrong host. Pinning the resolved base URL here keeps a workspace
+        addressable across a slug change (the old host stays alive as an alias)
+        without re-deriving it from a reusable label.
+
+        Resolution order (mirrors ``get_token``):
+        1. Environment variable ``ALPACON_MCP_<REGION>_<WORKSPACE>_URL``
+        2. Config-file object form ``{"token": "...", "url": "https://..."}``
+
+        Returns:
+            The normalized base URL if configured, otherwise None (caller derives
+            the default host).
+        """
+        env_var_name = f'ALPACON_MCP_{region.upper()}_{workspace.upper()}_URL'
+        env_url = os.getenv(env_var_name)
+        if env_url and env_url.strip():
+            return self._normalize_base_url(env_url)
+
+        if region in self.tokens and workspace in self.tokens[region]:
+            entry = self.tokens[region][workspace]
+            if isinstance(entry, dict):
+                url = entry.get('url')
+                if isinstance(url, str) and url.strip():
+                    return self._normalize_base_url(url)
+
         return None
 
     def get_all_tokens(self) -> dict[str, Any]:


### PR DESCRIPTION
## Why

`http_client.get_base_url()` derives the API host from the workspace label on every call as `https://{workspace}.{region}.alpacon.io`. Once a workspace's URL slug becomes a **mutable** label (ADR 0027 — workspace identity axes and the mutable URL slug), re-deriving the host from that label is unsafe:

- A slug is a mutable URL label; `schema_name` is frozen; joins are by UUID.
- Old hosts stay alive as `Domain` aliases indefinitely, but a **freed slug can eventually be reused by a different workspace**.
- So a stale workspace label re-derived on every call could resolve to the wrong host once the label is reused.

This is a gate before the first real slug change: the MCP server should be able to address a workspace by a **persisted, resolved base URL** rather than one reconstructed from a reusable label.

## What

Let a workspace pin its resolved API base URL instead of always deriving it:

- **token.json object form** — an entry may now be `{"token": "...", "url": "https://..."}` in addition to the legacy bare-string form. `get_base_url()` prefers the pinned URL and falls back to the default derivation when none is set.
- **Env override** — `ALPACON_MCP_<REGION>_<WORKSPACE>_URL` (mirrors the existing `..._TOKEN` override) wins over the config file.
- **Latent bug fix** — `TokenManager.get_token()` now unwraps the object form. `_collect_workspaces_from_tokens` already read the dict form for `has_token`, but `get_token` returned the raw dict as if it were the token; the object form was therefore half-supported.
- **Consistency** — `list_workspaces` reports the pinned URL as the workspace `domain` when set.

The bare-string form is **fully backward compatible** and unchanged in behavior.

### Slug-change scenario this protects against

1. Workspace `acme` (slug == `schema_name`) is configured in `token.json`.
2. Its slug is later changed to `acme-corp`; `acme.<region>.alpacon.io` survives as a Domain alias.
3. The freed slug `acme` is eventually reused by a **different** workspace after the alias is retired.
4. Without pinning, `get_base_url('<region>', 'acme')` would keep re-deriving `acme.<region>.alpacon.io` from the stale label and could point at the wrong workspace. Pinning the resolved base URL keeps the original workspace addressable.

## Tests / lint

- New `tests/test_token_manager.py`: bare-string vs object-form token resolution, env-var precedence, base-URL override resolution and normalization.
- Extended `tests/test_http_client.py`: pinned override is used verbatim; default derivation unchanged when no override.
- Extended `tests/test_workspace_tools.py`: `list_workspaces` reports the pinned URL.
- Full suite: **898 passed**. `ruff check` clean, `ruff format` clean, `mypy` clean on changed modules.

## Follow-up (out of scope, server-side)

The fully general fix — the server providing each workspace's canonical URL — is not built yet. ADR 0027's discovery/Domain-flip endpoint is approved but not implemented, and the JWT `workspaces` claim carries only `schema_name`/`auth0_id`/`region` (no slug/host). This PR is the client-side mitigation (persist the resolved host); server-provided host discovery is a separate follow-up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01F3bLh8D5D6f9WdKonA7LcZ