### PR TITLE
fix(commands): detect exec completion via handled_at, not finished_at

### DIFF
--- a/tests/test_command_tools.py
+++ b/tests/test_command_tools.py
@@ -266,11 +266,13 @@ class TestExecuteCommand:
             patch('tools.command_tools._get_command_result') as mock_poll,
         ):
             mock_submit.return_value = {'id': 'cmd-123'}
+            # Real Command API shape: handled_at signals completion, no 'finished_at'.
             mock_poll.return_value = {
                 'id': 'cmd-123',
-                'status': 'completed',
+                'status': 'success',
+                'success': True,
                 'exit_code': 0,
-                'finished_at': '2024-01-01T00:00:01Z',
+                'handled_at': '2024-01-01T00:00:01Z',
             }
 
             result = await execute_command(
@@ -293,7 +295,7 @@ class TestExecuteCommand:
             mock_submit.return_value = [{'id': 'cmd-123'}]
             mock_poll.return_value = {
                 'id': 'cmd-123',
-                'finished_at': '2024-01-01T00:00:01Z',
+                'handled_at': '2024-01-01T00:00:01Z',
             }
 
             result = await execute_command(
@@ -315,7 +317,7 @@ class TestExecuteCommand:
             mock_poll.return_value = {
                 'id': 'cmd-123',
                 'status': 'running',
-                'finished_at': None,
+                'handled_at': None,
             }
 
             result = await execute_command(
@@ -362,27 +364,92 @@ class TestExecuteCommand:
             assert 'No command data returned' in result['message']
 
     @pytest.mark.asyncio
-    async def test_stuck_status(self, mock_http_client, mock_token_manager):
+    async def test_failed_command_completes(
+        self, mock_http_client, mock_token_manager
+    ):
+        # A non-zero exit is a completed command ('failed'), not still-running.
         with (
             patch('tools.command_tools._submit_command') as mock_submit,
             patch('tools.command_tools._get_command_result') as mock_poll,
         ):
-            mock_submit.return_value = {'id': 'cmd-300'}
+            mock_submit.return_value = {'id': 'cmd-400'}
             mock_poll.return_value = {
-                'id': 'cmd-300',
-                'status': 'stuck',
-                'finished_at': None,
+                'id': 'cmd-400',
+                'status': 'failed',
+                'success': False,
+                'exit_code': 2,
+                'result': 'ls: cannot access',
+                'handled_at': '2024-01-01T00:00:01Z',
             }
 
             result = await execute_command(
                 server_id='550e8400-e29b-41d4-a716-446655440001',
-                command='bad command',
+                command='ls /nope',
                 workspace='testworkspace',
-                timeout=2,
+                timeout=10,
+            )
+
+            assert result['status'] == 'success'
+            assert result['data']['exit_code'] == 2
+
+    @pytest.mark.asyncio
+    @pytest.mark.parametrize('status', ['stuck', 'denied', 'rejected', 'error'])
+    async def test_terminal_failure_status(
+        self, status, mock_http_client, mock_token_manager
+    ):
+        # Terminal non-approval statuses: the command will not produce a result,
+        # so error out immediately instead of polling until timeout.
+        with (
+            patch('tools.command_tools._submit_command') as mock_submit,
+            patch('tools.command_tools._get_command_result') as mock_poll,
+        ):
+            mock_submit.return_value = {'id': 'cmd-401'}
+            mock_poll.return_value = {
+                'id': 'cmd-401',
+                'status': status,
+                'handled_at': None,
+            }
+
+            result = await execute_command(
+                server_id='550e8400-e29b-41d4-a716-446655440001',
+                command='rm -rf /',
+                workspace='testworkspace',
+                timeout=10,
             )
 
             assert result['status'] == 'error'
-            assert 'stuck' in result['message']
+            assert status in result['message']
+
+    @pytest.mark.asyncio
+    async def test_awaiting_approval_returns_pending(
+        self, mock_http_client, mock_token_manager
+    ):
+        # HITL verification: a human must approve out-of-band (ADR 0015), so
+        # return a structured pending result instead of burning the poll window.
+        with (
+            patch('tools.command_tools._submit_command') as mock_submit,
+            patch('tools.command_tools._get_command_result') as mock_poll,
+        ):
+            mock_submit.return_value = {'id': 'cmd-402'}
+            mock_poll.return_value = {
+                'id': 'cmd-402',
+                'status': 'awaiting_approval',
+                'handled_at': None,
+            }
+
+            result = await execute_command(
+                server_id='550e8400-e29b-41d4-a716-446655440001',
+                command='sudo reboot',
+                workspace='testworkspace',
+                timeout=10,
+            )
+
+            assert result['status'] == 'pending_approval'
+            assert result['category'] == 'COMMAND_AWAITING_APPROVAL'
+            assert result['requires_human_approval'] is True
+            assert result['command_id'] == 'cmd-402'
+            # Category has a registered next_action (not the generic fallback).
+            assert 'list_commands' in result['next_action']
 
     @pytest.mark.asyncio
     async def test_forwards_all_params(self, mock_http_client, mock_token_manager):
@@ -393,7 +460,7 @@ class TestExecuteCommand:
             mock_submit.return_value = {'id': 'cmd-200'}
             mock_poll.return_value = {
                 'id': 'cmd-200',
-                'finished_at': '2024-01-01T00:00:01Z',
+                'handled_at': '2024-01-01T00:00:01Z',
             }
 
             await execute_command(
@@ -437,11 +504,12 @@ class TestExecuteCommand:
             mock_submit.return_value = {'id': 'cmd-789'}
             mock_poll.return_value = {
                 'id': 'cmd-789',
-                'status': 'completed',
+                'status': 'failed',
+                'success': False,
                 'exit_code': 1,
                 'result': 'Alpacon denied this sudo command '
                 '(SUDO_PRESENCE_REQUIRED).\n',
-                'finished_at': '2024-01-01T00:00:01Z',
+                'handled_at': '2024-01-01T00:00:01Z',
             }
 
             result = await execute_command(
@@ -475,11 +543,12 @@ class TestExecuteCommand:
             mock_submit.return_value = {'id': 'cmd-791'}
             mock_poll.return_value = {
                 'id': 'cmd-791',
-                'status': 'completed',
+                'status': 'failed',
+                'success': False,
                 'exit_code': 1,
                 'result': 'Alpacon denied this sudo command '
                 '(SUDO_APPROVAL_REQUIRED).\n',
-                'finished_at': '2024-01-01T00:00:01Z',
+                'handled_at': '2024-01-01T00:00:01Z',
             }
 
             result = await execute_command(
@@ -506,10 +575,11 @@ class TestExecuteCommand:
             mock_submit.return_value = {'id': 'cmd-792'}
             mock_poll.return_value = {
                 'id': 'cmd-792',
-                'status': 'completed',
+                'status': 'failed',
+                'success': False,
                 'exit_code': 1,
                 'result': 'Alpacon denied this sudo command (SUDO_RISK_DENIED).\n',
-                'finished_at': '2024-01-01T00:00:01Z',
+                'handled_at': '2024-01-01T00:00:01Z',
             }
 
             result = await execute_command(
@@ -543,10 +613,11 @@ class TestExecuteCommand:
             mock_submit.return_value = {'id': 'cmd-790'}
             mock_poll.return_value = {
                 'id': 'cmd-790',
-                'status': 'completed',
+                'status': 'success',
+                'success': True,
                 'exit_code': 0,
                 'result': 'uid=0(root)\n',
-                'finished_at': '2024-01-01T00:00:01Z',
+                'handled_at': '2024-01-01T00:00:01Z',
             }
 
             result = await execute_command(
@@ -604,8 +675,8 @@ class TestExecuteCommandWithSession:
         mock_http_client.post.return_value = {'id': 'cmd-123'}
         mock_http_client.get.return_value = {
             'id': 'cmd-123',
-            'finished_at': '2026-05-19T10:00:00Z',
-            'status': 'completed',
+            'handled_at': '2026-05-19T10:00:00Z',
+            'status': 'success',
         }
 
         await execute_command(

--- a/tests/test_command_tools.py
+++ b/tests/test_command_tools.py
@@ -287,6 +287,39 @@ class TestExecuteCommand:
             assert result['command'] == 'echo test'
 
     @pytest.mark.asyncio
+    async def test_completes_after_polling(self, mock_http_client, mock_token_manager):
+        # The exact path the bug broke: first poll is still in-progress
+        # (handled_at=None), a later poll reports handled_at set. Detection
+        # must recognize completion on the transition, not only the first poll.
+        with (
+            patch('tools.command_tools._submit_command') as mock_submit,
+            patch('tools.command_tools._get_command_result') as mock_poll,
+        ):
+            mock_submit.return_value = {'id': 'cmd-123'}
+            mock_poll.side_effect = [
+                {'id': 'cmd-123', 'status': 'running', 'handled_at': None},
+                {'id': 'cmd-123', 'status': 'verifying', 'handled_at': None},
+                {
+                    'id': 'cmd-123',
+                    'status': 'success',
+                    'success': True,
+                    'exit_code': 0,
+                    'handled_at': '2024-01-01T00:00:03Z',
+                },
+            ]
+
+            result = await execute_command(
+                server_id='550e8400-e29b-41d4-a716-446655440001',
+                command='echo test',
+                workspace='testworkspace',
+                timeout=10,
+            )
+
+            assert result['status'] == 'success'
+            assert result['command_id'] == 'cmd-123'
+            assert mock_poll.call_count == 3
+
+    @pytest.mark.asyncio
     async def test_array_response(self, mock_http_client, mock_token_manager):
         with (
             patch('tools.command_tools._submit_command') as mock_submit,
@@ -364,9 +397,7 @@ class TestExecuteCommand:
             assert 'No command data returned' in result['message']
 
     @pytest.mark.asyncio
-    async def test_failed_command_completes(
-        self, mock_http_client, mock_token_manager
-    ):
+    async def test_failed_command_completes(self, mock_http_client, mock_token_manager):
         # A non-zero exit is a completed command ('failed'), not still-running.
         with (
             patch('tools.command_tools._submit_command') as mock_submit,
@@ -393,7 +424,7 @@ class TestExecuteCommand:
             assert result['data']['exit_code'] == 2
 
     @pytest.mark.asyncio
-    @pytest.mark.parametrize('status', ['stuck', 'denied', 'rejected', 'error'])
+    @pytest.mark.parametrize('status', ['stuck', 'denied', 'rejected'])
     async def test_terminal_failure_status(
         self, status, mock_http_client, mock_token_manager
     ):

--- a/tools/command_tools.py
+++ b/tools/command_tools.py
@@ -158,7 +158,7 @@ async def _get_command_result(
 
 
 @mcp_tool_handler(
-    description='List recent command execution history with status, output, and timestamps. Filterable by server ID. When to use: reviewing past commands or checking what has been run on a server. Related: get_command_result (get full output of a specific command).',
+    description='List recent command execution history with status, output, and timestamps. Filterable by server ID. When to use: reviewing past commands, or retrieving the result of a command whose execute_command call timed out. Related: execute_command (run a command and wait).',
     annotations=READ_ONLY,
     meta={'anthropic/searchHint': 'command history list recent'},
 )
@@ -309,7 +309,9 @@ async def execute_command(
         if isinstance(result, dict):
             status = result.get('status', '')
 
-            if result.get('finished_at') is not None:
+            # handled_at is set once the agent reports the result (status then
+            # becomes 'success'/'failed'); the Command API has no 'finished_at'.
+            if result.get('handled_at') is not None:
                 response = success_response(
                     data=result,
                     command_id=command_id,
@@ -335,7 +337,25 @@ async def execute_command(
                         )
                 return response
 
-            if status in ('stuck', 'error'):
+            if status == 'awaiting_approval':
+                # HITL verification gate: a human must approve out-of-band
+                # (ADR 0015); polling would only burn the timeout window.
+                return pending_approval_response(
+                    'Command is awaiting human approval. A human must approve '
+                    'it out-of-band (Alpacon web console or Slack); then check '
+                    'the result via list_commands or re-run.',
+                    category='COMMAND_AWAITING_APPROVAL',
+                    command_id=command_id,
+                    server_id=server_id,
+                    command=command,
+                    region=region,
+                    workspace=workspace,
+                )
+
+            # Terminal non-approval statuses: the command will not produce a
+            # result (denied/rejected never run; stuck/error gave up), so fail
+            # fast instead of polling until timeout.
+            if status in ('denied', 'rejected', 'stuck', 'error'):
                 return error_response(
                     f'Command failed with status: {status}',
                     command_id=command_id,

--- a/tools/command_tools.py
+++ b/tools/command_tools.py
@@ -342,8 +342,10 @@ async def execute_command(
                 # (ADR 0015); polling would only burn the timeout window.
                 return pending_approval_response(
                     'Command is awaiting human approval. A human must approve '
-                    'it out-of-band (Alpacon web console or Slack); then check '
-                    'the result via list_commands or re-run.',
+                    'it out-of-band (Alpacon web console or Slack); it then runs '
+                    'automatically. Wait, then retrieve the result via '
+                    'list_commands. Do not re-run: a resubmission needs its own '
+                    'approval and may double-execute the command.',
                     category='COMMAND_AWAITING_APPROVAL',
                     command_id=command_id,
                     server_id=server_id,
@@ -353,9 +355,11 @@ async def execute_command(
                 )
 
             # Terminal non-approval statuses: the command will not produce a
-            # result (denied/rejected never run; stuck/error gave up), so fail
-            # fast instead of polling until timeout.
-            if status in ('denied', 'rejected', 'stuck', 'error'):
+            # result (denied/rejected never run; stuck gave up), so fail fast
+            # instead of polling until timeout. ('error' is omitted: the
+            # server's compute_status never emits it given the scheduled_at
+            # default, so it is unreachable here.)
+            if status in ('denied', 'rejected', 'stuck'):
                 return error_response(
                     f'Command failed with status: {status}',
                     command_id=command_id,
@@ -366,8 +370,19 @@ async def execute_command(
                     details=result,
                 )
 
-            # Command still in progress — reset deadline (within hard cap)
-            if status in ('running', 'acked'):
+            # Command still in progress — reset deadline (within hard cap) so a
+            # slow AI verification or delayed delivery does not time out a
+            # command that is still advancing. Covers both pre-execution states
+            # (queued/scheduled/delivered/verifying) and execution (running).
+            # 'acked' is intentionally absent: compute_status returns 'running'
+            # once acked_at is set, so it is never emitted.
+            if status in (
+                'running',
+                'verifying',
+                'delivered',
+                'queued',
+                'scheduled',
+            ):
                 deadline = min(
                     loop.time() + timeout,
                     hard_deadline,

--- a/utils/common.py
+++ b/utils/common.py
@@ -91,8 +91,10 @@ _NEXT_ACTION_BY_CATEGORY: dict[str, str] = {
     ),
     'COMMAND_AWAITING_APPROVAL': (
         'A human must approve this command out-of-band (Alpacon web console or '
-        'Slack). You cannot approve it yourself. Wait for approval, then check '
-        'the result via list_commands or re-run; do not repeatedly resubmit.'
+        'Slack); it then runs automatically. You cannot approve it yourself. '
+        'Wait for approval, then retrieve the result via list_commands. Do not '
+        're-run: a resubmission needs its own approval and may double-execute '
+        'the command.'
     ),
     'SUDO_PRESENCE_REQUIRED': (
         'A human must complete a fresh MFA step-up out-of-band, then retry. You '

--- a/utils/common.py
+++ b/utils/common.py
@@ -75,8 +75,9 @@ def success_response(data: Any = None, **kwargs) -> dict[str, Any]:
 # The human-resolvable next action differs by category: SUDO_APPROVAL_REQUIRED /
 # WORK_SESSION_PENDING need an out-of-band approval, while SUDO_PRESENCE_REQUIRED
 # is an MFA step-up and SUDO_NO_WORKSESSION_POLICY is a scope addition — none of
-# which the agent can perform itself. APPROVAL_DECISION_HUMAN_ONLY is a pure
-# explanation that approving/rejecting is human-only; there is nothing to retry.
+# which the agent can perform itself. COMMAND_AWAITING_APPROVAL is the
+# command-level analogue of WORK_SESSION_PENDING. APPROVAL_DECISION_HUMAN_ONLY is
+# a pure explanation that approving/rejecting is human-only; nothing to retry.
 _NEXT_ACTION_BY_CATEGORY: dict[str, str] = {
     'SUDO_APPROVAL_REQUIRED': (
         'A human must approve this out-of-band (Alpacon web console or Slack). '
@@ -87,6 +88,11 @@ _NEXT_ACTION_BY_CATEGORY: dict[str, str] = {
         'A human must approve this Work Session out-of-band (Alpacon web console '
         'or Slack) before it activates. You cannot approve it yourself. Wait for '
         'approval, then retry.'
+    ),
+    'COMMAND_AWAITING_APPROVAL': (
+        'A human must approve this command out-of-band (Alpacon web console or '
+        'Slack). You cannot approve it yourself. Wait for approval, then check '
+        'the result via list_commands or re-run; do not repeatedly resubmit.'
     ),
     'SUDO_PRESENCE_REQUIRED': (
         'A human must complete a fresh MFA step-up out-of-band, then retry. You '


### PR DESCRIPTION
## Background

Investigating the Slack report of unstable exec (server listing intermittently failing, and command execution timing out without returning a result even with a Work Session attached), the exec timeout turned out to be a 100% reproducible structural bug, not an intermittent one.

`execute_command`'s polling loop detected completion by reading a `finished_at` field, which the Alpacon Command API never returns. The real completion marker is `handled_at`, and completion status is computed by alpacon-server's `compute_status` (`events/models.py`) as `success`/`failed`. Since `finished_at` is always absent, a command that finished instantly was never recognized as complete, so the loop kept polling until its deadline and the client timed out first.

Reproduced live against the web-editor server on dev: the command (`whoami`) finished server-side every time in `response_delay` 0.9s / `elapsed_time` 0.009s with `status: success`, yet the MCP tool call never received the result and timed out. By contrast `execute_command_multi_server`, which only submits without polling, returned normally. That contrast confirms the submit path is fine and the wait (polling) path is the cause.

This `finished_at` check has never matched the real API since the initial implementation on 2025-09-24, so this was always broken from the start rather than a recent regression.

## Changes

`tools/command_tools.py` polling loop:

- Detect completion via `handled_at is not None`. Per `compute_status`, `handled_at` being set implies status is `success`/`failed`, so it is the single accurate completion signal.
- `awaiting_approval` (HITL verification gate) now returns a structured `pending_approval` result instead of continuing to poll. The command has not run and a human must approve out-of-band (ADR 0015), so there is no reason to burn the timeout window.
- `denied`/`rejected` join the existing `stuck`/`error` fast-fail branch. All are terminal states where the command does not run.

`utils/common.py`:

- Register `COMMAND_AWAITING_APPROVAL` in `_NEXT_ACTION_BY_CATEGORY`. It previously fell back to the generic default text; explicit registration is this codebase's convention, matching every other category.

`list_commands` description fix:

- The description pointed a "Related" reference at a `get_command_result` tool that does not exist. Since that is exactly the path for retrieving a result after an exec timeout, an agent following it would call a nonexistent tool and fail. It now points to the real recovery path (retrieve a timed-out command's result via `list_commands`) and the real sibling (`execute_command`).

## Safety

The `awaiting_approval` `pending_approval` response does not forward the raw poll payload (`data=result`). The Command API payload carries AI risk internals such as `risk_score`/`tier2_reasoning`, which ADR 0015 forbids disclosing to clients beyond the category and next_action. This is consistent with the sudo-denial path, which also discloses only the category.

## Tests

Nine existing fixtures that pinned the buggy behavior were switched to the real API shape (`handled_at` + `success`/`failed`, removing the fictitious `finished_at`/`completed`). New tests: completion detection for a failed command, a parametrized test over the four terminal statuses (`stuck`/`denied`/`rejected`/`error`), and the `awaiting_approval` pending path with a `next_action` assertion confirming the registered category.

Before the fix, the new fixtures hung the tests (the polling loop failing to detect completion, matching the live symptom); after the fix, `test_command_tools.py` passes 41 tests and the full suite passes 885. Two pre-existing failures (`test_import_main`, `test_main_entry_point`) were confirmed via `git stash` to fail identically on a clean tree, so they are unrelated to this change.

## Remaining limitation (out of scope for this PR)

Commands taking longer than 60s can still fail to return a result after this fix, due to two layers: (1) the alpacon-mcp ingress has no ALB `idle_timeout` setting, so the connection is dropped at the default 60s while nothing streams during polling (needs a `load-balancer-attributes: idle_timeout.timeout_seconds` annotation like the alpacon chart's WebSocket ingress, in the gitops repo); (2) the MCP client's own tool timeout (~60-80s observed) is outside our control. For long commands the correct pattern is submit-then-retrieve via `list_commands`, and this PR also corrects that recovery path in the documentation.

## Checklist

- [x] Completion detected via a real API field (`handled_at`), dropping the nonexistent `finished_at` dependency
- [x] Terminal states (`denied`/`rejected`/`awaiting_approval`) handled explicitly, removing wasted polling
- [x] `COMMAND_AWAITING_APPROVAL` category registered and pinned with a `next_action` test
- [x] Removed the phantom tool reference in `list_commands`
- [x] Bug-pinning tests updated to the real API shape; regression tests added
- [x] Confirmed the two pre-existing failures are unrelated to this branch
