### PR TITLE
refactor(utils): consolidate ALPACON_MCP_AUTH_ENABLED check into one helper

### DIFF
--- a/server.py
+++ b/server.py
@@ -8,6 +8,7 @@ from typing import Literal
 
 from mcp.server.fastmcp import FastMCP
 
+from utils.common import is_auth_enabled
 from utils.logger import get_logger
 
 logger = get_logger('server')
@@ -74,7 +75,7 @@ def _create_mcp_server() -> FastMCP:
     creates the server with Auth0 JWT authentication for HTTP transport.
     Otherwise creates a standard server for stdio/SSE transport.
     """
-    auth_enabled = os.getenv('ALPACON_MCP_AUTH_ENABLED', '').lower() == 'true'
+    auth_enabled = is_auth_enabled()
 
     if auth_enabled:
         from mcp.server.auth.settings import AuthSettings
@@ -254,11 +255,6 @@ def _modules_to_load(toolsets: str | None, remote_mode: bool) -> set[str]:
     return enabled | ALWAYS_ON_MODULES
 
 
-def _is_remote_mode() -> bool:
-    """Check if running in remote (streamable-http) mode with JWT auth."""
-    return os.getenv('ALPACON_MCP_AUTH_ENABLED', '').lower() == 'true'
-
-
 def _install_upstream_auth_middleware():
     """Override run_streamable_http_async to wrap app with auth error middleware.
 
@@ -346,7 +342,7 @@ def run(
     else:
         logger.info('No config file specified, using default config discovery')
 
-    remote_mode = _is_remote_mode()
+    remote_mode = is_auth_enabled()
 
     if remote_mode:
         # Remote (streamable-http) mode: register OAuth routes

--- a/tests/test_webftp_tools.py
+++ b/tests/test_webftp_tools.py
@@ -1255,9 +1255,9 @@ class TestRemoteModeUnsupported:
         """webftp_upload_file returns remote_mode_unsupported error in remote mode.
 
         The decorator's auth check is bypassed (auth disabled) so the function
-        body's _is_remote_mode check is what we're exercising here.
+        body's is_auth_enabled check is what we're exercising here.
         """
-        with patch('tools.webftp_tools._is_auth_enabled', return_value=True):
+        with patch('tools.webftp_tools.is_auth_enabled', return_value=True):
             result = await webftp_upload_file(
                 server_id=self.SERVER_ID,
                 local_file_path='/local/test.txt',
@@ -1273,7 +1273,7 @@ class TestRemoteModeUnsupported:
     @pytest.mark.asyncio
     async def test_bulk_upload_remote_mode(self, mock_http_client, mock_token_manager):
         """webftp_bulk_upload returns remote_mode_unsupported error in remote mode."""
-        with patch('tools.webftp_tools._is_auth_enabled', return_value=True):
+        with patch('tools.webftp_tools.is_auth_enabled', return_value=True):
             result = await webftp_bulk_upload(
                 server_id=self.SERVER_ID,
                 local_file_paths=['/local/a.txt', '/local/b.txt'],
@@ -1291,7 +1291,7 @@ class TestRemoteModeUnsupported:
         self, mock_http_client, mock_token_manager
     ):
         """webftp_bulk_download returns remote_mode_unsupported error in remote mode."""
-        with patch('tools.webftp_tools._is_auth_enabled', return_value=True):
+        with patch('tools.webftp_tools.is_auth_enabled', return_value=True):
             result = await webftp_bulk_download(
                 server_id=self.SERVER_ID,
                 remote_paths=['/remote/a.txt'],
@@ -1320,7 +1320,7 @@ class TestRemoteModeDownload:
             'download_url': 'https://s3.example.com/file?sig=abc',
         }
 
-        with patch('tools.webftp_tools._is_auth_enabled', return_value=True):
+        with patch('tools.webftp_tools.is_auth_enabled', return_value=True):
             result = await webftp_download_file(
                 server_id=self.SERVER_ID,
                 remote_file_path='/remote/file.txt',
@@ -1345,7 +1345,7 @@ class TestRemoteModeDownload:
         ]
 
         with (
-            patch('tools.webftp_tools._is_auth_enabled', return_value=True),
+            patch('tools.webftp_tools.is_auth_enabled', return_value=True),
             patch('asyncio.sleep', new_callable=AsyncMock),
         ):
             result = await webftp_download_file(
@@ -1368,7 +1368,7 @@ class TestRemoteModeDownload:
         mock_http_client.get.return_value = {'success': None}
 
         with (
-            patch('tools.webftp_tools._is_auth_enabled', return_value=True),
+            patch('tools.webftp_tools.is_auth_enabled', return_value=True),
             patch('asyncio.sleep', new_callable=AsyncMock),
             patch('tools.webftp_tools._REMOTE_DOWNLOAD_TIMEOUT', 2),
         ):
@@ -1395,7 +1395,7 @@ class TestRemoteModeDownload:
         }
 
         with (
-            patch('tools.webftp_tools._is_auth_enabled', return_value=True),
+            patch('tools.webftp_tools.is_auth_enabled', return_value=True),
             patch('asyncio.sleep', new_callable=AsyncMock),
         ):
             result = await webftp_download_file(

--- a/tools/webftp_tools.py
+++ b/tools/webftp_tools.py
@@ -13,11 +13,12 @@ import httpx
 
 from utils.common import (
     error_response,
+    is_auth_enabled,
     resolve_work_session_id,
     success_response,
     unwrap_http_result,
 )
-from utils.decorators import _is_auth_enabled, mcp_tool_handler
+from utils.decorators import mcp_tool_handler
 from utils.error_handler import format_validation_error, validate_file_path
 from utils.http_client import http_client
 from utils.tool_annotations import ADDITIVE, READ_ONLY
@@ -341,7 +342,7 @@ async def webftp_upload_file(
     """Upload a local file to a server via S3 presigned URL."""
     token = kwargs.get('token')
 
-    if _is_auth_enabled():
+    if is_auth_enabled():
         return error_response(_REMOTE_MODE_ERROR, code='remote_mode_unsupported')
 
     if not validate_file_path(local_file_path):
@@ -575,7 +576,7 @@ async def webftp_download_file(
     if not validate_file_path(remote_file_path):
         return format_validation_error('remote_file_path', remote_file_path)
 
-    if _is_auth_enabled():
+    if is_auth_enabled():
         return await _download_remote_mode(
             server_id=server_id,
             remote_file_path=remote_file_path,
@@ -755,7 +756,7 @@ async def webftp_bulk_upload(
     """Upload multiple files to a server using bulk WebFTP API."""
     token = kwargs.get('token')
 
-    if _is_auth_enabled():
+    if is_auth_enabled():
         return error_response(_REMOTE_MODE_ERROR, code='remote_mode_unsupported')
 
     if not local_file_paths:
@@ -916,7 +917,7 @@ async def webftp_bulk_download(
     """Download multiple files/folders as a ZIP archive."""
     token = kwargs.get('token')
 
-    if _is_auth_enabled():
+    if is_auth_enabled():
         return error_response(_REMOTE_MODE_ERROR, code='remote_mode_unsupported')
 
     if not remote_paths:

--- a/tools/workspace_tools.py
+++ b/tools/workspace_tools.py
@@ -5,7 +5,12 @@ from typing import Any
 from mcp.types import ToolAnnotations
 
 from server import mcp
-from utils.common import error_response, success_response, unwrap_http_result
+from utils.common import (
+    error_response,
+    is_auth_enabled,
+    success_response,
+    unwrap_http_result,
+)
 from utils.decorators import mcp_tool_handler, require_jwt_auth
 from utils.http_client import http_client
 from utils.token_manager import TokenManager
@@ -115,10 +120,10 @@ async def list_workspaces(region: str = '') -> dict[str, Any]:
     Returns:
         Workspaces list response
     """
-    from utils.decorators import _get_jwt_token, _get_jwt_workspaces, _is_auth_enabled
+    from utils.decorators import _get_jwt_token, _get_jwt_workspaces
 
     # Use explicit transport mode check, not JWT presence
-    if _is_auth_enabled():
+    if is_auth_enabled():
         jwt_token = _get_jwt_token()
         if not jwt_token:
             return error_response(

--- a/utils/common.py
+++ b/utils/common.py
@@ -23,64 +23,6 @@ except importlib.metadata.PackageNotFoundError:
 # MCP User-Agent for identification
 MCP_USER_AGENT = f'alpacon-mcp/{MCP_VERSION} (MCP-Server; persistent-pool) Python/{platform.python_version()}'
 
-
-def is_auth_enabled() -> bool:
-    """Check if remote (streamable-http) mode with Auth0 JWT auth is enabled.
-
-    True when ALPACON_MCP_AUTH_ENABLED=true. False in stdio/SSE mode, which
-    authenticates with tokens from token.json.
-    """
-    return os.getenv('ALPACON_MCP_AUTH_ENABLED', '').lower() == 'true'
-
-
-def validate_token(region: str, workspace: str) -> str | None:
-    """Validate and retrieve token for given region and workspace.
-
-    Args:
-        region: Region (ap1, us1, eu1, etc.)
-        workspace: Workspace name
-
-    Returns:
-        Token string if found, None otherwise
-    """
-    token = token_manager.get_token(region, workspace)
-    if not token:
-        logger.error(f'No token found for {workspace}.{region}')
-    return token
-
-
-def error_response(message: str, **kwargs) -> dict[str, Any]:
-    """Create standardized error response.
-
-    Args:
-        message: Error message
-        **kwargs: Additional fields to include in response
-
-    Returns:
-        Standardized error response dict
-    """
-    response = {'status': 'error', 'message': message}
-    response.update(kwargs)
-    return response
-
-
-def success_response(data: Any = None, **kwargs) -> dict[str, Any]:
-    """Create standardized success response.
-
-    Args:
-        data: Response data
-        **kwargs: Additional fields to include in response
-
-    Returns:
-        Standardized success response dict
-    """
-    response = {'status': 'success'}
-    if data is not None:
-        response['data'] = data
-    response.update(kwargs)
-    return response
-
-
 # The human-resolvable next action differs by category: SUDO_APPROVAL_REQUIRED /
 # WORK_SESSION_PENDING need an out-of-band approval, while SUDO_PRESENCE_REQUIRED
 # is an MFA step-up and SUDO_NO_WORKSESSION_POLICY is a scope addition — none of
@@ -122,6 +64,98 @@ _NEXT_ACTION_BY_CATEGORY: dict[str, str] = {
     ),
 }
 _DEFAULT_NEXT_ACTION = _NEXT_ACTION_BY_CATEGORY['SUDO_APPROVAL_REQUIRED']
+
+# Server WorkSession gate codes → next-action telling the agent how to get inside a valid session (mirrors alpacon-cli worksession_error.go).
+_WORK_SESSION_GATE_NEXT_ACTION: dict[str, str] = {
+    'work_session_required': (
+        'No Work Session is attached. Create one with work_session_create '
+        '(scope covering this operation—"command" for command execution, '
+        '"webftp" for file transfers—plus the target server), have a human '
+        'approve it out-of-band, then retry passing its id as work_session_id.'
+    ),
+    'work_session_not_usable': (
+        'The attached Work Session is in a terminal state and cannot be used. '
+        'Create a new Work Session, get it approved, then retry.'
+    ),
+    'work_session_expired': (
+        'The attached Work Session has expired. Extend it with '
+        'work_session_extend, or create a new one, then retry.'
+    ),
+    'work_session_scope_not_allowed': (
+        'The attached Work Session does not include the scope for this '
+        'operation. Add the scope with work_session_update (may require '
+        'approval) or create a new session with the right scope, then retry.'
+    ),
+    'work_session_server_not_allowed': (
+        'The target server is not in the attached Work Session. Add it with '
+        'work_session_update, or create a new session including the server, '
+        'then retry.'
+    ),
+    'work_session_assignee_mismatch': (
+        'The attached Work Session is assigned to a different principal. Use a '
+        'session assigned to you, or create your own, then retry.'
+    ),
+}
+
+# Session exists but is unapproved; routes to pending-approval, not error.
+_WORK_SESSION_PENDING_CODE = 'work_session_not_active'
+
+_WORK_SESSION_GATE_CODES: frozenset[str] = frozenset(_WORK_SESSION_GATE_NEXT_ACTION) | {
+    _WORK_SESSION_PENDING_CODE
+}
+
+
+def is_auth_enabled() -> bool:
+    """Check if remote (streamable-http) mode with Auth0 JWT auth is enabled.
+
+    True when ALPACON_MCP_AUTH_ENABLED=true. False in stdio/SSE mode, which
+    authenticates with tokens from token.json.
+    """
+    return os.getenv('ALPACON_MCP_AUTH_ENABLED', '').lower() == 'true'
+
+
+def resolve_work_session_id(explicit: str | None) -> str | None:
+    """Resolve the effective Work Session id: explicit arg > ALPACON_WORK_SESSION env.
+
+    Mirrors alpacon-cli's resolve.go (flag > env). Returns None when neither is set.
+    """
+    return (
+        (explicit or '').strip()
+        or os.environ.get('ALPACON_WORK_SESSION', '').strip()
+        or None
+    )
+
+
+def error_response(message: str, **kwargs) -> dict[str, Any]:
+    """Create standardized error response.
+
+    Args:
+        message: Error message
+        **kwargs: Additional fields to include in response
+
+    Returns:
+        Standardized error response dict
+    """
+    response = {'status': 'error', 'message': message}
+    response.update(kwargs)
+    return response
+
+
+def success_response(data: Any = None, **kwargs) -> dict[str, Any]:
+    """Create standardized success response.
+
+    Args:
+        data: Response data
+        **kwargs: Additional fields to include in response
+
+    Returns:
+        Standardized success response dict
+    """
+    response = {'status': 'success'}
+    if data is not None:
+        response['data'] = data
+    response.update(kwargs)
+    return response
 
 
 def pending_approval_response(
@@ -172,6 +206,22 @@ def pending_approval_response(
     return response
 
 
+def validate_token(region: str, workspace: str) -> str | None:
+    """Validate and retrieve token for given region and workspace.
+
+    Args:
+        region: Region (ap1, us1, eu1, etc.)
+        workspace: Workspace name
+
+    Returns:
+        Token string if found, None otherwise
+    """
+    token = token_manager.get_token(region, workspace)
+    if not token:
+        logger.error(f'No token found for {workspace}.{region}')
+    return token
+
+
 def token_error_response(region: str, workspace: str) -> dict[str, Any]:
     """Create standardized token error response.
 
@@ -187,46 +237,6 @@ def token_error_response(region: str, workspace: str) -> dict[str, Any]:
         region=region,
         workspace=workspace,
     )
-
-
-# Server WorkSession gate codes → next-action telling the agent how to get inside a valid session (mirrors alpacon-cli worksession_error.go).
-_WORK_SESSION_GATE_NEXT_ACTION: dict[str, str] = {
-    'work_session_required': (
-        'No Work Session is attached. Create one with work_session_create '
-        '(scope covering this operation—"command" for command execution, '
-        '"webftp" for file transfers—plus the target server), have a human '
-        'approve it out-of-band, then retry passing its id as work_session_id.'
-    ),
-    'work_session_not_usable': (
-        'The attached Work Session is in a terminal state and cannot be used. '
-        'Create a new Work Session, get it approved, then retry.'
-    ),
-    'work_session_expired': (
-        'The attached Work Session has expired. Extend it with '
-        'work_session_extend, or create a new one, then retry.'
-    ),
-    'work_session_scope_not_allowed': (
-        'The attached Work Session does not include the scope for this '
-        'operation. Add the scope with work_session_update (may require '
-        'approval) or create a new session with the right scope, then retry.'
-    ),
-    'work_session_server_not_allowed': (
-        'The target server is not in the attached Work Session. Add it with '
-        'work_session_update, or create a new session including the server, '
-        'then retry.'
-    ),
-    'work_session_assignee_mismatch': (
-        'The attached Work Session is assigned to a different principal. Use a '
-        'session assigned to you, or create your own, then retry.'
-    ),
-}
-
-# Session exists but is unapproved; routes to pending-approval, not error.
-_WORK_SESSION_PENDING_CODE = 'work_session_not_active'
-
-_WORK_SESSION_GATE_CODES: frozenset[str] = frozenset(_WORK_SESSION_GATE_NEXT_ACTION) | {
-    _WORK_SESSION_PENDING_CODE
-}
 
 
 def work_session_gate_response(code: str, **kwargs: Any) -> dict[str, Any]:
@@ -314,15 +324,3 @@ def _extract_work_session_gate_code(result: dict[str, Any]) -> str | None:
     if isinstance(code, str) and code in _WORK_SESSION_GATE_CODES:
         return code
     return None
-
-
-def resolve_work_session_id(explicit: str | None) -> str | None:
-    """Resolve the effective Work Session id: explicit arg > ALPACON_WORK_SESSION env.
-
-    Mirrors alpacon-cli's resolve.go (flag > env). Returns None when neither is set.
-    """
-    return (
-        (explicit or '').strip()
-        or os.environ.get('ALPACON_WORK_SESSION', '').strip()
-        or None
-    )

--- a/utils/common.py
+++ b/utils/common.py
@@ -24,6 +24,15 @@ except importlib.metadata.PackageNotFoundError:
 MCP_USER_AGENT = f'alpacon-mcp/{MCP_VERSION} (MCP-Server; persistent-pool) Python/{platform.python_version()}'
 
 
+def is_auth_enabled() -> bool:
+    """Check if remote (streamable-http) mode with Auth0 JWT auth is enabled.
+
+    True when ALPACON_MCP_AUTH_ENABLED=true. False in stdio/SSE mode, which
+    authenticates with tokens from token.json.
+    """
+    return os.getenv('ALPACON_MCP_AUTH_ENABLED', '').lower() == 'true'
+
+
 def validate_token(region: str, workspace: str) -> str | None:
     """Validate and retrieve token for given region and workspace.
 

--- a/utils/decorators.py
+++ b/utils/decorators.py
@@ -10,7 +10,12 @@ from typing import Any
 
 from mcp.types import ToolAnnotations
 
-from utils.common import error_response, token_error_response, validate_token
+from utils.common import (
+    error_response,
+    is_auth_enabled,
+    token_error_response,
+    validate_token,
+)
 from utils.error_handler import (
     UpstreamAuthError,
     format_validation_error,
@@ -22,15 +27,6 @@ from utils.http_client import AlpaconHTTPClient
 from utils.logger import get_logger
 
 logger = get_logger('decorators')
-
-
-def _is_auth_enabled() -> bool:
-    """Check if OAuth2 authentication mode is enabled (streamable-http transport).
-
-    Returns True when running in streamable-http mode with Auth0 JWT auth.
-    Returns False when running in stdio/SSE mode with token.json.
-    """
-    return os.getenv('ALPACON_MCP_AUTH_ENABLED', '').lower() == 'true'
 
 
 def _get_jwt_token() -> str | None:
@@ -268,7 +264,7 @@ def with_token_validation(func: Callable) -> Callable:
         if not validate_workspace_format(workspace):
             return format_validation_error('workspace', workspace)
 
-        auth_enabled = _is_auth_enabled()
+        auth_enabled = is_auth_enabled()
 
         # Retrieve JWT token once upfront in streamable-http mode
         jwt_token = None

--- a/utils/health.py
+++ b/utils/health.py
@@ -4,17 +4,13 @@ import os
 import time
 from typing import Any
 
+from utils.common import is_auth_enabled
 from utils.logger import get_logger
 
 logger = get_logger('health')
 
 # Track server start time
 _start_time = time.monotonic()
-
-
-def _is_remote_mode() -> bool:
-    """Check if running in remote (streamable-http) mode with JWT auth."""
-    return os.getenv('ALPACON_MCP_AUTH_ENABLED', '').lower() == 'true'
 
 
 def _get_auth_info_remote() -> dict[str, Any]:
@@ -58,7 +54,7 @@ async def get_health_info() -> dict[str, Any]:
         MCP_VERSION = '0.4.2-dev'
 
     # Auth config — mode-appropriate info only
-    auth_info = _get_auth_info_remote() if _is_remote_mode() else _get_auth_info_local()
+    auth_info = _get_auth_info_remote() if is_auth_enabled() else _get_auth_info_local()
 
     # HTTP client pool status
     http_pool_active = http_client.pool_active

--- a/utils/http_client.py
+++ b/utils/http_client.py
@@ -2,14 +2,13 @@
 
 import asyncio
 import json
-import os
 import time
 from typing import Any
 from urllib.parse import urljoin
 
 import httpx
 
-from utils.common import MCP_USER_AGENT
+from utils.common import MCP_USER_AGENT, is_auth_enabled
 from utils.logger import get_logger
 
 logger = get_logger('http_client')
@@ -174,7 +173,7 @@ class AlpaconHTTPClient:
         except Exception as parse_exc:
             logger.debug('Failed to parse 401 response body as JSON: %s', parse_exc)
 
-        auth_enabled = os.getenv('ALPACON_MCP_AUTH_ENABLED', '').lower() == 'true'
+        auth_enabled = is_auth_enabled()
         is_jwt = bool(token and AlpaconHTTPClient._is_jwt(token))
 
         # DEBUG: Log all decision factors for 401 handling


### PR DESCRIPTION
## Background

The remote-mode check `os.getenv('ALPACON_MCP_AUTH_ENABLED', '').lower() == 'true'` was copy-pasted at five sites: `utils/health.py:17`, `utils/http_client.py:177`, `utils/decorators.py:33`, and twice in `server.py` (lines 77 and 259). Two of those five were wrapped in separate, identically-bodied private helpers that happened to share a name — `_is_remote_mode()` existed once in `utils/health.py` and again in `server.py`. On top of that, `tools/webftp_tools.py:20` reached across a module boundary to import the module-private `utils.decorators._is_auth_enabled` and called it at four sites.

One env var deciding local (stdio/SSE, token.json) versus remote (streamable-http, Auth0 JWT) mode should be read through one function.

## What changed

`is_auth_enabled()` now lives in `utils/common.py` and is the only place that reads `ALPACON_MCP_AUTH_ENABLED`. All five original checks call it, and the duplicated private helpers (`utils.decorators._is_auth_enabled`, `utils.health._is_remote_mode`, `server._is_remote_mode`) are gone.

| File | Before | After |
|---|---|---|
| `utils/common.py` | — | defines `is_auth_enabled()` |
| `utils/decorators.py` | `_is_auth_enabled()` helper | imports `is_auth_enabled` |
| `utils/health.py` | `_is_remote_mode()` helper | imports `is_auth_enabled` |
| `server.py` | inline check + `_is_remote_mode()` helper | imports `is_auth_enabled` |
| `utils/http_client.py` | inline check | imports `is_auth_enabled` |
| `tools/webftp_tools.py` | imports private `_is_auth_enabled` from `utils.decorators` | imports `is_auth_enabled` from `utils.common` |
| `tools/workspace_tools.py` | function-local import of private `_is_auth_enabled` | module-level import of `is_auth_enabled` |

`utils/common.py` was chosen as the home because it already hosts the shared helpers and sits below every consumer in the import graph — it only imports `utils.logger` and `utils.token_manager`. Hosting the helper in `utils/decorators.py` was not an option: `utils/decorators.py:26` imports `utils.http_client`, so `http_client` importing back from `decorators` would be a cycle.

Two follow-on edits: `utils/http_client.py` drops its `os` import, which the replaced line was the last user of, and the seven `patch(...)` targets in `tests/test_webftp_tools.py` move from `tools.webftp_tools._is_auth_enabled` to `tools.webftp_tools.is_auth_enabled`.

One small tidy-up rides along in a separate commit: `utils/common.py` declarations are reordered — module constants collected into one block after the imports, functions following in dependency order (define before use), private helper last. Pure code motion; with blank lines dropped the line multiset is identical before and after, and no signature, body, or import changed.

## Behavior

Unchanged. The five replaced expressions were byte-identical to each other — same `''` default, same `.lower()`, same `== 'true'` comparison — and the new helper keeps all three. Every original check already sat inside a function body, so evaluation still happens at call time, not at import time; `main_http.py:50` setting the env var before importing `server` remains correct.

The rename from `_is_auth_enabled` to `is_auth_enabled` drops the underscore because the function is now imported by six modules. A leading underscore on a symbol with cross-module callers was the pre-existing smell that `tools/webftp_tools.py` was already violating.

## Testing

- `uv run --extra dev python -m pytest tests -q`: 949 passed, 2 failed. Both failures (`tests/test_basic.py::test_import_main`, `tests/test_simple_integration.py::TestMCPServerConfiguration::test_main_entry_point`) reproduce on a clean tree — verified with `git stash` — and are caused by the local checkout directory being named `main`, so `import main` resolves to the package instead of `main.py`. Not related to this change.
- `ruff check .` and `ruff format --check .`: clean.
- Tests covering both branches of the flag (`tests/test_http_client.py`, `tests/test_health.py`, `tests/test_input_validation.py`, `tests/test_oauth.py`, `tests/test_mfa_precheck.py`) set `ALPACON_MCP_AUTH_ENABLED` via `patch.dict(os.environ, ...)` rather than patching a function, so they exercise the new helper unmodified.

## Checklist

- [x] No behavior change intended, and the replaced expressions were verified identical before removal
- [x] Tests pass locally (2 pre-existing failures documented above)
- [x] Lint and format clean
- [x] No new dependencies
