### PR TITLE
feat: add --toolsets for selective tool registration in local mode (#34)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ### Added
+- `--toolsets` CLI argument (and `ALPACON_MCP_TOOLSETS` env var) for local
+  stdio/SSE mode: selectively register toolsets; default remains `all`
+  (#34). Remote mode is unaffected and always registers every tool.
 - Workspace settings management tools under `/api/workspaces/`
   - Read tools: `get_workspace_access_control`, `get_workspace_security`, `list_workspace_mfa_methods`, `get_workspace_notifications`, `get_workspace_preferences`
   - Partial-update tools: `update_workspace_notifications`, `update_workspace_preferences`

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -65,6 +65,7 @@ uvx alpacon-mcp setup --token-file ~/my-tokens.json   # Use custom location
 uvx alpacon-mcp test                                  # Test API connection
 uvx alpacon-mcp list                                  # Show configured workspaces
 uvx alpacon-mcp add                                   # Add another workspace (shows path)
+uvx alpacon-mcp --toolsets servers,commands,webftp    # Register only these toolsets
 ```
 
 ## Development commands
@@ -270,6 +271,17 @@ All validators are defined in `utils/error_handler.py` and return user-friendly 
 5. **Input validation**: Early validation of region, workspace, server_id, and file paths before API calls
 6. **Error handling**: Comprehensive error handling and reporting
 7. **Multi-workspace**: Support for multiple workspaces across regions
+
+### Toolset selection (local mode)
+
+Local (stdio/SSE) mode accepts `--toolsets` / `ALPACON_MCP_TOOLSETS` to
+selectively import tool modules (registration is an import-time side effect).
+`TOOLSET_REGISTRY` in `server.py` maps 15 toolset names 1:1 to tool modules;
+`workspace_tools`, `health_tools`, `work_session_tools`, and `prompts` are
+always registered. `tools/resources.py` references tools as `'module.func'`
+strings and `register_resources(enabled_modules)` registers only resources
+whose backing module is enabled. Remote mode ignores the setting and
+registers everything. Default: `all` (non-breaking).
 
 ## Available MCP tools
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -280,8 +280,9 @@ selectively import tool modules (registration is an import-time side effect).
 `workspace_tools`, `health_tools`, `work_session_tools`, and `prompts` are
 always registered. `tools/resources.py` references tools as `'module.func'`
 strings and `register_resources(enabled_modules)` registers only resources
-whose backing module is enabled. Remote mode ignores the setting and
-registers everything. Default: `all` (non-breaking).
+whose backing module is enabled. Remote mode (gated on
+`ALPACON_MCP_AUTH_ENABLED=true`, not on the transport name) ignores the
+setting and registers everything. Default: `all` (non-breaking).
 
 ## Available MCP tools
 

--- a/README.md
+++ b/README.md
@@ -189,7 +189,44 @@ uvx alpacon-mcp setup --token-file ~/my.json   # Use custom file location
 uvx alpacon-mcp test                           # Test your connection
 uvx alpacon-mcp list                           # Show configured workspaces
 uvx alpacon-mcp add                            # Add another workspace (shows path)
+uvx alpacon-mcp --toolsets servers,commands,webftp   # Register only these toolsets
 ```
+
+---
+
+### Toolsets (selective tool registration)
+
+Local (stdio/SSE) mode can register a subset of toolsets to stay within
+client tool limits and reduce per-request token cost. Remote
+(streamable-http) mode always registers all tools and relies on the
+client's tool search optimization.
+
+```json
+{
+  "mcpServers": {
+    "alpacon": {
+      "command": "uvx",
+      "args": ["alpacon-mcp", "--toolsets", "servers,commands,webftp,metrics"]
+    }
+  }
+}
+```
+
+The `ALPACON_MCP_TOOLSETS` environment variable is also supported; the CLI
+argument wins when both are set. Default: `all` (register everything).
+
+Available toolsets (1:1 with tool modules): `servers`, `commands`, `webftp`,
+`metrics`, `alerts`, `events`, `system-info`, `iam`, `security`, `audit`,
+`approvals`, `webhooks`, `packages`, `certs`, `tokens`. Workspace, health,
+and Work Session tools are always registered regardless of selection, as are
+the MCP prompts; their names (`workspace`, `health`, `work-sessions`,
+`prompts`) are accepted in `--toolsets` but have no effect. Any other
+unrecognized name fails at startup.
+
+Narrow selections cut real capability: the workflow prompts still reference
+tools such as `execute_command` and `webftp_upload_file`, so an agent
+following them will hit "tool not found" if you excluded `commands` or
+`webftp`. Select the toolsets your workflows actually use.
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -197,9 +197,10 @@ uvx alpacon-mcp --toolsets servers,commands,webftp   # Register only these tools
 ### Toolsets (selective tool registration)
 
 Local (stdio/SSE) mode can register a subset of toolsets to stay within
-client tool limits and reduce per-request token cost. Remote
-(streamable-http) mode always registers all tools and relies on the
-client's tool search optimization.
+client tool limits and reduce per-request token cost. Remote mode
+(streamable-http with JWT auth, i.e. `ALPACON_MCP_AUTH_ENABLED=true`)
+always registers all tools and relies on the client's tool search
+optimization.
 
 ```json
 {

--- a/README.md
+++ b/README.md
@@ -227,7 +227,10 @@ unrecognized name fails at startup.
 Narrow selections cut real capability: the workflow prompts still reference
 tools such as `execute_command` and `webftp_upload_file`, so an agent
 following them will hit "tool not found" if you excluded `commands` or
-`webftp`. Select the toolsets your workflows actually use.
+`webftp`. Select the toolsets your workflows actually use. A few resources
+also cross module boundaries: `alpacon://servers/.../overview` is backed by
+`system_info_tools`, so `--toolsets servers` alone silently drops it—add
+`system-info` to keep it.
 
 ---
 

--- a/main.py
+++ b/main.py
@@ -114,6 +114,10 @@ Examples:
 
     try:
         run('stdio', config_file=args.config_file, toolsets=args.toolsets)
+    except ValueError as e:
+        # A toolsets typo is user error, not a crash: one clean line, no traceback.
+        logger.error(f'Invalid --toolsets: {e}')
+        raise SystemExit(2)
     except Exception as e:
         logger.error(f'Failed to start MCP server: {e}', exc_info=True)
         raise

--- a/main.py
+++ b/main.py
@@ -2,7 +2,7 @@
 import argparse
 from pathlib import Path
 
-from server import run
+from server import TOOLSETS_HELP, run
 from utils.logger import get_logger
 
 logger = get_logger('main')
@@ -35,6 +35,7 @@ Examples:
   uvx alpacon-mcp test               # Test connection
   uvx alpacon-mcp list               # Show configured workspaces
   uvx alpacon-mcp add                # Add another workspace
+  uvx alpacon-mcp --toolsets servers # Register only the listed toolsets
         """,
     )
     parser.add_argument(
@@ -57,6 +58,11 @@ Examples:
         '--token-file',
         type=str,
         help='Custom path to token.json file (overrides --local and default locations)',
+    )
+    parser.add_argument(
+        '--toolsets',
+        type=str,
+        help=TOOLSETS_HELP,
     )
 
     args = parser.parse_args()
@@ -107,7 +113,7 @@ Examples:
     logger.info(f'Configuration: config_file={args.config_file}')
 
     try:
-        run('stdio', config_file=args.config_file)
+        run('stdio', config_file=args.config_file, toolsets=args.toolsets)
     except Exception as e:
         logger.error(f'Failed to start MCP server: {e}', exc_info=True)
         raise

--- a/main.py
+++ b/main.py
@@ -2,7 +2,7 @@
 import argparse
 from pathlib import Path
 
-from server import TOOLSETS_HELP, run
+from server import TOOLSETS_HELP, ToolsetError, run
 from utils.logger import get_logger
 
 logger = get_logger('main')
@@ -114,8 +114,10 @@ Examples:
 
     try:
         run('stdio', config_file=args.config_file, toolsets=args.toolsets)
-    except ValueError as e:
+    except ToolsetError as e:
         # A toolsets typo is user error, not a crash: one clean line, no traceback.
+        # Scoped to ToolsetError so an unrelated ValueError during tool import
+        # (e.g. a bad numeric env var) still gets the full-traceback path below.
         logger.error(f'Invalid --toolsets: {e}')
         raise SystemExit(2)
     except Exception as e:

--- a/main_sse.py
+++ b/main_sse.py
@@ -1,10 +1,10 @@
 # main_sse.py
 import argparse
-import logging
 
-from server import TOOLSETS_HELP, run
+from server import TOOLSETS_HELP, ToolsetError, run
+from utils.logger import get_logger
 
-logger = logging.getLogger(__name__)
+logger = get_logger('main_sse')
 
 
 def main():
@@ -24,8 +24,10 @@ def main():
     args = parser.parse_args()
     try:
         run('sse', config_file=args.config_file, toolsets=args.toolsets)
-    except ValueError as e:
+    except ToolsetError as e:
         # A toolsets typo is user error, not a crash: one clean line, no traceback.
+        # Scoped to ToolsetError so an unrelated ValueError during tool import is
+        # not mislabeled as an --toolsets problem.
         logger.error(f'Invalid --toolsets: {e}')
         raise SystemExit(2)
 

--- a/main_sse.py
+++ b/main_sse.py
@@ -1,16 +1,26 @@
 # main_sse.py
 import argparse
 
-from server import run
+from server import TOOLSETS_HELP, run
 
-# Entry point to run the server with SSE
-if __name__ == '__main__':
+
+def main():
+    """Entry point for the alpacon-mcp-sse console script."""
     parser = argparse.ArgumentParser(description='Alpacon MCP Server (SSE mode)')
     parser.add_argument(
         '--config-file',
         type=str,
         help='Path to token configuration file (overrides default config discovery)',
     )
+    parser.add_argument(
+        '--toolsets',
+        type=str,
+        help=TOOLSETS_HELP,
+    )
 
     args = parser.parse_args()
-    run('sse', config_file=args.config_file)
+    run('sse', config_file=args.config_file, toolsets=args.toolsets)
+
+
+if __name__ == '__main__':
+    main()

--- a/main_sse.py
+++ b/main_sse.py
@@ -1,7 +1,10 @@
 # main_sse.py
 import argparse
+import logging
 
 from server import TOOLSETS_HELP, run
+
+logger = logging.getLogger(__name__)
 
 
 def main():
@@ -19,7 +22,12 @@ def main():
     )
 
     args = parser.parse_args()
-    run('sse', config_file=args.config_file, toolsets=args.toolsets)
+    try:
+        run('sse', config_file=args.config_file, toolsets=args.toolsets)
+    except ValueError as e:
+        # A toolsets typo is user error, not a crash: one clean line, no traceback.
+        logger.error(f'Invalid --toolsets: {e}')
+        raise SystemExit(2)
 
 
 if __name__ == '__main__':

--- a/server.py
+++ b/server.py
@@ -1,3 +1,4 @@
+import importlib
 import os
 import signal
 import sys
@@ -157,6 +158,85 @@ def _create_mcp_server() -> FastMCP:
 mcp = _create_mcp_server()
 
 
+TOOLS_PACKAGE = 'tools'
+TOOLSETS_ENV_VAR = 'ALPACON_MCP_TOOLSETS'
+TOOLSETS_ALL = 'all'
+TOOLSETS_HELP = (
+    f'Comma-separated toolsets to register, '
+    f'e.g. servers,commands,webftp (default: {TOOLSETS_ALL})'
+)
+
+# Local (stdio/SSE) mode can register a subset of these; remote loads all.
+TOOLSET_REGISTRY: dict[str, str] = {
+    'servers': 'server_tools',
+    'commands': 'command_tools',
+    'webftp': 'webftp_tools',
+    'metrics': 'metrics_tools',
+    'alerts': 'alert_tools',
+    'events': 'events_tools',
+    'system-info': 'system_info_tools',
+    'iam': 'iam_tools',
+    'security': 'security_tools',
+    'audit': 'audit_tools',
+    'approvals': 'approval_tools',
+    'webhooks': 'webhook_tools',
+    'packages': 'package_tools',
+    'certs': 'cert_tools',
+    'tokens': 'token_tools',
+}
+ALL_TOOL_MODULES: frozenset[str] = frozenset(TOOLSET_REGISTRY.values())
+
+# Always registered; these names are accepted in --toolsets but select nothing.
+# work_session_tools must stay: gate denials tell the agent to call work_session_*.
+ALWAYS_ON: dict[str, str] = {
+    'workspace': 'workspace_tools',
+    'health': 'health_tools',
+    'work-sessions': 'work_session_tools',
+    'prompts': 'prompts',
+}
+ALWAYS_ON_MODULES: frozenset[str] = frozenset(ALWAYS_ON.values())
+ALWAYS_ON_TOOLSET_NAMES: frozenset[str] = frozenset(ALWAYS_ON)
+
+
+def resolve_toolsets(toolsets: str | None) -> set[str]:
+    """CLI arg > ALPACON_MCP_TOOLSETS env var > 'all'; unknown name -> ValueError."""
+    raw = toolsets if toolsets is not None else os.getenv(TOOLSETS_ENV_VAR)
+    names = [n.strip() for n in raw.split(',') if n.strip()] if raw else []
+
+    # Validate before the 'all' short-circuit so a typo alongside it still fails.
+    unknown = [
+        n
+        for n in names
+        if n != TOOLSETS_ALL
+        and n not in TOOLSET_REGISTRY
+        and n not in ALWAYS_ON_TOOLSET_NAMES
+    ]
+    if unknown:
+        valid = ', '.join([*sorted(TOOLSET_REGISTRY), TOOLSETS_ALL])
+        raise ValueError(
+            f'Unknown toolset(s): {", ".join(unknown)}. Valid toolsets: {valid}'
+        )
+
+    if not names or TOOLSETS_ALL in names:
+        return set(ALL_TOOL_MODULES)
+    return {TOOLSET_REGISTRY[n] for n in names if n in TOOLSET_REGISTRY}
+
+
+def _modules_to_load(toolsets: str | None, remote_mode: bool) -> set[str]:
+    """Remote mode loads everything: client-side tool search optimizes there."""
+    if remote_mode:
+        # main_http.py has no --toolsets flag; a shared .env is the likely source.
+        requested = toolsets or os.getenv(TOOLSETS_ENV_VAR)
+        if requested:
+            logger.info(
+                'Remote mode registers all tools; ignoring toolsets=%s', requested
+            )
+        enabled = set(ALL_TOOL_MODULES)
+    else:
+        enabled = resolve_toolsets(toolsets)
+    return enabled | ALWAYS_ON_MODULES
+
+
 def _is_remote_mode() -> bool:
     """Check if running in remote (streamable-http) mode with JWT auth."""
     return os.getenv('ALPACON_MCP_AUTH_ENABLED', '').lower() == 'true'
@@ -226,12 +306,15 @@ def _register_http_health_endpoint():
 def run(
     transport: Literal['stdio', 'sse', 'streamable-http'] = 'stdio',
     config_file: str | None = None,
+    toolsets: str | None = None,
 ):
     """Run MCP server with optional config file path.
 
     Args:
         transport: Transport type ('stdio', 'sse', or 'streamable-http')
         config_file: Path to token config file (optional)
+        toolsets: Comma-separated toolset names for local mode (optional;
+            defaults to all; ignored in remote mode)
     """
     logger.info(f'Starting MCP server with transport: {transport}')
 
@@ -267,27 +350,16 @@ def run(
         _register_http_health_endpoint()
         logger.info('HTTP /health endpoint registered for transport: %s', transport)
 
-    # Import all tool modules to register MCP tools via decorators
-    import tools.alert_tools  # noqa: F401
-    import tools.approval_tools  # noqa: F401
-    import tools.audit_tools  # noqa: F401
-    import tools.cert_tools  # noqa: F401
-    import tools.command_tools  # noqa: F401
-    import tools.events_tools  # noqa: F401
-    import tools.health_tools  # noqa: F401
-    import tools.iam_tools  # noqa: F401
-    import tools.metrics_tools  # noqa: F401
-    import tools.package_tools  # noqa: F401
-    import tools.prompts  # noqa: F401
-    import tools.resources  # noqa: F401
-    import tools.security_tools  # noqa: F401
-    import tools.server_tools  # noqa: F401
-    import tools.system_info_tools  # noqa: F401
-    import tools.token_tools  # noqa: F401
-    import tools.webftp_tools  # noqa: F401
-    import tools.webhook_tools  # noqa: F401
-    import tools.work_session_tools  # noqa: F401
-    import tools.workspace_tools  # noqa: F401
+    # Import triggers registration: @mcp_tool_handler runs at import time.
+    modules = _modules_to_load(toolsets, remote_mode)
+    ordered = sorted(modules)
+    for module_name in ordered:
+        importlib.import_module(f'{TOOLS_PACKAGE}.{module_name}')
+    logger.info('Registered tool modules: %s', ', '.join(ordered))
+
+    from tools.resources import register_resources
+
+    register_resources(modules)
 
     # In remote mode, wrap the Starlette app with upstream auth error
     # middleware to propagate Alpacon API 401 as MCP transport 401.

--- a/server.py
+++ b/server.py
@@ -212,7 +212,10 @@ def resolve_toolsets(toolsets: str | None) -> set[str]:
         and n not in ALWAYS_ON_TOOLSET_NAMES
     ]
     if unknown:
-        valid = ', '.join([*sorted(TOOLSET_REGISTRY), TOOLSETS_ALL])
+        # Always-on names are accepted (but select nothing), so list them too.
+        valid = ', '.join(
+            [*sorted(TOOLSET_REGISTRY), *sorted(ALWAYS_ON_TOOLSET_NAMES), TOOLSETS_ALL]
+        )
         raise ValueError(
             f'Unknown toolset(s): {", ".join(unknown)}. Valid toolsets: {valid}'
         )

--- a/server.py
+++ b/server.py
@@ -198,10 +198,16 @@ ALWAYS_ON_MODULES: frozenset[str] = frozenset(ALWAYS_ON.values())
 ALWAYS_ON_TOOLSET_NAMES: frozenset[str] = frozenset(ALWAYS_ON)
 
 
+class ToolsetError(ValueError):
+    """Bad --toolsets/env input. Subclasses ValueError so entry points can catch
+    it without also swallowing unrelated ValueErrors raised during tool import."""
+
+
 def resolve_toolsets(toolsets: str | None) -> set[str]:
-    """CLI arg > ALPACON_MCP_TOOLSETS env var > 'all'; unknown name -> ValueError."""
+    """CLI arg > ALPACON_MCP_TOOLSETS env var > 'all'; unknown name -> ToolsetError."""
     raw = toolsets if toolsets is not None else os.getenv(TOOLSETS_ENV_VAR)
-    names = [n.strip() for n in raw.split(',') if n.strip()] if raw else []
+    # Registry keys are all lowercase, so normalize case for a friendlier match.
+    names = [n.strip().lower() for n in raw.split(',') if n.strip()] if raw else []
 
     # Validate before the 'all' short-circuit so a typo alongside it still fails.
     unknown = [
@@ -216,7 +222,7 @@ def resolve_toolsets(toolsets: str | None) -> set[str]:
         valid = ', '.join(
             [*sorted(TOOLSET_REGISTRY), *sorted(ALWAYS_ON_TOOLSET_NAMES), TOOLSETS_ALL]
         )
-        raise ValueError(
+        raise ToolsetError(
             f'Unknown toolset(s): {", ".join(unknown)}. Valid toolsets: {valid}'
         )
 

--- a/server.py
+++ b/server.py
@@ -212,7 +212,7 @@ def resolve_toolsets(toolsets: str | None) -> set[str]:
         and n not in ALWAYS_ON_TOOLSET_NAMES
     ]
     if unknown:
-        # Always-on names are accepted (but select nothing), so list them too.
+        # Always-on names are valid input too, so list them here.
         valid = ', '.join(
             [*sorted(TOOLSET_REGISTRY), *sorted(ALWAYS_ON_TOOLSET_NAMES), TOOLSETS_ALL]
         )

--- a/server.py
+++ b/server.py
@@ -222,7 +222,15 @@ def resolve_toolsets(toolsets: str | None) -> set[str]:
 
     if not names or TOOLSETS_ALL in names:
         return set(ALL_TOOL_MODULES)
-    return {TOOLSET_REGISTRY[n] for n in names if n in TOOLSET_REGISTRY}
+    selected = {TOOLSET_REGISTRY[n] for n in names if n in TOOLSET_REGISTRY}
+    if not selected:
+        # Only always-on names were given; warn so an all-no-op selection isn't silent.
+        logger.warning(
+            'No functional toolsets selected (only always-on names given: %s); '
+            'registering always-on tools only.',
+            ', '.join(names),
+        )
+    return selected
 
 
 def _modules_to_load(toolsets: str | None, remote_mode: bool) -> set[str]:

--- a/tests/test_health.py
+++ b/tests/test_health.py
@@ -1,7 +1,5 @@
 """Tests for health check functionality."""
 
-import ast
-import inspect
 from unittest.mock import MagicMock, patch
 
 import pytest
@@ -215,35 +213,13 @@ class TestHealthCheckRemoteMode:
         assert result['data']['auth']['mode'] == 'jwt'
 
     def test_server_module_imports_health_tools_unconditionally(self):
-        """server.run() must import tools.health_tools regardless of remote_mode.
+        """health_tools is always-on: no remote_mode or --toolsets value may drop it."""
+        assert 'health_tools' in server.ALWAYS_ON_MODULES
 
-        Verifies the guard `if not remote_mode: import tools.health_tools` has been
-        removed so the MCP tool is registered in all transports. Uses AST inspection
-        so the assertion isn't sensitive to whitespace or comment changes.
-        """
-        tree = ast.parse(inspect.getsource(server.run))
-        function_def = tree.body[0]
-        assert isinstance(function_def, (ast.FunctionDef, ast.AsyncFunctionDef))
-
-        def imports_health_tools(node: ast.AST) -> bool:
-            return isinstance(node, ast.Import) and any(
-                alias.name == 'tools.health_tools' for alias in node.names
-            )
-
-        # The import must appear at the top level of run(), not nested inside any
-        # conditional or other compound statement.
-        assert any(imports_health_tools(stmt) for stmt in function_def.body), (
-            'tools.health_tools must be imported unconditionally inside server.run()'
-        )
-
-        # No If block inside run() may guard the import.
-        # (Try/With are excluded so future graceful optional-dep handling isn't rejected.)
-        for node in ast.walk(function_def):
-            if isinstance(node, ast.If):
-                for child in ast.walk(node):
-                    assert not imports_health_tools(child), (
-                        'tools.health_tools import must not be guarded by an if block'
-                    )
+        for remote_mode in (True, False):
+            for toolsets in (None, 'servers'):
+                modules = server._modules_to_load(toolsets, remote_mode=remote_mode)
+                assert 'health_tools' in modules
 
 
 if __name__ == '__main__':

--- a/tests/test_http_client.py
+++ b/tests/test_http_client.py
@@ -278,9 +278,7 @@ class TestURLConstruction:
 
         fake_tm = MagicMock()
         fake_tm.get_base_url_override.return_value = 'https://old-slug.us1.alpacon.io'
-        with patch(
-            'utils.token_manager.get_token_manager', return_value=fake_tm
-        ):
+        with patch('utils.token_manager.get_token_manager', return_value=fake_tm):
             await http_client.get(
                 region='us1',
                 workspace='renamed-workspace',
@@ -298,12 +296,9 @@ class TestURLConstruction:
         """With no override configured, the default Alpacon Cloud host is derived."""
         fake_tm = MagicMock()
         fake_tm.get_base_url_override.return_value = None
-        with patch(
-            'utils.token_manager.get_token_manager', return_value=fake_tm
-        ):
+        with patch('utils.token_manager.get_token_manager', return_value=fake_tm):
             assert (
-                http_client.get_base_url('ap1', 'myws')
-                == 'https://myws.ap1.alpacon.io'
+                http_client.get_base_url('ap1', 'myws') == 'https://myws.ap1.alpacon.io'
             )
 
     @pytest.mark.asyncio
@@ -314,9 +309,7 @@ class TestURLConstruction:
 
         mock_tm = MagicMock()
         mock_tm.get_base_url_override.return_value = 'https://pinned.us1.alpacon.io'
-        with patch(
-            'utils.token_manager.get_token_manager', return_value=mock_tm
-        ):
+        with patch('utils.token_manager.get_token_manager', return_value=mock_tm):
             await http_client.get(
                 region='ap1',
                 workspace='oldlabel',
@@ -332,12 +325,9 @@ class TestURLConstruction:
         """With no override configured, the default Alpacon Cloud host is derived."""
         mock_tm = MagicMock()
         mock_tm.get_base_url_override.return_value = None
-        with patch(
-            'utils.token_manager.get_token_manager', return_value=mock_tm
-        ):
+        with patch('utils.token_manager.get_token_manager', return_value=mock_tm):
             assert (
-                http_client.get_base_url('ap1', 'myws')
-                == 'https://myws.ap1.alpacon.io'
+                http_client.get_base_url('ap1', 'myws') == 'https://myws.ap1.alpacon.io'
             )
 
 

--- a/tests/test_resources.py
+++ b/tests/test_resources.py
@@ -7,13 +7,12 @@ import pytest
 
 import tools.resources as res
 from server import ALL_TOOL_MODULES, ALWAYS_ON_MODULES, mcp
-from tools.resources import register_resources
 
 
 @pytest.fixture(scope='module', autouse=True)
 def _register_all_resources():
     """Resources are no longer registered at import time."""
-    register_resources(set(ALL_TOOL_MODULES) | ALWAYS_ON_MODULES)
+    res.register_resources(set(ALL_TOOL_MODULES) | ALWAYS_ON_MODULES)
 
 
 async def _registered_uris():

--- a/tests/test_resources.py
+++ b/tests/test_resources.py
@@ -1,8 +1,19 @@
 """Tests for alpacon:// MCP resources."""
 
+import inspect
+import re
+
 import pytest
 
-from server import mcp
+import tools.resources as res
+from server import ALL_TOOL_MODULES, ALWAYS_ON_MODULES, mcp
+from tools.resources import register_resources
+
+
+@pytest.fixture(scope='module', autouse=True)
+def _register_all_resources():
+    """Resources are no longer registered at import time."""
+    register_resources(set(ALL_TOOL_MODULES) | ALWAYS_ON_MODULES)
 
 
 async def _registered_uris():
@@ -16,8 +27,6 @@ class TestResourceRegistration:
     @pytest.mark.asyncio
     async def test_helper_registers_and_reads(self):
         """register_resource builds a real-signature wrapper that reads through."""
-        import tools.resources as res
-
         captured = {}
 
         async def fake_fn(region, workspace, alert_id):
@@ -35,8 +44,6 @@ class TestResourceRegistration:
     @pytest.mark.asyncio
     async def test_helper_passes_extra_kwargs(self):
         """extra kwargs are forwarded to the backing function."""
-        import tools.resources as res
-
         captured = {}
 
         async def fake_fn(region, workspace, acknowledged=None):
@@ -56,8 +63,6 @@ class TestResourceRegistration:
     @pytest.mark.asyncio
     async def test_extra_kwargs_without_path_params(self):
         """No path params + extra must not emit a leading-comma SyntaxError."""
-        import tools.resources as res
-
         captured = {}
 
         async def fake_fn(flag=None):
@@ -74,10 +79,8 @@ class TestResourceRegistration:
     @pytest.mark.asyncio
     async def test_all_resources_registered(self):
         """Every RESOURCES entry is registered, no dup, no legacy scheme."""
-        import tools.resources as res
-
         uris = await _registered_uris()
-        table_uris = {uri for _n, _f, uri in res.RESOURCES}
+        table_uris = {uri for _n, _ref, uri in res.RESOURCES}
 
         assert table_uris <= uris
         assert 'alpacon://alerts/active/{region}/{workspace}' in uris  # extra-kwarg one
@@ -101,7 +104,6 @@ class TestResourceRegistration:
         """The exec'd wrapper must adopt the resource name and this module's
         identity, not stay '_wrapper' with a '<string>' traceback frame, so
         stack traces and name-based diagnostics stay legible."""
-        import tools.resources as res
 
         async def fake_fn(region, workspace):
             return {'ok': True}
@@ -123,12 +125,8 @@ class TestResourceRegistration:
     def test_uri_params_match_function_signatures(self):
         """Every URI {param} and extra kwarg must be a real parameter of its
         backing function — a typo breaks at read time, not import; catch it here."""
-        import inspect
-        import re
-
-        import tools.resources as res
-
-        for name, fn, uri, extra in res._REGISTRATIONS:
+        for name, ref, uri, extra in res.REGISTRATIONS:
+            fn = res._resolve(ref)
             wanted = set(re.findall(r'\{(\w+)\}', uri)) | set(extra or {})
             sig = inspect.signature(fn).parameters
             accepted = {
@@ -137,7 +135,7 @@ class TestResourceRegistration:
                 if v.kind not in (v.VAR_KEYWORD, v.VAR_POSITIONAL)
             }
             missing = wanted - accepted
-            assert not missing, f'{name}: {missing} not accepted by {fn.__name__}'
+            assert not missing, f'{name}: {missing} not accepted by {ref}'
 
             # Inverse: every required (no-default) param must be filled by the URI
             # or an extra kwarg, else the read fails at runtime, not import.
@@ -156,17 +154,13 @@ class TestResourceRegistration:
         its own handler — a general guard so a future literal/{id} sibling pair
         can't silently shadow one another. Subsumes the specific /active/, /scopes/,
         etc. cases without hard-coding them."""
-        import re
-
-        import tools.resources as res
-
         mgr = mcp._resource_manager
 
         def concrete(uri: str) -> str:
             # Sentinel placeholders never collide with a literal segment.
             return re.sub(r'\{(\w+)\}', lambda m: f'_{m.group(1)}_', uri)
 
-        for name, _fn, uri, _extra in res._REGISTRATIONS:
+        for name, _ref, uri, _extra in res.REGISTRATIONS:
             resolved = await mgr.get_resource(concrete(uri))
             assert resolved.name == name, (
                 f'{uri} -> {resolved.name}, want {name} (shadowed)'

--- a/tests/test_toolsets.py
+++ b/tests/test_toolsets.py
@@ -1,0 +1,217 @@
+"""Tests for --toolsets selective tool registration (issue #34)."""
+
+import ast
+import importlib
+import importlib.util
+import sys
+from pathlib import Path
+
+import pytest
+
+import server
+import tools.resources as res
+from server import (
+    ALL_TOOL_MODULES,
+    ALWAYS_ON_MODULES,
+    TOOLS_PACKAGE,
+    TOOLSET_REGISTRY,
+    TOOLSETS_ENV_VAR,
+    _modules_to_load,
+    resolve_toolsets,
+)
+
+ALL_MODULES = set(TOOLSET_REGISTRY.values())
+
+
+@pytest.fixture(autouse=True)
+def _no_toolsets_env(monkeypatch):
+    monkeypatch.delenv(TOOLSETS_ENV_VAR, raising=False)
+
+
+class TestResolveToolsets:
+    def test_default_is_all(self):
+        assert resolve_toolsets(None) == ALL_MODULES
+
+    def test_empty_string_is_all(self):
+        assert resolve_toolsets('') == ALL_MODULES
+
+    def test_all_keyword(self):
+        assert resolve_toolsets('all') == ALL_MODULES
+
+    def test_single_toolset(self):
+        assert resolve_toolsets('servers') == {'server_tools'}
+
+    def test_multiple_toolsets_with_whitespace(self):
+        assert resolve_toolsets(' servers, commands , webftp ') == {
+            'server_tools',
+            'command_tools',
+            'webftp_tools',
+        }
+
+    def test_env_var_used_when_cli_absent(self, monkeypatch):
+        # Pinned literal: renaming the constant must not silently move the contract.
+        assert TOOLSETS_ENV_VAR == 'ALPACON_MCP_TOOLSETS'
+        monkeypatch.setenv(TOOLSETS_ENV_VAR, 'metrics')
+        assert resolve_toolsets(None) == {'metrics_tools'}
+
+    def test_cli_wins_over_env_var(self, monkeypatch):
+        monkeypatch.setenv(TOOLSETS_ENV_VAR, 'metrics')
+        assert resolve_toolsets('servers') == {'server_tools'}
+
+    def test_unknown_name_fails_fast_with_valid_names(self):
+        with pytest.raises(ValueError) as exc:
+            resolve_toolsets('servers,nope')
+        assert 'nope' in str(exc.value)
+        assert 'servers' in str(exc.value)  # valid-name listing
+
+    def test_always_on_aliases_are_ignored_not_errors(self):
+        assert resolve_toolsets('servers,workspace,health,work-sessions,prompts') == {
+            'server_tools'
+        }
+
+    def test_unknown_name_alongside_all_still_fails(self):
+        with pytest.raises(ValueError) as exc:
+            resolve_toolsets('all,mtrics')
+        assert 'mtrics' in str(exc.value)
+
+
+class TestRegistryConsistency:
+    def test_registry_covers_every_tool_module(self):
+        """resources.py is the resource registry, not a tool module, hence excluded."""
+        tools_dir = Path(server.__file__).parent / TOOLS_PACKAGE
+        on_disk = {p.stem for p in tools_dir.glob('*.py')} - {'__init__', 'resources'}
+        assert on_disk == ALL_MODULES | ALWAYS_ON_MODULES
+
+    def test_registry_modules_are_importable(self):
+        for module_name in ALL_MODULES | ALWAYS_ON_MODULES:
+            importlib.import_module(f'{TOOLS_PACKAGE}.{module_name}')
+
+
+class TestResourceRegistrations:
+    def test_resources_module_imports_no_tool_module(self):
+        """tools/resources.py must not import a tool module, or --toolsets registers
+        everything. Checked statically: sys.modules is process-global here.
+        """
+        tool_modules = ALL_TOOL_MODULES | ALWAYS_ON_MODULES
+        leaked = set()
+        # ast.walk, not tree.body: an import nested in a try/if still executes.
+        for node in ast.walk(ast.parse(Path(res.__file__).read_text())):
+            if isinstance(node, ast.ImportFrom) and node.module:
+                # `from tools import cert_tools` names the module in .names.
+                if node.module == TOOLS_PACKAGE:
+                    leaked |= {a.name for a in node.names} & tool_modules
+                elif node.module.split('.')[0] == TOOLS_PACKAGE:
+                    leaked |= {node.module.split('.')[1]} & tool_modules
+            elif isinstance(node, ast.Import):
+                for alias in node.names:
+                    parts = alias.name.split('.')
+                    if parts[0] == TOOLS_PACKAGE and len(parts) > 1:
+                        leaked |= {parts[1]} & tool_modules
+
+        assert not leaked, f'tools/resources.py eagerly imports: {sorted(leaked)}'
+
+    def test_every_ref_resolves_to_a_real_function(self):
+        for name, ref, _uri, _extra in res.REGISTRATIONS:
+            module_name, func_name = ref.split('.', 1)
+            mod = importlib.import_module(f'{TOOLS_PACKAGE}.{module_name}')
+            assert hasattr(mod, func_name), f'{name}: tools.{ref} does not exist'
+
+    def test_register_resources_filters_by_module(self, monkeypatch):
+        registered: list[str] = []
+        monkeypatch.setattr(
+            res,
+            'register_resource',
+            lambda uri, fn, name, extra=None: registered.append(name),
+        )
+        res.register_resources({'server_tools'})
+
+        expected = {
+            name
+            for name, ref, _uri, _extra in res.REGISTRATIONS
+            if ref.split('.', 1)[0] == 'server_tools'
+        }
+        assert set(registered) == expected
+        assert 'servers_list' in registered
+        assert 'alerts_list' not in registered
+
+
+class TestCliWiring:
+    @staticmethod
+    def _load(filename):
+        # By path: the repo dir is named 'main', so `import main` hits that package.
+        path = Path(server.__file__).parent / filename
+        spec = importlib.util.spec_from_file_location(f'_probe_{filename}', path)
+        module = importlib.util.module_from_spec(spec)
+        spec.loader.exec_module(module)
+        return module
+
+    def test_stdio_entry_point_forwards_toolsets(self, monkeypatch):
+        module = self._load('main.py')
+        captured = {}
+        monkeypatch.setattr(
+            module, 'run', lambda transport, **kw: captured.update(kw, t=transport)
+        )
+        # --config-file keeps main() off the interactive setup-wizard branch.
+        monkeypatch.setattr(
+            sys, 'argv', ['main.py', '--toolsets', 'servers', '--config-file', 'x.json']
+        )
+        module.main()
+
+        assert captured['t'] == 'stdio'
+        assert captured['toolsets'] == 'servers'
+
+    def test_sse_entry_point_forwards_toolsets(self, monkeypatch):
+        module = self._load('main_sse.py')
+        captured = {}
+        monkeypatch.setattr(
+            module, 'run', lambda transport, **kw: captured.update(kw, t=transport)
+        )
+        monkeypatch.setattr(sys, 'argv', ['main_sse.py', '--toolsets', 'metrics'])
+        module.main()
+
+        assert captured['t'] == 'sse'
+        assert captured['toolsets'] == 'metrics'
+
+
+class TestRunWiring:
+    def test_run_imports_selection_and_hands_it_to_register_resources(
+        self, monkeypatch
+    ):
+        """run() is where the pieces meet; unit tests of the parts miss a
+        mismatch here (e.g. handing register_resources the sorted list)."""
+        imported: list[str] = []
+        real_import = importlib.import_module
+        handed: dict = {}
+
+        def spy(name, *args, **kwargs):
+            imported.append(name)
+            return real_import(name, *args, **kwargs)
+
+        monkeypatch.setattr(server.importlib, 'import_module', spy)
+        monkeypatch.setattr(res, 'register_resources', lambda m: handed.update(m=m))
+        monkeypatch.setattr(server.mcp, 'run', lambda transport: None)
+        monkeypatch.setenv('ALPACON_MCP_TRANSPORT', 'restored-on-teardown')
+        monkeypatch.delenv('ALPACON_MCP_AUTH_ENABLED', raising=False)
+
+        server.run('stdio', toolsets='servers')
+
+        expected = _modules_to_load('servers', remote_mode=False)
+        prefix = f'{TOOLS_PACKAGE}.'
+        assert {n for n in imported if n.startswith(prefix)} == {
+            prefix + m for m in expected
+        }
+        assert handed['m'] == expected
+
+
+class TestModulesToLoad:
+    def test_local_mode_selects_subset_plus_always_on(self):
+        modules = _modules_to_load('servers,metrics', remote_mode=False)
+        assert modules == {'server_tools', 'metrics_tools', *ALWAYS_ON_MODULES}
+
+    def test_remote_mode_ignores_toolsets(self):
+        modules = _modules_to_load('servers', remote_mode=True)
+        assert modules == ALL_MODULES | ALWAYS_ON_MODULES
+
+    def test_local_default_loads_everything(self):
+        modules = _modules_to_load(None, remote_mode=False)
+        assert modules == ALL_MODULES | ALWAYS_ON_MODULES

--- a/tests/test_toolsets.py
+++ b/tests/test_toolsets.py
@@ -61,6 +61,13 @@ class TestResolveToolsets:
             'servers,workspace,health,work-sessions,prompts'
         ) == {'server_tools'}
 
+    def test_only_always_on_names_warns_and_selects_nothing(self, caplog):
+        with caplog.at_level('WARNING'):
+            assert server.resolve_toolsets('health,workspace') == set()
+        assert any(
+            'No functional toolsets selected' in r.message for r in caplog.records
+        )
+
     def test_unknown_name_alongside_all_still_fails(self):
         with pytest.raises(ValueError) as exc:
             server.resolve_toolsets('all,mtrics')

--- a/tests/test_toolsets.py
+++ b/tests/test_toolsets.py
@@ -50,11 +50,18 @@ class TestResolveToolsets:
         assert server.resolve_toolsets('servers') == {'server_tools'}
 
     def test_unknown_name_fails_fast_with_valid_names(self):
-        with pytest.raises(ValueError) as exc:
+        # ToolsetError, not a bare ValueError, so entry points catch only this.
+        with pytest.raises(server.ToolsetError) as exc:
             server.resolve_toolsets('servers,nope')
         assert 'nope' in str(exc.value)
         assert 'servers' in str(exc.value)  # selectable toolset listed
         assert 'health' in str(exc.value)  # always-on names listed as valid too
+
+    def test_names_are_case_insensitive(self):
+        assert server.resolve_toolsets('Servers, METRICS') == {
+            'server_tools',
+            'metrics_tools',
+        }
 
     def test_always_on_aliases_are_ignored_not_errors(self):
         assert server.resolve_toolsets(

--- a/tests/test_toolsets.py
+++ b/tests/test_toolsets.py
@@ -10,39 +10,30 @@ import pytest
 
 import server
 import tools.resources as res
-from server import (
-    ALL_TOOL_MODULES,
-    ALWAYS_ON_MODULES,
-    TOOLS_PACKAGE,
-    TOOLSET_REGISTRY,
-    TOOLSETS_ENV_VAR,
-    _modules_to_load,
-    resolve_toolsets,
-)
 
-ALL_MODULES = set(TOOLSET_REGISTRY.values())
+ALL_MODULES = set(server.TOOLSET_REGISTRY.values())
 
 
 @pytest.fixture(autouse=True)
 def _no_toolsets_env(monkeypatch):
-    monkeypatch.delenv(TOOLSETS_ENV_VAR, raising=False)
+    monkeypatch.delenv(server.TOOLSETS_ENV_VAR, raising=False)
 
 
 class TestResolveToolsets:
     def test_default_is_all(self):
-        assert resolve_toolsets(None) == ALL_MODULES
+        assert server.resolve_toolsets(None) == ALL_MODULES
 
     def test_empty_string_is_all(self):
-        assert resolve_toolsets('') == ALL_MODULES
+        assert server.resolve_toolsets('') == ALL_MODULES
 
     def test_all_keyword(self):
-        assert resolve_toolsets('all') == ALL_MODULES
+        assert server.resolve_toolsets('all') == ALL_MODULES
 
     def test_single_toolset(self):
-        assert resolve_toolsets('servers') == {'server_tools'}
+        assert server.resolve_toolsets('servers') == {'server_tools'}
 
     def test_multiple_toolsets_with_whitespace(self):
-        assert resolve_toolsets(' servers, commands , webftp ') == {
+        assert server.resolve_toolsets(' servers, commands , webftp ') == {
             'server_tools',
             'command_tools',
             'webftp_tools',
@@ -50,41 +41,42 @@ class TestResolveToolsets:
 
     def test_env_var_used_when_cli_absent(self, monkeypatch):
         # Pinned literal: renaming the constant must not silently move the contract.
-        assert TOOLSETS_ENV_VAR == 'ALPACON_MCP_TOOLSETS'
-        monkeypatch.setenv(TOOLSETS_ENV_VAR, 'metrics')
-        assert resolve_toolsets(None) == {'metrics_tools'}
+        assert server.TOOLSETS_ENV_VAR == 'ALPACON_MCP_TOOLSETS'
+        monkeypatch.setenv(server.TOOLSETS_ENV_VAR, 'metrics')
+        assert server.resolve_toolsets(None) == {'metrics_tools'}
 
     def test_cli_wins_over_env_var(self, monkeypatch):
-        monkeypatch.setenv(TOOLSETS_ENV_VAR, 'metrics')
-        assert resolve_toolsets('servers') == {'server_tools'}
+        monkeypatch.setenv(server.TOOLSETS_ENV_VAR, 'metrics')
+        assert server.resolve_toolsets('servers') == {'server_tools'}
 
     def test_unknown_name_fails_fast_with_valid_names(self):
         with pytest.raises(ValueError) as exc:
-            resolve_toolsets('servers,nope')
+            server.resolve_toolsets('servers,nope')
         assert 'nope' in str(exc.value)
-        assert 'servers' in str(exc.value)  # valid-name listing
+        assert 'servers' in str(exc.value)  # selectable toolset listed
+        assert 'health' in str(exc.value)  # always-on names listed as valid too
 
     def test_always_on_aliases_are_ignored_not_errors(self):
-        assert resolve_toolsets('servers,workspace,health,work-sessions,prompts') == {
-            'server_tools'
-        }
+        assert server.resolve_toolsets(
+            'servers,workspace,health,work-sessions,prompts'
+        ) == {'server_tools'}
 
     def test_unknown_name_alongside_all_still_fails(self):
         with pytest.raises(ValueError) as exc:
-            resolve_toolsets('all,mtrics')
+            server.resolve_toolsets('all,mtrics')
         assert 'mtrics' in str(exc.value)
 
 
 class TestRegistryConsistency:
     def test_registry_covers_every_tool_module(self):
         """resources.py is the resource registry, not a tool module, hence excluded."""
-        tools_dir = Path(server.__file__).parent / TOOLS_PACKAGE
+        tools_dir = Path(server.__file__).parent / server.TOOLS_PACKAGE
         on_disk = {p.stem for p in tools_dir.glob('*.py')} - {'__init__', 'resources'}
-        assert on_disk == ALL_MODULES | ALWAYS_ON_MODULES
+        assert on_disk == ALL_MODULES | server.ALWAYS_ON_MODULES
 
     def test_registry_modules_are_importable(self):
-        for module_name in ALL_MODULES | ALWAYS_ON_MODULES:
-            importlib.import_module(f'{TOOLS_PACKAGE}.{module_name}')
+        for module_name in ALL_MODULES | server.ALWAYS_ON_MODULES:
+            importlib.import_module(f'{server.TOOLS_PACKAGE}.{module_name}')
 
 
 class TestResourceRegistrations:
@@ -92,20 +84,20 @@ class TestResourceRegistrations:
         """tools/resources.py must not import a tool module, or --toolsets registers
         everything. Checked statically: sys.modules is process-global here.
         """
-        tool_modules = ALL_TOOL_MODULES | ALWAYS_ON_MODULES
+        tool_modules = server.ALL_TOOL_MODULES | server.ALWAYS_ON_MODULES
         leaked = set()
         # ast.walk, not tree.body: an import nested in a try/if still executes.
         for node in ast.walk(ast.parse(Path(res.__file__).read_text())):
             if isinstance(node, ast.ImportFrom) and node.module:
                 # `from tools import cert_tools` names the module in .names.
-                if node.module == TOOLS_PACKAGE:
+                if node.module == server.TOOLS_PACKAGE:
                     leaked |= {a.name for a in node.names} & tool_modules
-                elif node.module.split('.')[0] == TOOLS_PACKAGE:
+                elif node.module.split('.')[0] == server.TOOLS_PACKAGE:
                     leaked |= {node.module.split('.')[1]} & tool_modules
             elif isinstance(node, ast.Import):
                 for alias in node.names:
                     parts = alias.name.split('.')
-                    if parts[0] == TOOLS_PACKAGE and len(parts) > 1:
+                    if parts[0] == server.TOOLS_PACKAGE and len(parts) > 1:
                         leaked |= {parts[1]} & tool_modules
 
         assert not leaked, f'tools/resources.py eagerly imports: {sorted(leaked)}'
@@ -113,7 +105,7 @@ class TestResourceRegistrations:
     def test_every_ref_resolves_to_a_real_function(self):
         for name, ref, _uri, _extra in res.REGISTRATIONS:
             module_name, func_name = ref.split('.', 1)
-            mod = importlib.import_module(f'{TOOLS_PACKAGE}.{module_name}')
+            mod = importlib.import_module(f'{server.TOOLS_PACKAGE}.{module_name}')
             assert hasattr(mod, func_name), f'{name}: tools.{ref} does not exist'
 
     def test_register_resources_filters_by_module(self, monkeypatch):
@@ -195,8 +187,8 @@ class TestRunWiring:
 
         server.run('stdio', toolsets='servers')
 
-        expected = _modules_to_load('servers', remote_mode=False)
-        prefix = f'{TOOLS_PACKAGE}.'
+        expected = server._modules_to_load('servers', remote_mode=False)
+        prefix = f'{server.TOOLS_PACKAGE}.'
         assert {n for n in imported if n.startswith(prefix)} == {
             prefix + m for m in expected
         }
@@ -205,13 +197,13 @@ class TestRunWiring:
 
 class TestModulesToLoad:
     def test_local_mode_selects_subset_plus_always_on(self):
-        modules = _modules_to_load('servers,metrics', remote_mode=False)
-        assert modules == {'server_tools', 'metrics_tools', *ALWAYS_ON_MODULES}
+        modules = server._modules_to_load('servers,metrics', remote_mode=False)
+        assert modules == {'server_tools', 'metrics_tools', *server.ALWAYS_ON_MODULES}
 
     def test_remote_mode_ignores_toolsets(self):
-        modules = _modules_to_load('servers', remote_mode=True)
-        assert modules == ALL_MODULES | ALWAYS_ON_MODULES
+        modules = server._modules_to_load('servers', remote_mode=True)
+        assert modules == ALL_MODULES | server.ALWAYS_ON_MODULES
 
     def test_local_default_loads_everything(self):
-        modules = _modules_to_load(None, remote_mode=False)
-        assert modules == ALL_MODULES | ALWAYS_ON_MODULES
+        modules = server._modules_to_load(None, remote_mode=False)
+        assert modules == ALL_MODULES | server.ALWAYS_ON_MODULES

--- a/tools/resources.py
+++ b/tools/resources.py
@@ -1,6 +1,6 @@
 """alpacon:// MCP resources — thin read-only wrappers over list_/get_ tools.
 
-Resources are generated from the RESOURCES registry table to avoid ~70 copies
+Resources are generated from the RESOURCES registry table to avoid ~75 copies
 of identical boilerplate. Each wrapper is built via exec with real named
 parameters because FastMCP matches URI template params to the function
 signature by name; a **kwargs wrapper fails its func_metadata check.

--- a/tools/resources.py
+++ b/tools/resources.py
@@ -4,104 +4,17 @@ Resources are generated from the RESOURCES registry table to avoid ~70 copies
 of identical boilerplate. Each wrapper is built via exec with real named
 parameters because FastMCP matches URI template params to the function
 signature by name; a **kwargs wrapper fails its func_metadata check.
+
+Tool refs are `module.func` strings resolved lazily: importing this module must
+not import (and thereby register) any tool module, or --toolsets breaks.
 """
 
+import importlib
 import inspect
 import re
 from collections.abc import Callable
 
-from server import mcp
-from tools.alert_tools import get_alert, list_alerts
-from tools.approval_tools import (
-    get_approval_request,
-    list_approval_requests,
-    list_sudo_policies,
-)
-from tools.audit_tools import (
-    get_activity_log,
-    get_session_analysis_detail,
-    list_activity_logs,
-    list_server_logs,
-    list_session_analyses,
-    list_webftp_logs,
-)
-from tools.cert_tools import (
-    get_certificate,
-    get_certificate_authority,
-    get_revoke_request,
-    get_sign_request,
-    list_certificate_authorities,
-    list_certificates,
-    list_revoke_requests,
-    list_sign_requests,
-)
-from tools.command_tools import list_commands
-from tools.events_tools import get_event, list_events
-from tools.iam_tools import (
-    get_iam_application,
-    get_iam_group,
-    get_iam_user,
-    list_iam_applications,
-    list_iam_groups,
-    list_iam_memberships,
-    list_iam_users,
-)
-from tools.metrics_tools import (
-    get_alert_rules,
-    get_cpu_usage,
-    get_disk_io,
-    get_disk_usage,
-    get_memory_usage,
-    get_network_traffic,
-    get_server_metrics_summary,
-    get_top_servers,
-)
-from tools.package_tools import list_python_packages, list_system_package_entries
-from tools.security_tools import (
-    list_command_acls,
-    list_file_acls,
-    list_server_acls,
-)
-from tools.server_tools import (
-    get_server,
-    get_server_note,
-    list_registration_tokens,
-    list_server_notes,
-    list_servers,
-)
-from tools.system_info_tools import (
-    get_disk_info,
-    get_network_interfaces,
-    get_os_version,
-    get_server_overview,
-    get_system_info,
-    get_system_time,
-    list_system_groups,
-    list_system_packages,
-    list_system_users,
-)
-from tools.token_tools import (
-    get_api_token,
-    list_api_token_presets,
-    list_api_token_scopes,
-    list_api_tokens,
-)
-from tools.webftp_tools import (
-    webftp_downloads_list,
-    webftp_sessions_list,
-    webftp_uploads_list,
-)
-from tools.webhook_tools import get_webhook, list_event_subscriptions, list_webhooks
-from tools.work_session_tools import work_session_get, work_session_list
-from tools.workspace_tools import (
-    get_current_user,
-    get_workspace_access_control,
-    get_workspace_notifications,
-    get_workspace_preferences,
-    get_workspace_security,
-    list_workspace_mfa_methods,
-    list_workspaces,
-)
+from server import TOOLS_PACKAGE, mcp
 
 
 def register_resource(
@@ -134,317 +47,405 @@ def register_resource(
     mcp.resource(uri, name=name, description=doc, mime_type='application/json')(wrapper)
 
 
-RESOURCES: list[tuple[str, Callable, str]] = [
-    ('servers_list', list_servers, 'alpacon://servers/{region}/{workspace}'),
-    ('server_detail', get_server, 'alpacon://servers/{region}/{workspace}/{server_id}'),
+# (resource name, `module.func` reference, URI template)
+RESOURCES: list[tuple[str, str, str]] = [
+    (
+        'servers_list',
+        'server_tools.list_servers',
+        'alpacon://servers/{region}/{workspace}',
+    ),
+    (
+        'server_detail',
+        'server_tools.get_server',
+        'alpacon://servers/{region}/{workspace}/{server_id}',
+    ),
     (
         'server_notes_list',
-        list_server_notes,
+        'server_tools.list_server_notes',
         'alpacon://servers/{region}/{workspace}/{server_id}/notes',
     ),
     (
         'server_overview',
-        get_server_overview,
+        'system_info_tools.get_server_overview',
         'alpacon://servers/{region}/{workspace}/{server_id}/overview',
     ),
     (
         'server_note_detail',
-        get_server_note,
+        'server_tools.get_server_note',
         'alpacon://server-notes/{region}/{workspace}/{note_id}',
     ),
     (
         'registration_tokens_list',
-        list_registration_tokens,
+        'server_tools.list_registration_tokens',
         'alpacon://registration-tokens/{region}/{workspace}',
     ),
     (
         'system_info',
-        get_system_info,
+        'system_info_tools.get_system_info',
         'alpacon://system/{region}/{workspace}/{server_id}/info',
     ),
     (
         'system_os_version',
-        get_os_version,
+        'system_info_tools.get_os_version',
         'alpacon://system/{region}/{workspace}/{server_id}/os-version',
     ),
     (
         'system_users',
-        list_system_users,
+        'system_info_tools.list_system_users',
         'alpacon://system/{region}/{workspace}/{server_id}/users',
     ),
     (
         'system_groups',
-        list_system_groups,
+        'system_info_tools.list_system_groups',
         'alpacon://system/{region}/{workspace}/{server_id}/groups',
     ),
     (
         'system_packages',
-        list_system_packages,
+        'system_info_tools.list_system_packages',
         'alpacon://system/{region}/{workspace}/{server_id}/packages',
     ),
     (
         'system_network_interfaces',
-        get_network_interfaces,
+        'system_info_tools.get_network_interfaces',
         'alpacon://system/{region}/{workspace}/{server_id}/network-interfaces',
     ),
     (
         'system_disk_info',
-        get_disk_info,
+        'system_info_tools.get_disk_info',
         'alpacon://system/{region}/{workspace}/{server_id}/disk-info',
     ),
     (
         'system_time',
-        get_system_time,
+        'system_info_tools.get_system_time',
         'alpacon://system/{region}/{workspace}/{server_id}/time',
     ),
     (
         'metrics_cpu',
-        get_cpu_usage,
+        'metrics_tools.get_cpu_usage',
         'alpacon://metrics/{region}/{workspace}/{server_id}/cpu',
     ),
     (
         'metrics_memory',
-        get_memory_usage,
+        'metrics_tools.get_memory_usage',
         'alpacon://metrics/{region}/{workspace}/{server_id}/memory',
     ),
     (
         'metrics_disk',
-        get_disk_usage,
+        'metrics_tools.get_disk_usage',
         'alpacon://metrics/{region}/{workspace}/{server_id}/disk',
     ),
     (
         'metrics_disk_io',
-        get_disk_io,
+        'metrics_tools.get_disk_io',
         'alpacon://metrics/{region}/{workspace}/{server_id}/disk-io',
     ),
     (
         'metrics_network',
-        get_network_traffic,
+        'metrics_tools.get_network_traffic',
         'alpacon://metrics/{region}/{workspace}/{server_id}/network',
     ),
     (
         'metrics_summary',
-        get_server_metrics_summary,
+        'metrics_tools.get_server_metrics_summary',
         'alpacon://metrics/{region}/{workspace}/{server_id}/summary',
     ),
-    ('metrics_top', get_top_servers, 'alpacon://metrics/{region}/{workspace}/top'),
-    ('alert_rules', get_alert_rules, 'alpacon://alert-rules/{region}/{workspace}'),
-    ('alerts_list', list_alerts, 'alpacon://alerts/{region}/{workspace}'),
-    ('alert_detail', get_alert, 'alpacon://alerts/{region}/{workspace}/{alert_id}'),
+    (
+        'metrics_top',
+        'metrics_tools.get_top_servers',
+        'alpacon://metrics/{region}/{workspace}/top',
+    ),
+    (
+        'alert_rules',
+        'metrics_tools.get_alert_rules',
+        'alpacon://alert-rules/{region}/{workspace}',
+    ),
+    ('alerts_list', 'alert_tools.list_alerts', 'alpacon://alerts/{region}/{workspace}'),
+    (
+        'alert_detail',
+        'alert_tools.get_alert',
+        'alpacon://alerts/{region}/{workspace}/{alert_id}',
+    ),
     (
         'approvals_list',
-        list_approval_requests,
+        'approval_tools.list_approval_requests',
         'alpacon://approvals/{region}/{workspace}',
     ),
     (
         'approval_detail',
-        get_approval_request,
+        'approval_tools.get_approval_request',
         'alpacon://approvals/{region}/{workspace}/{request_id}',
     ),
     (
         'sudo_policies_list',
-        list_sudo_policies,
+        'approval_tools.list_sudo_policies',
         'alpacon://sudo-policies/{region}/{workspace}',
     ),
     (
         'audit_activity_list',
-        list_activity_logs,
+        'audit_tools.list_activity_logs',
         'alpacon://audit/activity/{region}/{workspace}',
     ),
     (
         'audit_activity_detail',
-        get_activity_log,
+        'audit_tools.get_activity_log',
         'alpacon://audit/activity/{region}/{workspace}/{log_id}',
     ),
     (
         'audit_server_logs',
-        list_server_logs,
+        'audit_tools.list_server_logs',
         'alpacon://audit/server-logs/{region}/{workspace}',
     ),
     (
         'audit_webftp_logs',
-        list_webftp_logs,
+        'audit_tools.list_webftp_logs',
         'alpacon://audit/webftp-logs/{region}/{workspace}',
     ),
     (
         'audit_session_analyses',
-        list_session_analyses,
+        'audit_tools.list_session_analyses',
         'alpacon://audit/session-analyses/{region}/{workspace}',
     ),
     (
         'audit_session_analysis_detail',
-        get_session_analysis_detail,
+        'audit_tools.get_session_analysis_detail',
         'alpacon://audit/session-analyses/{region}/{workspace}/{analysis_id}',
     ),
     (
         'cert_authorities_list',
-        list_certificate_authorities,
+        'cert_tools.list_certificate_authorities',
         'alpacon://certs/authorities/{region}/{workspace}',
     ),
     (
         'cert_authority_detail',
-        get_certificate_authority,
+        'cert_tools.get_certificate_authority',
         'alpacon://certs/authorities/{region}/{workspace}/{ca_id}',
     ),
     (
         'cert_sign_requests_list',
-        list_sign_requests,
+        'cert_tools.list_sign_requests',
         'alpacon://certs/sign-requests/{region}/{workspace}',
     ),
     (
         'cert_sign_request_detail',
-        get_sign_request,
+        'cert_tools.get_sign_request',
         'alpacon://certs/sign-requests/{region}/{workspace}/{csr_id}',
     ),
-    ('certs_list', list_certificates, 'alpacon://certs/{region}/{workspace}'),
+    (
+        'certs_list',
+        'cert_tools.list_certificates',
+        'alpacon://certs/{region}/{workspace}',
+    ),
     (
         'cert_detail',
-        get_certificate,
+        'cert_tools.get_certificate',
         'alpacon://certs/{region}/{workspace}/{certificate_id}',
     ),
     (
         'cert_revoke_requests_list',
-        list_revoke_requests,
+        'cert_tools.list_revoke_requests',
         'alpacon://certs/revoke-requests/{region}/{workspace}',
     ),
     (
         'cert_revoke_request_detail',
-        get_revoke_request,
+        'cert_tools.get_revoke_request',
         'alpacon://certs/revoke-requests/{region}/{workspace}/{revoke_id}',
     ),
-    ('commands_list', list_commands, 'alpacon://commands/{region}/{workspace}'),
-    ('events_list', list_events, 'alpacon://events/{region}/{workspace}'),
-    ('event_detail', get_event, 'alpacon://events/{region}/{workspace}/{event_id}'),
-    ('iam_users_list', list_iam_users, 'alpacon://iam/users/{region}/{workspace}'),
+    (
+        'commands_list',
+        'command_tools.list_commands',
+        'alpacon://commands/{region}/{workspace}',
+    ),
+    (
+        'events_list',
+        'events_tools.list_events',
+        'alpacon://events/{region}/{workspace}',
+    ),
+    (
+        'event_detail',
+        'events_tools.get_event',
+        'alpacon://events/{region}/{workspace}/{event_id}',
+    ),
+    (
+        'iam_users_list',
+        'iam_tools.list_iam_users',
+        'alpacon://iam/users/{region}/{workspace}',
+    ),
     (
         'iam_user_detail',
-        get_iam_user,
+        'iam_tools.get_iam_user',
         'alpacon://iam/users/{region}/{workspace}/{user_id}',
     ),
-    ('iam_groups_list', list_iam_groups, 'alpacon://iam/groups/{region}/{workspace}'),
+    (
+        'iam_groups_list',
+        'iam_tools.list_iam_groups',
+        'alpacon://iam/groups/{region}/{workspace}',
+    ),
     (
         'iam_group_detail',
-        get_iam_group,
+        'iam_tools.get_iam_group',
         'alpacon://iam/groups/{region}/{workspace}/{group_id}',
     ),
     (
         'iam_memberships_list',
-        list_iam_memberships,
+        'iam_tools.list_iam_memberships',
         'alpacon://iam/memberships/{region}/{workspace}',
     ),
     (
         'iam_applications_list',
-        list_iam_applications,
+        'iam_tools.list_iam_applications',
         'alpacon://iam/applications/{region}/{workspace}',
     ),
     (
         'iam_application_detail',
-        get_iam_application,
+        'iam_tools.get_iam_application',
         'alpacon://iam/applications/{region}/{workspace}/{app_id}',
     ),
     (
         'packages_system',
-        list_system_package_entries,
+        'package_tools.list_system_package_entries',
         'alpacon://packages/system/{region}/{workspace}/{server_id}',
     ),
     (
         'packages_python',
-        list_python_packages,
+        'package_tools.list_python_packages',
         'alpacon://packages/python/{region}/{workspace}/{server_id}',
     ),
-    ('acls_command', list_command_acls, 'alpacon://acls/command/{region}/{workspace}'),
-    ('acls_server', list_server_acls, 'alpacon://acls/server/{region}/{workspace}'),
-    ('acls_file', list_file_acls, 'alpacon://acls/file/{region}/{workspace}'),
-    ('tokens_list', list_api_tokens, 'alpacon://tokens/{region}/{workspace}'),
-    ('token_detail', get_api_token, 'alpacon://tokens/{region}/{workspace}/{token_id}'),
+    (
+        'acls_command',
+        'security_tools.list_command_acls',
+        'alpacon://acls/command/{region}/{workspace}',
+    ),
+    (
+        'acls_server',
+        'security_tools.list_server_acls',
+        'alpacon://acls/server/{region}/{workspace}',
+    ),
+    (
+        'acls_file',
+        'security_tools.list_file_acls',
+        'alpacon://acls/file/{region}/{workspace}',
+    ),
+    (
+        'tokens_list',
+        'token_tools.list_api_tokens',
+        'alpacon://tokens/{region}/{workspace}',
+    ),
+    (
+        'token_detail',
+        'token_tools.get_api_token',
+        'alpacon://tokens/{region}/{workspace}/{token_id}',
+    ),
     (
         'token_scopes',
-        list_api_token_scopes,
+        'token_tools.list_api_token_scopes',
         'alpacon://tokens/scopes/{region}/{workspace}',
     ),
     (
         'token_presets',
-        list_api_token_presets,
+        'token_tools.list_api_token_presets',
         'alpacon://tokens/presets/{region}/{workspace}',
     ),
     (
         'event_subscriptions_list',
-        list_event_subscriptions,
+        'webhook_tools.list_event_subscriptions',
         'alpacon://event-subscriptions/{region}/{workspace}',
     ),
-    ('webhooks_list', list_webhooks, 'alpacon://webhooks/{region}/{workspace}'),
+    (
+        'webhooks_list',
+        'webhook_tools.list_webhooks',
+        'alpacon://webhooks/{region}/{workspace}',
+    ),
     (
         'webhook_detail',
-        get_webhook,
+        'webhook_tools.get_webhook',
         'alpacon://webhooks/{region}/{workspace}/{webhook_id}',
     ),
     (
         'webftp_sessions',
-        webftp_sessions_list,
+        'webftp_tools.webftp_sessions_list',
         'alpacon://webftp/sessions/{region}/{workspace}',
     ),
     (
         'webftp_downloads',
-        webftp_downloads_list,
+        'webftp_tools.webftp_downloads_list',
         'alpacon://webftp/downloads/{region}/{workspace}',
     ),
     (
         'webftp_uploads',
-        webftp_uploads_list,
+        'webftp_tools.webftp_uploads_list',
         'alpacon://webftp/uploads/{region}/{workspace}',
     ),
     (
         'work_sessions_list',
-        work_session_list,
+        'work_session_tools.work_session_list',
         'alpacon://work-sessions/{region}/{workspace}',
     ),
     (
         'work_session_detail',
-        work_session_get,
+        'work_session_tools.work_session_get',
         'alpacon://work-sessions/{region}/{workspace}/{session_id}',
     ),
-    ('workspaces_all', list_workspaces, 'alpacon://workspaces'),
-    ('workspaces_list', list_workspaces, 'alpacon://workspaces/{region}'),
-    ('current_user', get_current_user, 'alpacon://current-user/{region}/{workspace}'),
+    ('workspaces_all', 'workspace_tools.list_workspaces', 'alpacon://workspaces'),
+    (
+        'workspaces_list',
+        'workspace_tools.list_workspaces',
+        'alpacon://workspaces/{region}',
+    ),
+    (
+        'current_user',
+        'workspace_tools.get_current_user',
+        'alpacon://current-user/{region}/{workspace}',
+    ),
     (
         'workspace_settings_access_control',
-        get_workspace_access_control,
+        'workspace_tools.get_workspace_access_control',
         'alpacon://workspace-settings/access-control/{region}/{workspace}',
     ),
     (
         'workspace_settings_security',
-        get_workspace_security,
+        'workspace_tools.get_workspace_security',
         'alpacon://workspace-settings/security/{region}/{workspace}',
     ),
     (
         'workspace_settings_mfa_methods',
-        list_workspace_mfa_methods,
+        'workspace_tools.list_workspace_mfa_methods',
         'alpacon://workspace-settings/mfa-methods/{region}/{workspace}',
     ),
     (
         'workspace_settings_notifications',
-        get_workspace_notifications,
+        'workspace_tools.get_workspace_notifications',
         'alpacon://workspace-settings/notifications/{region}/{workspace}',
     ),
     (
         'workspace_settings_preferences',
-        get_workspace_preferences,
+        'workspace_tools.get_workspace_preferences',
         'alpacon://workspace-settings/preferences/{region}/{workspace}',
     ),
 ]
 
-# (name, fn, uri, extra) — extra pins fixed kwargs for the few filtered resources.
-_REGISTRATIONS = [(n, f, u, None) for n, f, u in RESOURCES] + [
+# (name, `module.func` ref, uri, extra) — extra pins fixed kwargs for filtered resources.
+REGISTRATIONS: list[tuple[str, str, str, dict | None]] = [
+    (n, ref, uri, None) for n, ref, uri in RESOURCES
+] + [
     (
         'alerts_active',
-        list_alerts,
+        'alert_tools.list_alerts',
         'alpacon://alerts/active/{region}/{workspace}',
         {'acknowledged': False},
     ),
 ]
 
 
-# Fewer placeholders first so a literal segment (/active/) wins over a sibling
-# {id} wildcard — FastMCP matches the first registered template.
-for _name, _fn, _uri, _extra in sorted(_REGISTRATIONS, key=lambda r: r[2].count('{')):
-    register_resource(_uri, _fn, _name, _extra)
+def _resolve(ref: str) -> Callable:
+    module_name, func_name = ref.split('.', 1)
+    return getattr(importlib.import_module(f'{TOOLS_PACKAGE}.{module_name}'), func_name)
+
+
+def register_resources(enabled_modules: set[str]) -> None:
+    """Fewer placeholders first so a literal segment (/active/) beats a sibling
+    {id} wildcard — FastMCP takes the first match. That holds only within one
+    call, so pass the complete enabled set at once.
+    """
+    selected = [r for r in REGISTRATIONS if r[1].split('.', 1)[0] in enabled_modules]
+    for name, ref, uri, extra in sorted(selected, key=lambda r: r[2].count('{')):
+        register_resource(uri, _resolve(ref), name, extra)


### PR DESCRIPTION
## Background

Local stdio/SSE mode registered all 19 tool modules unconditionally in `run()`. Clients cap the number of exposed tools, and more registered tools raise the per-request token cost, but there was no way to register only the toolsets a workflow actually uses.

## What changed

Add a `--toolsets` CLI argument and an `ALPACON_MCP_TOOLSETS` environment variable to select which toolsets local mode registers. Precedence is CLI argument > env var > default `all`, so the default keeps existing behavior unchanged.

Tool registration is an import-time side effect of the `@mcp_tool_handler` decorator, so selection has to happen at the import boundary. The hardcoded import block in `run()` (19 tool modules plus a `tools.resources` import) was replaced with an `importlib.import_module` loop driven by `TOOLSET_REGISTRY` (15 toolset names mapped 1:1 to modules). `resolve_toolsets` resolves and validates the names, matching them case-insensitively and rejecting unknown names before the `all` short-circuit so a typo alongside `all` still fails. An unknown name raises `ToolsetError` (a `ValueError` subclass), which both entry points catch to log a one-line `Invalid --toolsets` message and exit 2 — scoped to that type so an unrelated `ValueError` raised while importing a tool module keeps the full-traceback path. `_modules_to_load` decides the final module set based on remote vs local.

`workspace`, `health`, `work-sessions`, and `prompts` are always registered. `work_session_tools` in particular must stay, because gate-denial responses instruct the agent to call `work_session_*`. These four names are accepted in `--toolsets` but have no effect on selection; any other unrecognized name fails at startup. If a selection resolves to only always-on names (e.g. `--toolsets health`), it registers just the always-on tools and logs a warning so the all-no-op selection is not silent.

`tools/resources.py` was refactored into a registry that references tools as `'module.func'` strings, so importing it no longer imports (and registers) tool modules, which would defeat selection. `register_resources(enabled_modules)` registers only resources whose backing module is enabled, and `run()` now calls it explicitly since resource registration is no longer an import side effect. A few resources cross module boundaries — `alpacon://servers/.../overview` is backed by `system_info_tools` — so the README notes that `--toolsets servers` alone drops it and needs `system-info` added.

The broken `alpacon-mcp-sse` console script was fixed along the way: it pointed at `main_sse:main`, which did not exist, so a `main()` was added to `main_sse.py`.

## Scope

Remote mode ignores `--toolsets` and always registers every tool; it relies on the client's tool-search optimization, and this avoids accidentally narrowing tools in an authenticated remote deployment. "Remote mode" is gated on `ALPACON_MCP_AUTH_ENABLED=true` (JWT auth), not on the transport name, matching the existing `_is_remote_mode` definition. When a toolsets value is detected in remote mode, it is logged as ignored.

Narrow selections cut real capability: the workflow prompts still reference tools such as `execute_command` and `webftp_upload_file`, so an agent following them will hit "tool not found" if you exclude `commands` or `webftp`. Select the toolsets your workflows actually use.

## Tests

New `tests/test_toolsets.py` covers `resolve_toolsets` (precedence, whitespace, case-insensitive matching, unknown-name fail-fast raising `ToolsetError`, always-on names ignored, always-on-only selection warns and selects nothing), `_modules_to_load` (local subset plus always-on, remote full set, local default full set), registry-to-disk consistency, an AST guard that `resources.py` imports no tool module, `register_resources` filtering, both entry points forwarding `--toolsets`, and `run()` wiring.

Full suite: 949 passed. Two failures (`test_basic.py::test_import_main`, `test_simple_integration.py::TestMCPServerConfiguration::test_main_entry_point`) are pre-existing and unrelated to this branch: the checkout directory is named `main`, which shadows the top-level `main.py` on `import main` (they reproduce on the base commit). ruff lint and format pass.

Closes #34
