### PR TITLE
feat(workspace): add workspace settings management tools

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,7 +12,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   - Read tools: `get_workspace_access_control`, `get_workspace_security`, `list_workspace_mfa_methods`, `get_workspace_notifications`, `get_workspace_preferences`
   - Partial-update tools: `update_workspace_notifications`, `update_workspace_preferences`
   - Exposed the five read tools as `alpacon://workspace-settings/{access-control|security|mfa-methods|notifications|preferences}/{region}/{workspace}` resources
-  - Security and access-control writes are intentionally omitted (server gates them behind a superuser session with fresh MFA, unsatisfiable by a static API token); `get_workspace_security` is SaaS-only and returns a clear message on on-premise 404
+  - Security and access-control writes are intentionally omitted from the tool surface; on SaaS the server gates them behind a superuser session with fresh MFA (unsatisfiable by a static API token), and even where an on-premise admin token could write them, keeping governance-level settings human-only via the web console is the safer default
+  - `get_workspace_security` and `list_workspace_mfa_methods` require JWT (OAuth/SSO) authentication and short-circuit a static API token before any request, and are SaaS-only (a clear not-available message on on-premise 404)
+  - The list fields on the update tools (`notification_channels`, `enabled_extensions`, `allowed_domains`) replace the whole array rather than appending; documented the read-merge-write pattern
 
 ### Documentation
 - Documented the hosted remote MCP server (`https://mcp.alpacon.io/mcp`, streamable-http transport)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+- Workspace settings management tools under `/api/workspaces/`
+  - Read tools: `get_workspace_access_control`, `get_workspace_security`, `list_workspace_mfa_methods`, `get_workspace_notifications`, `get_workspace_preferences`
+  - Partial-update tools: `update_workspace_notifications`, `update_workspace_preferences`
+  - Exposed the five read tools as `alpacon://workspace-settings/{access-control|security|mfa-methods|notifications|preferences}/{region}/{workspace}` resources
+  - Security and access-control writes are intentionally omitted (server gates them behind a superuser session with fresh MFA, unsatisfiable by a static API token); `get_workspace_security` is SaaS-only and returns a clear message on on-premise 404
+
 ### Documentation
 - Documented the hosted remote MCP server (`https://mcp.alpacon.io/mcp`, streamable-http transport)
   - Added a "Remote MCP server (hosted, no install)" section to `README.md` with per-client setup for Claude Code, Claude Desktop, Cursor, and VS Code

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -480,6 +480,15 @@ All validators are defined in `utils/error_handler.py` and return user-friendly 
 ### ⚙️ Authentication & workspace
 - `list_workspaces`: List available workspaces
 - `get_current_user`: Get currently authenticated user info (username, email, role, UID, shell, home directory)
+- `get_workspace_access_control`: Get workspace access control settings (sudo/root access policy, tunnel/editor defaults, home directory permission, Work Session TTLs, command-env audit exposure, shared account names)
+- `get_workspace_security`: Get workspace authentication/security settings (mfa_required, allowed_mfa_methods, mfa_timeout); SaaS-only route, returns a clear message instead of a raw 404 on-premise
+- `list_workspace_mfa_methods`: List MFA methods allowed for the workspace (`allowed_mfa_methods`, `passkey_as_mfa`); useful when guiding a user through the remote-mode MFA re-authentication flow
+- `get_workspace_notifications`: Get workspace notification settings (disconnection_notification, notification_channels)
+- `get_workspace_preferences`: Get workspace-wide preferences (timezone, locale, billing_email, etc.); workspace-global, not per-user
+- `update_workspace_notifications`: Update workspace notification settings (partial update)
+- `update_workspace_preferences`: Update workspace-wide preferences (partial update); changing `timezone` shifts the workspace's billing-usage aggregation boundary, and `billing_email`/`allowed_domains` are only accepted on SaaS deployments
+
+Access control and security settings are intentionally read-only here: the server gates writes to those governance-level settings behind a superuser session with fresh MFA, which a static API token (stdio mode) cannot satisfy, so they stay human-only via the web console.
 
 **Note**: User settings and profile endpoints are not currently implemented in the Alpacon server. The following tools have been removed:
 - ~~`get_user_settings`~~: Not available (was using `/api/user/settings/`)
@@ -488,7 +497,7 @@ All validators are defined in `utils/error_handler.py` and return user-friendly 
 
 Alternative endpoints available in the server:
 - `/api/profiles/preferences/` (profiles app)
-- `/api/workspaces/preferences/` (workspaces app)
+- `/api/workspaces/preferences/` (workspaces app; see `get_workspace_preferences`/`update_workspace_preferences` above)
 - `/api/auth0/users/` (auth0 app)
 
 ### 🧩 MCP resources
@@ -502,6 +511,7 @@ Read-only data exposed as `alpacon://` resources (one per read tool). URI conven
 - `alpacon://iam/{users|groups|applications}/{region}/{workspace}`: IAM
 - `alpacon://certs/...`, `alpacon://audit/...`, `alpacon://tokens/...`, `alpacon://webhooks/...`, `alpacon://acls/...`, `alpacon://webftp/...`, `alpacon://approvals/...`, `alpacon://events/...`, `alpacon://commands/...`, `alpacon://work-sessions/...`
 - `alpacon://workspaces` (all regions) and `alpacon://workspaces/{region}`, `alpacon://current-user/{region}/{workspace}`
+- `alpacon://workspace-settings/{access-control|security|mfa-methods|notifications|preferences}/{region}/{workspace}`: workspace-wide settings
 
 Resources are generated from a registry table in `tools/resources.py`.
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -481,14 +481,14 @@ All validators are defined in `utils/error_handler.py` and return user-friendly 
 - `list_workspaces`: List available workspaces
 - `get_current_user`: Get currently authenticated user info (username, email, role, UID, shell, home directory)
 - `get_workspace_access_control`: Get workspace access control settings (sudo/root access policy, tunnel/editor defaults, home directory permission, Work Session TTLs, command-env audit exposure, shared account names)
-- `get_workspace_security`: Get workspace authentication/security settings (mfa_required, allowed_mfa_methods, mfa_timeout); SaaS-only route, returns a clear message instead of a raw 404 on-premise
-- `list_workspace_mfa_methods`: List MFA methods allowed for the workspace (`allowed_mfa_methods`, `passkey_as_mfa`); useful when guiding a user through the remote-mode MFA re-authentication flow
+- `get_workspace_security`: Get workspace authentication/security settings (mfa_required, allowed_mfa_methods, mfa_timeout); JWT/SSO auth only (a static API token is rejected before the request via `@require_jwt_auth`) and SaaS-only route, returns a clear message instead of a raw 404 on-premise
+- `list_workspace_mfa_methods`: List MFA methods allowed for the workspace (`allowed_mfa_methods`, `passkey_as_mfa`); same JWT/SSO-only, SaaS-only constraints as `get_workspace_security`; useful when guiding a user through the remote-mode MFA re-authentication flow
 - `get_workspace_notifications`: Get workspace notification settings (disconnection_notification, notification_channels)
 - `get_workspace_preferences`: Get workspace-wide preferences (timezone, locale, billing_email, etc.); workspace-global, not per-user
-- `update_workspace_notifications`: Update workspace notification settings (partial update)
-- `update_workspace_preferences`: Update workspace-wide preferences (partial update); changing `timezone` shifts the workspace's billing-usage aggregation boundary, and `billing_email`/`allowed_domains` are only accepted on SaaS deployments
+- `update_workspace_notifications`: Update workspace notification settings (partial update); `notification_channels` replaces the whole list rather than appending (read via `get_workspace_notifications`, merge, then send)
+- `update_workspace_preferences`: Update workspace-wide preferences (partial update); changing `timezone` shifts the workspace's billing-usage aggregation boundary, `billing_email`/`allowed_domains` are only accepted on SaaS deployments, and the list fields (`enabled_extensions`, `allowed_domains`) replace the whole list rather than appending (narrowing `enabled_extensions` also 402s on non-enterprise plans)
 
-Access control and security settings are intentionally read-only here: the server gates writes to those governance-level settings behind a superuser session with fresh MFA, which a static API token (stdio mode) cannot satisfy, so they stay human-only via the web console.
+Access control and security settings are intentionally read-only here. On SaaS the server gates those governance-level writes behind a superuser session with fresh MFA, which a static API token (stdio mode) cannot satisfy. On-premise the same writes require only an admin token with the `workspaces` scope (MFA is skipped), so a token could technically perform them—but keeping governance-level settings human-only via the web console is the deliberate, safer default regardless of deployment, so no write tool is exposed.
 
 **Note**: User settings and profile endpoints are not currently implemented in the Alpacon server. The following tools have been removed:
 - ~~`get_user_settings`~~: Not available (was using `/api/user/settings/`)

--- a/README.md
+++ b/README.md
@@ -429,6 +429,14 @@ Install the MCP extension and add to settings:
 
 ### ⚙️ Workspace
 - **list_workspaces**: List available workspaces
+- **get_current_user**: Get the currently authenticated user
+- **get_workspace_access_control**: Get access control settings (read-only)
+- **get_workspace_security**: Get authentication/security settings (SaaS only)
+- **list_workspace_mfa_methods**: List allowed MFA methods
+- **get_workspace_notifications**: Get notification settings
+- **get_workspace_preferences**: Get workspace-wide preferences
+- **update_workspace_notifications**: Update notification settings (partial)
+- **update_workspace_preferences**: Update workspace-wide preferences (partial)
 
 ## 🌍 Supported platforms
 

--- a/README.md
+++ b/README.md
@@ -431,8 +431,8 @@ Install the MCP extension and add to settings:
 - **list_workspaces**: List available workspaces
 - **get_current_user**: Get the currently authenticated user
 - **get_workspace_access_control**: Get access control settings (read-only)
-- **get_workspace_security**: Get authentication/security settings (SaaS only)
-- **list_workspace_mfa_methods**: List allowed MFA methods
+- **get_workspace_security**: Get authentication/security settings (JWT/SSO auth only, SaaS only)
+- **list_workspace_mfa_methods**: List allowed MFA methods (JWT/SSO auth only, SaaS only)
 - **get_workspace_notifications**: Get notification settings
 - **get_workspace_preferences**: Get workspace-wide preferences
 - **update_workspace_notifications**: Update notification settings (partial)

--- a/docs/api-reference.md
+++ b/docs/api-reference.md
@@ -576,7 +576,7 @@ Update workspace-wide preferences. Only the fields you provide are sent (partial
 - `timezone` (string, optional): Workspace timezone; also the billing clock
 - `invite_ttl` (integer, optional): Invitation link time-to-live, in seconds
 - `enabled_extensions` (array, optional): List of enabled extension names
-- `websh_session_timeout` (integer, optional): WebSH idle session timeout, in seconds
+- `websh_session_timeout` (integer, optional): Websh idle session timeout, in seconds
 - `auto_agent_upgrade` (boolean, optional): Whether agents auto-upgrade
 - `package_proxy` (string, optional): Proxy server URL for package installation
 - `billing_email` (string, optional): Billing contact email; SaaS-only field

--- a/docs/api-reference.md
+++ b/docs/api-reference.md
@@ -517,6 +517,74 @@ Get list of available workspaces.
 **Parameters:**
 - `region` (string, default: "ap1"): Region name
 
+### `get_workspace_access_control`
+Get the workspace access control settings: sudo/root access policy (`allow_sudo_with_mfa`, `allow_direct_root`, `block_local_sudo`, `sudo_timeout`), tunnel/editor defaults, `home_directory_permission`, Work Session TTLs (`work_session_max_ttl`, `work_session_pending_ttl`), command-env audit exposure, and `shared_account_names`.
+
+**Parameters:**
+- `workspace` (string): Workspace name
+- `region` (string, default: "ap1"): Region name
+
+**Note:** On-premise deployments omit the MFA-related fields (`allow_sudo_with_mfa`, `block_local_sudo`, `sudo_timeout`).
+
+### `get_workspace_security`
+Get the workspace authentication/security settings: `mfa_required`, `allowed_mfa_methods`, `mfa_timeout`, and which actions require MFA.
+
+**Parameters:**
+- `workspace` (string): Workspace name
+- `region` (string, default: "ap1"): Region name
+
+**Note:** This route is SaaS-only. On-premise deployments return 404 from the upstream API; this tool reports that the settings are not available on this deployment instead of a generic error.
+
+### `list_workspace_mfa_methods`
+List the MFA methods allowed for the workspace (`allowed_mfa_methods`, `passkey_as_mfa`). Useful when guiding a user through the remote/streamable-http MFA re-authentication flow.
+
+**Parameters:**
+- `workspace` (string): Workspace name
+- `region` (string, default: "ap1"): Region name
+
+### `get_workspace_notifications`
+Get the workspace notification settings: `disconnection_notification` and `notification_channels`.
+
+**Parameters:**
+- `workspace` (string): Workspace name
+- `region` (string, default: "ap1"): Region name
+
+### `get_workspace_preferences`
+Get the workspace-wide preferences: timezone, locale, `front_url`, `invite_ttl`, `enabled_extensions`, `websh_session_timeout`, `auto_agent_upgrade`, `package_proxy`, `billing_email`, `allowed_domains`. Workspace-global configuration, not per-user.
+
+**Parameters:**
+- `workspace` (string): Workspace name
+- `region` (string, default: "ap1"): Region name
+
+### `update_workspace_notifications`
+Update workspace notification settings. Only the fields you provide are sent (partial update).
+
+**Parameters:**
+- `workspace` (string): Workspace name
+- `disconnection_notification` (boolean, optional): Notify when a server disconnects/goes offline
+- `notification_channels` (array, optional): Channel types to notify through (`email`, `webhook`, `push`)
+- `region` (string, default: "ap1"): Region name
+
+### `update_workspace_preferences`
+Update workspace-wide preferences. Only the fields you provide are sent (partial update).
+
+**Parameters:**
+- `workspace` (string): Workspace name
+- `front_url` (string, optional): Workspace front-end URL
+- `country` (string, optional): Workspace country code
+- `language` (string, optional): Workspace locale/language code
+- `timezone` (string, optional): Workspace timezone; also the billing clock
+- `invite_ttl` (integer, optional): Invitation link time-to-live, in seconds
+- `enabled_extensions` (array, optional): List of enabled extension names
+- `websh_session_timeout` (integer, optional): WebSH idle session timeout, in seconds
+- `auto_agent_upgrade` (boolean, optional): Whether agents auto-upgrade
+- `package_proxy` (string, optional): Proxy server URL for package installation
+- `billing_email` (string, optional): Billing contact email; SaaS-only field
+- `allowed_domains` (array, optional): Allowed email domains for invites; SaaS-only field
+- `region` (string, default: "ap1"): Region name
+
+**⚠️ Warning:** `timezone` is the workspace's billing clock—changing it shifts the daily usage-aggregation boundary. `billing_email` and `allowed_domains` are only accepted by the server on SaaS deployments.
+
 ---
 
 

--- a/docs/api-reference.md
+++ b/docs/api-reference.md
@@ -533,7 +533,9 @@ Get the workspace authentication/security settings: `mfa_required`, `allowed_mfa
 - `workspace` (string): Workspace name
 - `region` (string, default: "ap1"): Region name
 
-**Note:** This route is SaaS-only. On-premise deployments return 404 from the upstream API; this tool reports that the settings are not available on this deployment instead of a generic error.
+**Note:** Requires JWT (OAuth/SSO) authentication. The upstream `SecuritySettingsViewSet` has no `APITokenAuthentication`, so a static API token (stdio mode) is rejected before any request is sent; use remote/streamable-http (browser SSO) mode to read these settings.
+
+**Note:** This route is also SaaS-only. On-premise deployments return 404 from the upstream API; this tool reports that the settings are not available on this deployment instead of a generic error.
 
 ### `list_workspace_mfa_methods`
 List the MFA methods allowed for the workspace (`allowed_mfa_methods`, `passkey_as_mfa`). Useful when guiding a user through the remote/streamable-http MFA re-authentication flow.
@@ -541,6 +543,8 @@ List the MFA methods allowed for the workspace (`allowed_mfa_methods`, `passkey_
 **Parameters:**
 - `workspace` (string): Workspace name
 - `region` (string, default: "ap1"): Region name
+
+**Note:** Like `get_workspace_security`, this requires JWT (OAuth/SSO) authentication (a static API token is rejected up front) and the route is SaaS-only.
 
 ### `get_workspace_notifications`
 Get the workspace notification settings: `disconnection_notification` and `notification_channels`.
@@ -562,7 +566,7 @@ Update workspace notification settings. Only the fields you provide are sent (pa
 **Parameters:**
 - `workspace` (string): Workspace name
 - `disconnection_notification` (boolean, optional): Notify when a server disconnects/goes offline
-- `notification_channels` (array, optional): Channel types to notify through (`email`, `webhook`, `push`)
+- `notification_channels` (array, optional): Channel types to notify through (`email`, `webhook`, `push`). Replaces the whole list (not additive); read via `get_workspace_notifications` and merge before sending
 - `region` (string, default: "ap1"): Region name
 
 ### `update_workspace_preferences`
@@ -575,15 +579,15 @@ Update workspace-wide preferences. Only the fields you provide are sent (partial
 - `language` (string, optional): Workspace locale/language code
 - `timezone` (string, optional): Workspace timezone; also the billing clock
 - `invite_ttl` (integer, optional): Invitation link time-to-live, in seconds
-- `enabled_extensions` (array, optional): List of enabled extension names
+- `enabled_extensions` (array, optional): List of enabled extension names. Replaces the whole list (not additive); read via `get_workspace_preferences` and merge before sending. Narrowing it fails with HTTP 402 on non-enterprise plans
 - `websh_session_timeout` (integer, optional): Websh idle session timeout, in seconds
 - `auto_agent_upgrade` (boolean, optional): Whether agents auto-upgrade
 - `package_proxy` (string, optional): Proxy server URL for package installation
 - `billing_email` (string, optional): Billing contact email; SaaS-only field
-- `allowed_domains` (array, optional): Allowed email domains for invites; SaaS-only field
+- `allowed_domains` (array, optional): Allowed email domains for invites; SaaS-only field. Replaces the whole list (not additive); read via `get_workspace_preferences` and merge before sending
 - `region` (string, default: "ap1"): Region name
 
-**⚠️ Warning:** `timezone` is the workspace's billing clock—changing it shifts the daily usage-aggregation boundary. `billing_email` and `allowed_domains` are only accepted by the server on SaaS deployments.
+**⚠️ Warning:** `timezone` is the workspace's billing clock—changing it shifts the daily usage-aggregation boundary. The list fields (`enabled_extensions`, `allowed_domains`) replace the whole list rather than appending—read the current value, merge, then send. `billing_email` and `allowed_domains` are only accepted by the server on SaaS deployments.
 
 ---
 

--- a/tests/test_workspace_tools.py
+++ b/tests/test_workspace_tools.py
@@ -9,7 +9,17 @@ from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
 
-from tools.workspace_tools import get_current_user
+from tests.conftest import HTTP_ERROR_ENVELOPE
+from tools.workspace_tools import (
+    get_current_user,
+    get_workspace_access_control,
+    get_workspace_notifications,
+    get_workspace_preferences,
+    get_workspace_security,
+    list_workspace_mfa_methods,
+    update_workspace_notifications,
+    update_workspace_preferences,
+)
 
 
 @pytest.fixture
@@ -210,20 +220,25 @@ class TestListWorkspaces:
         assert len(workspaces) == 6
 
 
+@pytest.fixture
+def mock_http_client():
+    """Mock HTTP client for testing workspace settings tools."""
+    with patch('tools.workspace_tools.http_client') as mock_client:
+        mock_client.get = AsyncMock()
+        mock_client.patch = AsyncMock()
+        yield mock_client
+
+
+@pytest.fixture
+def mock_token():
+    """Mock token manager for testing workspace settings tools."""
+    with patch('utils.common.token_manager') as mock_manager:
+        mock_manager.get_token.return_value = 'test-token'
+        yield mock_manager
+
+
 class TestGetCurrentUser:
     """Test get_current_user function."""
-
-    @pytest.fixture
-    def mock_http_client(self):
-        with patch('tools.workspace_tools.http_client') as mock_client:
-            mock_client.get = AsyncMock()
-            yield mock_client
-
-    @pytest.fixture
-    def mock_token(self):
-        with patch('utils.common.token_manager') as mock_manager:
-            mock_manager.get_token.return_value = 'test-token'
-            yield mock_manager
 
     @pytest.mark.asyncio
     async def test_get_current_user_success(self, mock_http_client, mock_token):
@@ -253,6 +268,340 @@ class TestGetCurrentUser:
 
         assert result['status'] == 'error'
         assert 'workspace' in result['message'].lower()
+
+
+class TestGetWorkspaceAccessControl:
+    """Test get_workspace_access_control function."""
+
+    @pytest.mark.asyncio
+    async def test_success(self, mock_http_client, mock_token):
+        mock_http_client.get.return_value = {
+            'sudo_access': 'allowed',
+            'root_access': 'denied',
+            'work_session_ttl': 3600,
+        }
+
+        result = await get_workspace_access_control(
+            workspace='testworkspace', region='ap1'
+        )
+
+        assert result['status'] == 'success'
+        assert result['data']['work_session_ttl'] == 3600
+        mock_http_client.get.assert_called_once_with(
+            region='ap1',
+            workspace='testworkspace',
+            endpoint='/api/workspaces/access-control/-/',
+            token='test-token',
+        )
+
+    @pytest.mark.asyncio
+    async def test_http_error(self, mock_http_client, mock_token):
+        mock_http_client.get.return_value = HTTP_ERROR_ENVELOPE
+
+        result = await get_workspace_access_control(
+            workspace='testworkspace', region='ap1'
+        )
+
+        assert result['status'] == 'error'
+
+
+class TestGetWorkspaceSecurity:
+    """Test get_workspace_security function, including the SaaS-only 404 case."""
+
+    @pytest.mark.asyncio
+    async def test_success(self, mock_http_client, mock_token):
+        mock_http_client.get.return_value = {
+            'mfa_required': True,
+            'allowed_mfa_methods': ['totp', 'webauthn'],
+            'mfa_timeout': 900,
+        }
+
+        result = await get_workspace_security(workspace='testworkspace', region='ap1')
+
+        assert result['status'] == 'success'
+        assert result['data']['mfa_required'] is True
+        mock_http_client.get.assert_called_once_with(
+            region='ap1',
+            workspace='testworkspace',
+            endpoint='/api/workspaces/security/-/',
+            token='test-token',
+        )
+
+    @pytest.mark.asyncio
+    async def test_not_available_on_premise_returns_clear_message(
+        self, mock_http_client, mock_token
+    ):
+        """On-premise deployments 404 this SaaS-only route; report a clear reason."""
+        mock_http_client.get.return_value = HTTP_ERROR_ENVELOPE
+
+        result = await get_workspace_security(workspace='testworkspace', region='ap1')
+
+        assert result['status'] == 'error'
+        assert result['status_code'] == 404
+        assert 'not available on this deployment' in result['message']
+
+    @pytest.mark.asyncio
+    async def test_other_http_error(self, mock_http_client, mock_token):
+        mock_http_client.get.return_value = {
+            'error': 'HTTP Error',
+            'status_code': 500,
+            'message': 'Internal server error',
+        }
+
+        result = await get_workspace_security(workspace='testworkspace', region='ap1')
+
+        assert result['status'] == 'error'
+        assert result['status_code'] == 500
+        assert 'not available on this deployment' not in result['message']
+
+
+class TestListWorkspaceMfaMethods:
+    """Test list_workspace_mfa_methods function."""
+
+    @pytest.mark.asyncio
+    async def test_success(self, mock_http_client, mock_token):
+        mock_http_client.get.return_value = {
+            'allowed_mfa_methods': ['totp'],
+            'passkey_as_mfa': False,
+        }
+
+        result = await list_workspace_mfa_methods(
+            workspace='testworkspace', region='ap1'
+        )
+
+        assert result['status'] == 'success'
+        assert result['data']['allowed_mfa_methods'] == ['totp']
+        mock_http_client.get.assert_called_once_with(
+            region='ap1',
+            workspace='testworkspace',
+            endpoint='/api/workspaces/security/-/mfa-methods/',
+            token='test-token',
+        )
+
+    @pytest.mark.asyncio
+    async def test_http_error(self, mock_http_client, mock_token):
+        mock_http_client.get.return_value = HTTP_ERROR_ENVELOPE
+
+        result = await list_workspace_mfa_methods(
+            workspace='testworkspace', region='ap1'
+        )
+
+        assert result['status'] == 'error'
+
+
+class TestGetWorkspaceNotifications:
+    """Test get_workspace_notifications function."""
+
+    @pytest.mark.asyncio
+    async def test_success(self, mock_http_client, mock_token):
+        mock_http_client.get.return_value = {
+            'disconnection_notification': True,
+            'notification_channels': ['email'],
+        }
+
+        result = await get_workspace_notifications(
+            workspace='testworkspace', region='ap1'
+        )
+
+        assert result['status'] == 'success'
+        assert result['data']['notification_channels'] == ['email']
+        mock_http_client.get.assert_called_once_with(
+            region='ap1',
+            workspace='testworkspace',
+            endpoint='/api/workspaces/notifications/-/',
+            token='test-token',
+        )
+
+    @pytest.mark.asyncio
+    async def test_http_error(self, mock_http_client, mock_token):
+        mock_http_client.get.return_value = HTTP_ERROR_ENVELOPE
+
+        result = await get_workspace_notifications(
+            workspace='testworkspace', region='ap1'
+        )
+
+        assert result['status'] == 'error'
+
+
+class TestGetWorkspacePreferences:
+    """Test get_workspace_preferences function."""
+
+    @pytest.mark.asyncio
+    async def test_success(self, mock_http_client, mock_token):
+        mock_http_client.get.return_value = {
+            'timezone': 'Asia/Seoul',
+            'language': 'ko',
+            'billing_email': 'billing@example.com',
+        }
+
+        result = await get_workspace_preferences(
+            workspace='testworkspace', region='ap1'
+        )
+
+        assert result['status'] == 'success'
+        assert result['data']['timezone'] == 'Asia/Seoul'
+        mock_http_client.get.assert_called_once_with(
+            region='ap1',
+            workspace='testworkspace',
+            endpoint='/api/workspaces/preferences/-/',
+            token='test-token',
+        )
+
+    @pytest.mark.asyncio
+    async def test_http_error(self, mock_http_client, mock_token):
+        mock_http_client.get.return_value = HTTP_ERROR_ENVELOPE
+
+        result = await get_workspace_preferences(
+            workspace='testworkspace', region='ap1'
+        )
+
+        assert result['status'] == 'error'
+
+
+class TestUpdateWorkspaceNotifications:
+    """Test update_workspace_notifications function."""
+
+    @pytest.mark.asyncio
+    async def test_partial_update_only_sends_provided_fields(
+        self, mock_http_client, mock_token
+    ):
+        mock_http_client.patch.return_value = {
+            'disconnection_notification': False,
+            'notification_channels': ['email'],
+        }
+
+        result = await update_workspace_notifications(
+            workspace='testworkspace',
+            disconnection_notification=False,
+            region='ap1',
+        )
+
+        assert result['status'] == 'success'
+        mock_http_client.patch.assert_called_once_with(
+            region='ap1',
+            workspace='testworkspace',
+            endpoint='/api/workspaces/notifications/-/',
+            token='test-token',
+            data={'disconnection_notification': False},
+        )
+
+    @pytest.mark.asyncio
+    async def test_update_multiple_fields(self, mock_http_client, mock_token):
+        mock_http_client.patch.return_value = {
+            'disconnection_notification': True,
+            'notification_channels': ['email', 'webhook'],
+        }
+
+        result = await update_workspace_notifications(
+            workspace='testworkspace',
+            disconnection_notification=True,
+            notification_channels=['email', 'webhook'],
+            region='ap1',
+        )
+
+        assert result['status'] == 'success'
+        mock_http_client.patch.assert_called_once_with(
+            region='ap1',
+            workspace='testworkspace',
+            endpoint='/api/workspaces/notifications/-/',
+            token='test-token',
+            data={
+                'disconnection_notification': True,
+                'notification_channels': ['email', 'webhook'],
+            },
+        )
+
+    @pytest.mark.asyncio
+    async def test_no_fields_provided_returns_error(self, mock_http_client, mock_token):
+        result = await update_workspace_notifications(
+            workspace='testworkspace', region='ap1'
+        )
+
+        assert result['status'] == 'error'
+        mock_http_client.patch.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_http_error(self, mock_http_client, mock_token):
+        mock_http_client.patch.return_value = HTTP_ERROR_ENVELOPE
+
+        result = await update_workspace_notifications(
+            workspace='testworkspace', disconnection_notification=True, region='ap1'
+        )
+
+        assert result['status'] == 'error'
+
+
+class TestUpdateWorkspacePreferences:
+    """Test update_workspace_preferences function."""
+
+    @pytest.mark.asyncio
+    async def test_partial_update_only_sends_provided_fields(
+        self, mock_http_client, mock_token
+    ):
+        mock_http_client.patch.return_value = {'timezone': 'Asia/Seoul'}
+
+        result = await update_workspace_preferences(
+            workspace='testworkspace',
+            timezone='Asia/Seoul',
+            region='ap1',
+        )
+
+        assert result['status'] == 'success'
+        mock_http_client.patch.assert_called_once_with(
+            region='ap1',
+            workspace='testworkspace',
+            endpoint='/api/workspaces/preferences/-/',
+            token='test-token',
+            data={'timezone': 'Asia/Seoul'},
+        )
+
+    @pytest.mark.asyncio
+    async def test_update_multiple_fields(self, mock_http_client, mock_token):
+        mock_http_client.patch.return_value = {
+            'timezone': 'Asia/Seoul',
+            'auto_agent_upgrade': False,
+            'enabled_extensions': ['metrics'],
+        }
+
+        result = await update_workspace_preferences(
+            workspace='testworkspace',
+            timezone='Asia/Seoul',
+            auto_agent_upgrade=False,
+            enabled_extensions=['metrics'],
+            region='ap1',
+        )
+
+        assert result['status'] == 'success'
+        mock_http_client.patch.assert_called_once_with(
+            region='ap1',
+            workspace='testworkspace',
+            endpoint='/api/workspaces/preferences/-/',
+            token='test-token',
+            data={
+                'timezone': 'Asia/Seoul',
+                'auto_agent_upgrade': False,
+                'enabled_extensions': ['metrics'],
+            },
+        )
+
+    @pytest.mark.asyncio
+    async def test_no_fields_provided_returns_error(self, mock_http_client, mock_token):
+        result = await update_workspace_preferences(
+            workspace='testworkspace', region='ap1'
+        )
+
+        assert result['status'] == 'error'
+        mock_http_client.patch.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_http_error(self, mock_http_client, mock_token):
+        mock_http_client.patch.return_value = HTTP_ERROR_ENVELOPE
+
+        result = await update_workspace_preferences(
+            workspace='testworkspace', timezone='Asia/Seoul', region='ap1'
+        )
+
+        assert result['status'] == 'error'
 
 
 if __name__ == '__main__':

--- a/tests/test_workspace_tools.py
+++ b/tests/test_workspace_tools.py
@@ -395,7 +395,11 @@ class TestListWorkspaceMfaMethods:
         )
 
     @pytest.mark.asyncio
-    async def test_http_error(self, mock_http_client, mock_token):
+    async def test_not_available_on_premise_returns_clear_message(
+        self, mock_http_client, mock_token
+    ):
+        """This mfa-methods sub-route shares the SaaS-only 404 guard, so on-premise
+        deployments get the same clear reason as get_workspace_security."""
         mock_http_client.get.return_value = HTTP_ERROR_ENVELOPE
 
         result = await list_workspace_mfa_methods(
@@ -403,6 +407,42 @@ class TestListWorkspaceMfaMethods:
         )
 
         assert result['status'] == 'error'
+        assert result['status_code'] == 404
+        assert 'not available on this deployment' in result['message']
+
+    @pytest.mark.asyncio
+    async def test_other_http_error(self, mock_http_client, mock_token):
+        mock_http_client.get.return_value = {
+            'error': 'HTTP Error',
+            'status_code': 500,
+            'message': 'Internal server error',
+        }
+
+        result = await list_workspace_mfa_methods(
+            workspace='testworkspace', region='ap1'
+        )
+
+        assert result['status'] == 'error'
+        assert result['status_code'] == 500
+        assert 'not available on this deployment' not in result['message']
+
+    @pytest.mark.asyncio
+    async def test_success_payload_with_status_code_404_is_not_misread(
+        self, mock_http_client, mock_token
+    ):
+        """A success payload carrying status_code 404 (no error key) must not trip
+        the shared SaaS-only branch."""
+        mock_http_client.get.return_value = {
+            'allowed_mfa_methods': ['totp'],
+            'status_code': 404,
+        }
+
+        result = await list_workspace_mfa_methods(
+            workspace='testworkspace', region='ap1'
+        )
+
+        assert result['status'] == 'success'
+        assert result['data']['allowed_mfa_methods'] == ['totp']
 
 
 class TestGetWorkspaceNotifications:
@@ -534,6 +574,8 @@ class TestUpdateWorkspaceNotifications:
         )
 
         assert result['status'] == 'error'
+        assert result['region'] == 'ap1'
+        assert result['workspace'] == 'testworkspace'
         mock_http_client.patch.assert_not_called()
 
     @pytest.mark.asyncio
@@ -607,6 +649,8 @@ class TestUpdateWorkspacePreferences:
         )
 
         assert result['status'] == 'error'
+        assert result['region'] == 'ap1'
+        assert result['workspace'] == 'testworkspace'
         mock_http_client.patch.assert_not_called()
 
     @pytest.mark.asyncio

--- a/tests/test_workspace_tools.py
+++ b/tests/test_workspace_tools.py
@@ -354,6 +354,22 @@ class TestGetWorkspaceSecurity:
         assert result['status_code'] == 500
         assert 'not available on this deployment' not in result['message']
 
+    @pytest.mark.asyncio
+    async def test_success_payload_with_status_code_404_is_not_misread(
+        self, mock_http_client, mock_token
+    ):
+        """A success payload that happens to carry status_code 404 (no error key)
+        must not trip the SaaS-only branch."""
+        mock_http_client.get.return_value = {
+            'mfa_required': True,
+            'status_code': 404,
+        }
+
+        result = await get_workspace_security(workspace='testworkspace', region='ap1')
+
+        assert result['status'] == 'success'
+        assert result['data']['status_code'] == 404
+
 
 class TestListWorkspaceMfaMethods:
     """Test list_workspace_mfa_methods function."""

--- a/tests/test_workspace_tools.py
+++ b/tests/test_workspace_tools.py
@@ -237,6 +237,18 @@ def mock_token():
         yield mock_manager
 
 
+@pytest.fixture
+def mock_jwt_token():
+    """Mock token manager returning a JWT-shaped token.
+
+    The security-settings tools stack @require_jwt_auth, which rejects any
+    token that is not JWT-shaped (3 dotted non-empty parts).
+    """
+    with patch('utils.common.token_manager') as mock_manager:
+        mock_manager.get_token.return_value = 'header.payload.signature'
+        yield mock_manager
+
+
 class TestGetCurrentUser:
     """Test get_current_user function."""
 
@@ -309,7 +321,7 @@ class TestGetWorkspaceSecurity:
     """Test get_workspace_security function, including the SaaS-only 404 case."""
 
     @pytest.mark.asyncio
-    async def test_success(self, mock_http_client, mock_token):
+    async def test_success(self, mock_http_client, mock_jwt_token):
         mock_http_client.get.return_value = {
             'mfa_required': True,
             'allowed_mfa_methods': ['totp', 'webauthn'],
@@ -324,12 +336,22 @@ class TestGetWorkspaceSecurity:
             region='ap1',
             workspace='testworkspace',
             endpoint='/api/workspaces/security/-/',
-            token='test-token',
+            token='header.payload.signature',
         )
 
     @pytest.mark.asyncio
+    async def test_rejects_non_jwt_token(self, mock_http_client, mock_token):
+        """A static API token (stdio mode) is rejected before any request; the
+        upstream SecuritySettingsViewSet has no APITokenAuthentication."""
+        result = await get_workspace_security(workspace='testworkspace', region='ap1')
+
+        assert result['status'] == 'error'
+        assert 'JWT' in result['message']
+        mock_http_client.get.assert_not_called()
+
+    @pytest.mark.asyncio
     async def test_not_available_on_premise_returns_clear_message(
-        self, mock_http_client, mock_token
+        self, mock_http_client, mock_jwt_token
     ):
         """On-premise deployments 404 this SaaS-only route; report a clear reason."""
         mock_http_client.get.return_value = HTTP_ERROR_ENVELOPE
@@ -341,7 +363,7 @@ class TestGetWorkspaceSecurity:
         assert 'not available on this deployment' in result['message']
 
     @pytest.mark.asyncio
-    async def test_other_http_error(self, mock_http_client, mock_token):
+    async def test_other_http_error(self, mock_http_client, mock_jwt_token):
         mock_http_client.get.return_value = {
             'error': 'HTTP Error',
             'status_code': 500,
@@ -356,7 +378,7 @@ class TestGetWorkspaceSecurity:
 
     @pytest.mark.asyncio
     async def test_success_payload_with_status_code_404_is_not_misread(
-        self, mock_http_client, mock_token
+        self, mock_http_client, mock_jwt_token
     ):
         """A success payload that happens to carry status_code 404 (no error key)
         must not trip the SaaS-only branch."""
@@ -375,7 +397,7 @@ class TestListWorkspaceMfaMethods:
     """Test list_workspace_mfa_methods function."""
 
     @pytest.mark.asyncio
-    async def test_success(self, mock_http_client, mock_token):
+    async def test_success(self, mock_http_client, mock_jwt_token):
         mock_http_client.get.return_value = {
             'allowed_mfa_methods': ['totp'],
             'passkey_as_mfa': False,
@@ -391,12 +413,24 @@ class TestListWorkspaceMfaMethods:
             region='ap1',
             workspace='testworkspace',
             endpoint='/api/workspaces/security/-/mfa-methods/',
-            token='test-token',
+            token='header.payload.signature',
         )
 
     @pytest.mark.asyncio
+    async def test_rejects_non_jwt_token(self, mock_http_client, mock_token):
+        """A static API token is rejected before any request, matching
+        get_workspace_security (no APITokenAuthentication on the sub-route)."""
+        result = await list_workspace_mfa_methods(
+            workspace='testworkspace', region='ap1'
+        )
+
+        assert result['status'] == 'error'
+        assert 'JWT' in result['message']
+        mock_http_client.get.assert_not_called()
+
+    @pytest.mark.asyncio
     async def test_not_available_on_premise_returns_clear_message(
-        self, mock_http_client, mock_token
+        self, mock_http_client, mock_jwt_token
     ):
         """This mfa-methods sub-route shares the SaaS-only 404 guard, so on-premise
         deployments get the same clear reason as get_workspace_security."""
@@ -411,7 +445,7 @@ class TestListWorkspaceMfaMethods:
         assert 'not available on this deployment' in result['message']
 
     @pytest.mark.asyncio
-    async def test_other_http_error(self, mock_http_client, mock_token):
+    async def test_other_http_error(self, mock_http_client, mock_jwt_token):
         mock_http_client.get.return_value = {
             'error': 'HTTP Error',
             'status_code': 500,
@@ -428,7 +462,7 @@ class TestListWorkspaceMfaMethods:
 
     @pytest.mark.asyncio
     async def test_success_payload_with_status_code_404_is_not_misread(
-        self, mock_http_client, mock_token
+        self, mock_http_client, mock_jwt_token
     ):
         """A success payload carrying status_code 404 (no error key) must not trip
         the shared SaaS-only branch."""

--- a/tools/resources.py
+++ b/tools/resources.py
@@ -93,7 +93,15 @@ from tools.webftp_tools import (
 )
 from tools.webhook_tools import get_webhook, list_event_subscriptions, list_webhooks
 from tools.work_session_tools import work_session_get, work_session_list
-from tools.workspace_tools import get_current_user, list_workspaces
+from tools.workspace_tools import (
+    get_current_user,
+    get_workspace_access_control,
+    get_workspace_notifications,
+    get_workspace_preferences,
+    get_workspace_security,
+    list_workspace_mfa_methods,
+    list_workspaces,
+)
 
 
 def register_resource(
@@ -398,6 +406,31 @@ RESOURCES: list[tuple[str, Callable, str]] = [
     ('workspaces_all', list_workspaces, 'alpacon://workspaces'),
     ('workspaces_list', list_workspaces, 'alpacon://workspaces/{region}'),
     ('current_user', get_current_user, 'alpacon://current-user/{region}/{workspace}'),
+    (
+        'workspace_settings_access_control',
+        get_workspace_access_control,
+        'alpacon://workspace-settings/access-control/{region}/{workspace}',
+    ),
+    (
+        'workspace_settings_security',
+        get_workspace_security,
+        'alpacon://workspace-settings/security/{region}/{workspace}',
+    ),
+    (
+        'workspace_settings_mfa_methods',
+        list_workspace_mfa_methods,
+        'alpacon://workspace-settings/mfa-methods/{region}/{workspace}',
+    ),
+    (
+        'workspace_settings_notifications',
+        get_workspace_notifications,
+        'alpacon://workspace-settings/notifications/{region}/{workspace}',
+    ),
+    (
+        'workspace_settings_preferences',
+        get_workspace_preferences,
+        'alpacon://workspace-settings/preferences/{region}/{workspace}',
+    ),
 ]
 
 # (name, fn, uri, extra) — extra pins fixed kwargs for the few filtered resources.

--- a/tools/workspace_tools.py
+++ b/tools/workspace_tools.py
@@ -269,7 +269,11 @@ async def get_workspace_security(
         token=token,
     )
 
-    if isinstance(result, dict) and result.get('status_code') == 404:
+    if (
+        isinstance(result, dict)
+        and 'error' in result
+        and result.get('status_code') == 404
+    ):
         return error_response(
             'Workspace security settings are not available on this deployment '
             '(this endpoint is SaaS-only and returns 404 on-premise).',
@@ -530,7 +534,7 @@ async def update_workspace_preferences(
         timezone: Workspace timezone; also the billing clock (optional)
         invite_ttl: Invitation link time-to-live, in seconds (optional)
         enabled_extensions: List of enabled extension names (optional)
-        websh_session_timeout: WebSH idle session timeout, in seconds (optional)
+        websh_session_timeout: Websh idle session timeout, in seconds (optional)
         auto_agent_upgrade: Whether agents auto-upgrade (optional)
         package_proxy: Proxy server URL for package installation, e.g.
             http://proxy.example.com:8080 (optional)

--- a/tools/workspace_tools.py
+++ b/tools/workspace_tools.py
@@ -65,6 +65,33 @@ def _collect_workspaces_from_tokens(
     return workspaces
 
 
+def _saas_only_security_404(
+    result: Any, region: str, workspace: str
+) -> dict[str, Any] | None:
+    """Translate a SaaS-only 404 into a clear "not available" error.
+
+    The SecuritySettingsViewSet routes (security settings and their mfa-methods
+    sub-route) are only registered under AUTH0_ENABLED, so on-premise
+    deployments return 404. Requires the http_client `error` key (matching
+    unwrap_http_result) so a success payload carrying status_code 404 is not
+    misread. Returns an error_response when the result is a 404 error envelope,
+    else None so the caller continues with normal unwrapping.
+    """
+    if (
+        isinstance(result, dict)
+        and 'error' in result
+        and result.get('status_code') == 404
+    ):
+        return error_response(
+            'Workspace security settings are not available on this deployment '
+            '(this endpoint is SaaS-only and returns 404 on-premise).',
+            region=region,
+            workspace=workspace,
+            status_code=404,
+        )
+    return None
+
+
 @mcp.tool(
     description='List all available workspaces and their regions. Returns workspace names, region codes, and domain hostnames. In local mode reads from token.json; in server mode extracts from JWT claims. When to use: first tool to call to discover which workspaces are configured. Related: list_servers (find servers in a workspace). Note: Most other tools require a workspace parameter from this list.',
     annotations=ToolAnnotations(readOnlyHint=True, destructiveHint=False),
@@ -269,18 +296,9 @@ async def get_workspace_security(
         token=token,
     )
 
-    if (
-        isinstance(result, dict)
-        and 'error' in result
-        and result.get('status_code') == 404
-    ):
-        return error_response(
-            'Workspace security settings are not available on this deployment '
-            '(this endpoint is SaaS-only and returns 404 on-premise).',
-            region=region,
-            workspace=workspace,
-            status_code=404,
-        )
+    saas_only = _saas_only_security_404(result, region, workspace)
+    if saas_only:
+        return saas_only
 
     err = unwrap_http_result(
         result,
@@ -327,6 +345,10 @@ async def list_workspace_mfa_methods(
         endpoint='/api/workspaces/security/-/mfa-methods/',
         token=token,
     )
+
+    saas_only = _saas_only_security_404(result, region, workspace)
+    if saas_only:
+        return saas_only
 
     err = unwrap_http_result(
         result,
@@ -469,7 +491,9 @@ async def update_workspace_notifications(
         update_data['notification_channels'] = notification_channels
 
     if not update_data:
-        return error_response('No update data provided')
+        return error_response(
+            'No update data provided', region=region, workspace=workspace
+        )
 
     result = await http_client.patch(
         region=region,
@@ -572,7 +596,9 @@ async def update_workspace_preferences(
         update_data['allowed_domains'] = allowed_domains
 
     if not update_data:
-        return error_response('No update data provided')
+        return error_response(
+            'No update data provided', region=region, workspace=workspace
+        )
 
     result = await http_client.patch(
         region=region,

--- a/tools/workspace_tools.py
+++ b/tools/workspace_tools.py
@@ -6,7 +6,7 @@ from mcp.types import ToolAnnotations
 
 from server import mcp
 from utils.common import error_response, success_response, unwrap_http_result
-from utils.decorators import mcp_tool_handler
+from utils.decorators import mcp_tool_handler, require_jwt_auth
 from utils.http_client import http_client
 from utils.token_manager import TokenManager
 from utils.tool_annotations import IDEMPOTENT_WRITE, READ_ONLY
@@ -265,9 +265,12 @@ async def get_workspace_access_control(
     description=(
         'Get the workspace authentication/security settings: mfa_required, allowed_mfa_methods, '
         'mfa_timeout, and which actions require MFA. '
-        'Note: this route is SaaS-only; on-premise deployments return 404 from the upstream '
-        'API, and this tool reports that the settings are not available on this deployment '
-        'rather than a generic error. '
+        'Note: the upstream route authenticates JWT (OAuth/SSO) sessions only, so a static '
+        'API token (stdio mode) is rejected before any request is sent; use remote/'
+        'streamable-http (browser SSO) mode to read these settings. '
+        'Note: this route is also SaaS-only; on-premise deployments return 404 from the '
+        'upstream API, and this tool reports that the settings are not available on this '
+        'deployment rather than a generic error. '
         'Related: list_workspace_mfa_methods (allowed methods only), get_workspace_access_control.'
     ),
     annotations=READ_ONLY,
@@ -275,10 +278,14 @@ async def get_workspace_access_control(
         'anthropic/searchHint': 'workspace security mfa authentication settings',
     },
 )
+@require_jwt_auth
 async def get_workspace_security(
     workspace: str, region: str = '', **kwargs
 ) -> dict[str, Any]:
     """Get the workspace authentication/security settings.
+
+    Requires JWT (OAuth/SSO) authentication: the upstream SecuritySettingsViewSet
+    has no APITokenAuthentication, so a static API token is rejected up front.
 
     Args:
         workspace: Workspace name. Required parameter
@@ -318,6 +325,9 @@ async def get_workspace_security(
         'whether a passkey can satisfy MFA (passkey_as_mfa). Useful when a tool call fails '
         'with an MFA re-authentication requirement (remote/streamable-http mode) and you need '
         'to tell the user which methods they can use to complete the browser re-auth step. '
+        'Note: like get_workspace_security, the upstream route authenticates JWT (OAuth/SSO) '
+        'sessions only; a static API token (stdio mode) is rejected before any request is '
+        'sent, and the route is SaaS-only (on-premise returns a clear not-available message). '
         'Related: get_workspace_security (full security settings).'
     ),
     annotations=READ_ONLY,
@@ -325,10 +335,14 @@ async def get_workspace_security(
         'anthropic/searchHint': 'workspace mfa methods list allowed passkey reauth',
     },
 )
+@require_jwt_auth
 async def list_workspace_mfa_methods(
     workspace: str, region: str = '', **kwargs
 ) -> dict[str, Any]:
     """List MFA methods allowed for the workspace.
+
+    Requires JWT (OAuth/SSO) authentication: the upstream mfa-methods action has
+    no APITokenAuthentication, so a static API token is rejected up front.
 
     Args:
         workspace: Workspace name. Required parameter
@@ -457,7 +471,11 @@ async def get_workspace_preferences(
         'Update workspace notification settings. Only the fields you provide are sent '
         '(partial update). Fields: disconnection_notification (bool, notify when a server '
         'disconnects/goes offline), notification_channels (list of channel types to notify '
-        'through: email, webhook, push). Related: get_workspace_notifications.'
+        'through: email, webhook, push). '
+        'Warning: notification_channels REPLACES the whole list, it does not append. To add '
+        'a channel, first read the current list via get_workspace_notifications, merge, then '
+        'send the full list — otherwise the omitted channels are dropped. '
+        'Related: get_workspace_notifications.'
     ),
     annotations=IDEMPOTENT_WRITE,
     meta={
@@ -476,7 +494,9 @@ async def update_workspace_notifications(
     Args:
         workspace: Workspace name. Required parameter
         disconnection_notification: Notify when a server disconnects (optional)
-        notification_channels: Channel types to notify through, e.g. email/webhook/push (optional)
+        notification_channels: Channel types to notify through, e.g. email/webhook/push.
+            Replaces the whole list (not additive); read via get_workspace_notifications
+            and merge before sending to avoid dropping existing channels (optional)
         region: Region (ap1, us1, eu1). Auto-detected if not provided
 
     Returns:
@@ -523,6 +543,10 @@ async def update_workspace_notifications(
         'billing_email, allowed_domains. '
         "Warning: timezone is the workspace's billing clock—changing it shifts the daily "
         'usage-aggregation boundary. '
+        'Warning: the list fields (enabled_extensions, allowed_domains) REPLACE the whole '
+        'list, they do not append; read the current value via get_workspace_preferences, '
+        'merge, then send the full list to avoid dropping existing entries. Narrowing '
+        'enabled_extensions additionally fails with HTTP 402 on non-enterprise plans. '
         'Warning: billing_email and allowed_domains are only accepted by the server on SaaS '
         'deployments. '
         'Related: get_workspace_preferences.'
@@ -557,13 +581,17 @@ async def update_workspace_preferences(
         language: Workspace locale/language code (optional)
         timezone: Workspace timezone; also the billing clock (optional)
         invite_ttl: Invitation link time-to-live, in seconds (optional)
-        enabled_extensions: List of enabled extension names (optional)
+        enabled_extensions: List of enabled extension names. Replaces the whole list
+            (not additive); read via get_workspace_preferences and merge before sending.
+            Narrowing this list fails with HTTP 402 on non-enterprise plans (optional)
         websh_session_timeout: Websh idle session timeout, in seconds (optional)
         auto_agent_upgrade: Whether agents auto-upgrade (optional)
         package_proxy: Proxy server URL for package installation, e.g.
             http://proxy.example.com:8080 (optional)
         billing_email: Billing contact email; SaaS-only field (optional)
-        allowed_domains: Allowed email domains for invites; SaaS-only field (optional)
+        allowed_domains: Allowed email domains for invites; SaaS-only field. Replaces the
+            whole list (not additive); read via get_workspace_preferences and merge before
+            sending (optional)
         region: Region (ap1, us1, eu1). Auto-detected if not provided
 
     Returns:

--- a/tools/workspace_tools.py
+++ b/tools/workspace_tools.py
@@ -9,7 +9,7 @@ from utils.common import error_response, success_response, unwrap_http_result
 from utils.decorators import mcp_tool_handler
 from utils.http_client import http_client
 from utils.token_manager import TokenManager
-from utils.tool_annotations import READ_ONLY
+from utils.tool_annotations import IDEMPOTENT_WRITE, READ_ONLY
 
 
 def _collect_workspaces_from_tokens(
@@ -175,6 +175,412 @@ async def get_current_user(
     err = unwrap_http_result(
         result,
         default_message='Failed to get current user',
+        region=region,
+        workspace=workspace,
+    )
+    if err:
+        return err
+
+    return success_response(data=result, region=region, workspace=workspace)
+
+
+@mcp_tool_handler(
+    description=(
+        'Get the workspace access control settings: sudo/root access policy '
+        '(allow_sudo_with_mfa, allow_direct_root, block_local_sudo, sudo_timeout), '
+        'tunnel/editor defaults, home_directory_permission, Work Session TTLs '
+        '(work_session_max_ttl, work_session_pending_ttl), command-env audit exposure, '
+        'and shared_account_names. Use this to check what privilege-escalation and '
+        'session-lifetime rules apply workspace-wide before requesting elevated access. '
+        'Note: on-premise deployments omit the MFA-related fields (allow_sudo_with_mfa, '
+        'block_local_sudo, sudo_timeout). '
+        'Related: get_workspace_security (MFA/authentication settings), list_sudo_policies.'
+    ),
+    annotations=READ_ONLY,
+    meta={
+        'anthropic/searchHint': 'workspace access control sudo root tunnel editor home directory work session ttl shared accounts policy',
+    },
+)
+async def get_workspace_access_control(
+    workspace: str, region: str = '', **kwargs
+) -> dict[str, Any]:
+    """Get the workspace access control settings.
+
+    Args:
+        workspace: Workspace name. Required parameter
+        region: Region (ap1, us1, eu1). Auto-detected if not provided
+
+    Returns:
+        Workspace access control settings response
+    """
+    token = kwargs.get('token')
+
+    result = await http_client.get(
+        region=region,
+        workspace=workspace,
+        endpoint='/api/workspaces/access-control/-/',
+        token=token,
+    )
+
+    err = unwrap_http_result(
+        result,
+        default_message='Failed to get workspace access control settings',
+        region=region,
+        workspace=workspace,
+    )
+    if err:
+        return err
+
+    return success_response(data=result, region=region, workspace=workspace)
+
+
+@mcp_tool_handler(
+    description=(
+        'Get the workspace authentication/security settings: mfa_required, allowed_mfa_methods, '
+        'mfa_timeout, and which actions require MFA. '
+        'Note: this route is SaaS-only; on-premise deployments return 404 from the upstream '
+        'API, and this tool reports that the settings are not available on this deployment '
+        'rather than a generic error. '
+        'Related: list_workspace_mfa_methods (allowed methods only), get_workspace_access_control.'
+    ),
+    annotations=READ_ONLY,
+    meta={
+        'anthropic/searchHint': 'workspace security mfa authentication settings',
+    },
+)
+async def get_workspace_security(
+    workspace: str, region: str = '', **kwargs
+) -> dict[str, Any]:
+    """Get the workspace authentication/security settings.
+
+    Args:
+        workspace: Workspace name. Required parameter
+        region: Region (ap1, us1, eu1). Auto-detected if not provided
+
+    Returns:
+        Workspace security settings response
+    """
+    token = kwargs.get('token')
+
+    result = await http_client.get(
+        region=region,
+        workspace=workspace,
+        endpoint='/api/workspaces/security/-/',
+        token=token,
+    )
+
+    if isinstance(result, dict) and result.get('status_code') == 404:
+        return error_response(
+            'Workspace security settings are not available on this deployment '
+            '(this endpoint is SaaS-only and returns 404 on-premise).',
+            region=region,
+            workspace=workspace,
+            status_code=404,
+        )
+
+    err = unwrap_http_result(
+        result,
+        default_message='Failed to get workspace security settings',
+        region=region,
+        workspace=workspace,
+    )
+    if err:
+        return err
+
+    return success_response(data=result, region=region, workspace=workspace)
+
+
+@mcp_tool_handler(
+    description=(
+        'List the MFA methods allowed for this workspace. Returns allowed_mfa_methods and '
+        'whether a passkey can satisfy MFA (passkey_as_mfa). Useful when a tool call fails '
+        'with an MFA re-authentication requirement (remote/streamable-http mode) and you need '
+        'to tell the user which methods they can use to complete the browser re-auth step. '
+        'Related: get_workspace_security (full security settings).'
+    ),
+    annotations=READ_ONLY,
+    meta={
+        'anthropic/searchHint': 'workspace mfa methods list allowed passkey reauth',
+    },
+)
+async def list_workspace_mfa_methods(
+    workspace: str, region: str = '', **kwargs
+) -> dict[str, Any]:
+    """List MFA methods allowed for the workspace.
+
+    Args:
+        workspace: Workspace name. Required parameter
+        region: Region (ap1, us1, eu1). Auto-detected if not provided
+
+    Returns:
+        Allowed MFA methods response
+    """
+    token = kwargs.get('token')
+
+    result = await http_client.get(
+        region=region,
+        workspace=workspace,
+        endpoint='/api/workspaces/security/-/mfa-methods/',
+        token=token,
+    )
+
+    err = unwrap_http_result(
+        result,
+        default_message='Failed to list workspace MFA methods',
+        region=region,
+        workspace=workspace,
+    )
+    if err:
+        return err
+
+    return success_response(data=result, region=region, workspace=workspace)
+
+
+@mcp_tool_handler(
+    description=(
+        'Get the workspace notification settings: disconnection_notification and the '
+        'notification_channels used to deliver workspace-level alerts. '
+        'Related: update_workspace_notifications, list_webhooks, list_event_subscriptions.'
+    ),
+    annotations=READ_ONLY,
+    meta={
+        'anthropic/searchHint': 'workspace notifications settings disconnection channels',
+    },
+)
+async def get_workspace_notifications(
+    workspace: str, region: str = '', **kwargs
+) -> dict[str, Any]:
+    """Get the workspace notification settings.
+
+    Args:
+        workspace: Workspace name. Required parameter
+        region: Region (ap1, us1, eu1). Auto-detected if not provided
+
+    Returns:
+        Workspace notification settings response
+    """
+    token = kwargs.get('token')
+
+    result = await http_client.get(
+        region=region,
+        workspace=workspace,
+        endpoint='/api/workspaces/notifications/-/',
+        token=token,
+    )
+
+    err = unwrap_http_result(
+        result,
+        default_message='Failed to get workspace notification settings',
+        region=region,
+        workspace=workspace,
+    )
+    if err:
+        return err
+
+    return success_response(data=result, region=region, workspace=workspace)
+
+
+@mcp_tool_handler(
+    description=(
+        'Get the workspace-wide preferences: timezone, locale (country/language), '
+        'front_url, invite_ttl, enabled_extensions, websh_session_timeout, '
+        'auto_agent_upgrade, package_proxy, billing_email, and allowed_domains. '
+        'This is workspace-global configuration, not a per-user preference. '
+        'Related: update_workspace_preferences, get_workspace_notifications.'
+    ),
+    annotations=READ_ONLY,
+    meta={
+        'anthropic/searchHint': 'workspace preferences settings timezone locale billing',
+    },
+)
+async def get_workspace_preferences(
+    workspace: str, region: str = '', **kwargs
+) -> dict[str, Any]:
+    """Get the workspace-wide preferences.
+
+    Args:
+        workspace: Workspace name. Required parameter
+        region: Region (ap1, us1, eu1). Auto-detected if not provided
+
+    Returns:
+        Workspace preferences response
+    """
+    token = kwargs.get('token')
+
+    result = await http_client.get(
+        region=region,
+        workspace=workspace,
+        endpoint='/api/workspaces/preferences/-/',
+        token=token,
+    )
+
+    err = unwrap_http_result(
+        result,
+        default_message='Failed to get workspace preferences',
+        region=region,
+        workspace=workspace,
+    )
+    if err:
+        return err
+
+    return success_response(data=result, region=region, workspace=workspace)
+
+
+@mcp_tool_handler(
+    description=(
+        'Update workspace notification settings. Only the fields you provide are sent '
+        '(partial update). Fields: disconnection_notification (bool, notify when a server '
+        'disconnects/goes offline), notification_channels (list of channel types to notify '
+        'through: email, webhook, push). Related: get_workspace_notifications.'
+    ),
+    annotations=IDEMPOTENT_WRITE,
+    meta={
+        'anthropic/searchHint': 'workspace notifications update modify settings',
+    },
+)
+async def update_workspace_notifications(
+    workspace: str,
+    disconnection_notification: bool | None = None,
+    notification_channels: list[str] | None = None,
+    region: str = '',
+    **kwargs,
+) -> dict[str, Any]:
+    """Update the workspace notification settings (partial update).
+
+    Args:
+        workspace: Workspace name. Required parameter
+        disconnection_notification: Notify when a server disconnects (optional)
+        notification_channels: Channel types to notify through, e.g. email/webhook/push (optional)
+        region: Region (ap1, us1, eu1). Auto-detected if not provided
+
+    Returns:
+        Workspace notification update response
+    """
+    token = kwargs.get('token')
+
+    update_data: dict[str, Any] = {}
+    if disconnection_notification is not None:
+        update_data['disconnection_notification'] = disconnection_notification
+    if notification_channels is not None:
+        update_data['notification_channels'] = notification_channels
+
+    if not update_data:
+        return error_response('No update data provided')
+
+    result = await http_client.patch(
+        region=region,
+        workspace=workspace,
+        endpoint='/api/workspaces/notifications/-/',
+        token=token,
+        data=update_data,
+    )
+
+    err = unwrap_http_result(
+        result,
+        default_message='Failed to update workspace notification settings',
+        region=region,
+        workspace=workspace,
+    )
+    if err:
+        return err
+
+    return success_response(data=result, region=region, workspace=workspace)
+
+
+@mcp_tool_handler(
+    description=(
+        'Update workspace-wide preferences. Only the fields you provide are sent (partial '
+        'update). Fields: front_url, country, language, timezone, invite_ttl, '
+        'enabled_extensions, websh_session_timeout, auto_agent_upgrade, package_proxy, '
+        'billing_email, allowed_domains. '
+        "Warning: timezone is the workspace's billing clock—changing it shifts the daily "
+        'usage-aggregation boundary. '
+        'Warning: billing_email and allowed_domains are only accepted by the server on SaaS '
+        'deployments. '
+        'Related: get_workspace_preferences.'
+    ),
+    annotations=IDEMPOTENT_WRITE,
+    meta={
+        'anthropic/searchHint': 'workspace preferences update modify timezone billing',
+    },
+)
+async def update_workspace_preferences(
+    workspace: str,
+    front_url: str | None = None,
+    country: str | None = None,
+    language: str | None = None,
+    timezone: str | None = None,
+    invite_ttl: int | None = None,
+    enabled_extensions: list[str] | None = None,
+    websh_session_timeout: int | None = None,
+    auto_agent_upgrade: bool | None = None,
+    package_proxy: str | None = None,
+    billing_email: str | None = None,
+    allowed_domains: list[str] | None = None,
+    region: str = '',
+    **kwargs,
+) -> dict[str, Any]:
+    """Update the workspace-wide preferences (partial update).
+
+    Args:
+        workspace: Workspace name. Required parameter
+        front_url: Workspace front-end URL (optional)
+        country: Workspace country code (optional)
+        language: Workspace locale/language code (optional)
+        timezone: Workspace timezone; also the billing clock (optional)
+        invite_ttl: Invitation link time-to-live, in seconds (optional)
+        enabled_extensions: List of enabled extension names (optional)
+        websh_session_timeout: WebSH idle session timeout, in seconds (optional)
+        auto_agent_upgrade: Whether agents auto-upgrade (optional)
+        package_proxy: Proxy server URL for package installation, e.g.
+            http://proxy.example.com:8080 (optional)
+        billing_email: Billing contact email; SaaS-only field (optional)
+        allowed_domains: Allowed email domains for invites; SaaS-only field (optional)
+        region: Region (ap1, us1, eu1). Auto-detected if not provided
+
+    Returns:
+        Workspace preferences update response
+    """
+    token = kwargs.get('token')
+
+    update_data: dict[str, Any] = {}
+    if front_url is not None:
+        update_data['front_url'] = front_url
+    if country is not None:
+        update_data['country'] = country
+    if language is not None:
+        update_data['language'] = language
+    if timezone is not None:
+        update_data['timezone'] = timezone
+    if invite_ttl is not None:
+        update_data['invite_ttl'] = invite_ttl
+    if enabled_extensions is not None:
+        update_data['enabled_extensions'] = enabled_extensions
+    if websh_session_timeout is not None:
+        update_data['websh_session_timeout'] = websh_session_timeout
+    if auto_agent_upgrade is not None:
+        update_data['auto_agent_upgrade'] = auto_agent_upgrade
+    if package_proxy is not None:
+        update_data['package_proxy'] = package_proxy
+    if billing_email is not None:
+        update_data['billing_email'] = billing_email
+    if allowed_domains is not None:
+        update_data['allowed_domains'] = allowed_domains
+
+    if not update_data:
+        return error_response('No update data provided')
+
+    result = await http_client.patch(
+        region=region,
+        workspace=workspace,
+        endpoint='/api/workspaces/preferences/-/',
+        token=token,
+        data=update_data,
+    )
+
+    err = unwrap_http_result(
+        result,
+        default_message='Failed to update workspace preferences',
         region=region,
         workspace=workspace,
     )

--- a/utils/decorators.py
+++ b/utils/decorators.py
@@ -495,9 +495,12 @@ def require_jwt_auth(func: Callable) -> Callable:
 
     Stack INSIDE ``@mcp_tool_handler`` so the resolved token is already
     in the wrapped function's ``**kwargs`` when this guard runs. Used on
-    tools whose endpoint ``APITokenObjectPermission`` would 403 for
-    ``source='api'`` requests — short-circuiting here skips the wasted
-    round-trip and returns a clearer error.
+    tools whose endpoint authentication accepts only JWT (OAuth/SSO)
+    sessions — e.g. ``APITokenObjectPermission`` 403s ``source='api'``
+    requests, and viewsets whose ``authentication_classes`` omit
+    ``APITokenAuthentication`` return 403 (AnonymousUser) for static API
+    tokens. Short-circuiting here skips the wasted round-trip and returns
+    a clearer error than the raw upstream 403.
 
     Usage::
 
@@ -511,8 +514,8 @@ def require_jwt_auth(func: Callable) -> Callable:
         token = kwargs.get('token')
         if token and not AlpaconHTTPClient._is_jwt(token):
             return error_response(
-                f'{func.__name__} requires JWT (OAuth/SSO) authentication; '
-                'API tokens cannot manage other API tokens. '
+                f'{func.__name__} requires JWT (OAuth/SSO) authentication and '
+                'cannot be performed with a static API token. '
                 'Re-authenticate via browser-based SSO and retry.'
             )
         return await func(*args, **kwargs)


### PR DESCRIPTION
## Background

The only workspace-related MCP tools so far were `list_workspaces` and `get_current_user`. Alpacon's `/api/workspaces/` surface exposes management endpoints for access control, security/authentication settings, the allowed MFA methods, notification settings, and workspace-wide preferences, but none of them were reachable through MCP, so an agent could neither inspect a workspace's policy state nor change its general settings. Issue #80's original draft proposed six endpoints and full read/update coverage; the scope was adjusted after checking each claim against the actual server implementation.

## Changes

Added seven workspace-settings tools to `tools/workspace_tools.py`.

Read tools:
- `get_workspace_access_control`: GET `/api/workspaces/access-control/-/`
- `get_workspace_security`: GET `/api/workspaces/security/-/`
- `list_workspace_mfa_methods`: GET `/api/workspaces/security/-/mfa-methods/`
- `get_workspace_notifications`: GET `/api/workspaces/notifications/-/`
- `get_workspace_preferences`: GET `/api/workspaces/preferences/-/`

Update tools (partial update; only provided fields are sent):
- `update_workspace_notifications`: PATCH `/api/workspaces/notifications/-/`
- `update_workspace_preferences`: PATCH `/api/workspaces/preferences/-/`

All tools follow the existing `@mcp_tool_handler` + `unwrap_http_result` + `success_response` pattern, with `READ_ONLY` on the read tools and `IDEMPOTENT_WRITE` on the update tools. The five read tools are also exposed as `alpacon://workspace-settings/{access-control|security|mfa-methods|notifications|preferences}/{region}/{workspace}` resources in `tools/resources.py`. The tool and resource lists in CLAUDE.md, `docs/api-reference.md`, and the `README.md` workspace section were updated, and a `CHANGELOG.md` Unreleased entry was added.

## Out of scope

Some items from the original draft were dropped because they did not match the real server implementation or the platform's policy model.

Security/access-control update tools: the server gates writes to these settings behind a superuser session with fresh MFA re-verification. A static API token (stdio mode) can never satisfy this, and a remote-mode caller would have to complete browser MFA before every change. These are governance-level settings, so only reads are exposed and writes stay human-only via the web console.

Usage/billing lookup: the `/api/workspaces/workspaces/` list response carries no usage data, and the real usage endpoint (`/api/workspaces/workspaces/{id}/usage/`) only accepts portal service-to-service (M2M) credentials, so it cannot be called with a workspace token. Deferred until a customer-facing usage API exists.

Per-user preferences: the draft labeled this "user preferences", but `/api/workspaces/preferences/-/` is workspace-wide configuration. Per-user settings live in a separate app (`/api/profiles/preferences/-/`) and can be handled in a follow-up issue if needed.

## Permissions

| Endpoint | Read | Write |
|---|---|---|
| access-control | exposed | not exposed (superuser + MFA, web console only) |
| security | exposed (SaaS only) | not exposed (superuser + MFA, web console only) |
| mfa-methods | exposed | n/a |
| notifications | exposed | exposed (superuser) |
| preferences | exposed | exposed (admin) |

## Safety

`get_workspace_security` is a SaaS-only route and returns 404 on on-premise deployments; the tool translates that into a clear "not available on this deployment" message instead of a generic upstream error. This 404 branch requires the http_client `error` key (matching `unwrap_http_result`), so a success payload that happens to carry `status_code: 404` is not misread. For `update_workspace_preferences`, the tool description and docs warn that `timezone` is the workspace's billing clock (changing it shifts the daily usage-aggregation boundary), and that `billing_email` / `allowed_domains` are only accepted by the server on SaaS deployments.

## Testing

`tests/test_workspace_tools.py` adds a test class per tool. Read tools cover success and error cases; `get_workspace_security` additionally covers the on-premise 404 to clear-message path, confirms that handling does not leak into other error codes (e.g. 500), and asserts that a success payload carrying `status_code: 404` is not misread as unavailable; update tools verify that partial update sends only the provided fields, that no fields provided returns an error, and the HTTP error envelope. Full suite `pytest tests/ -q` reports 924 passed (7 pre-existing unrelated warnings); `ruff check` / `ruff format` pass.

## Checklist

- [x] Add seven tools and register them via `@mcp.tool`
- [x] Expose `alpacon://` resources for the five read tools
- [x] Update CLAUDE.md, docs/api-reference.md, README.md, and CHANGELOG.md
- [x] Add unit tests and confirm the full suite passes
- [ ] Verify `list_workspace_mfa_methods` against a live remote (streamable-http) session

Closes #80
