### PR TITLE
refactor(utils): consolidate retry backoff and UUID list validation

### DIFF
--- a/tests/test_http_client.py
+++ b/tests/test_http_client.py
@@ -11,6 +11,7 @@ import httpx
 import pytest
 
 from utils.http_client import AlpaconHTTPClient, http_client
+from utils.recovery_hints import _detect_error_domain, enrich_error_response
 
 
 @pytest.fixture
@@ -137,6 +138,36 @@ class TestHTTPClientGet:
         assert result['error'] == 'Max retries exceeded'
         # Should have retried 3 times
         assert mock_httpx_client.request.call_count == 3
+
+    @pytest.mark.asyncio
+    async def test_get_500_exhaustion_enriches_with_server_hints(
+        self, mock_httpx_client
+    ):
+        """5xx exhaustion carries status_code and a 'server'-domain message.
+
+        Both feed enrich_error_response, which every decorated tool runs over
+        its result, so changing either moves the hints the caller receives.
+        """
+        mock_response = create_mock_response(status_code=500)
+        mock_httpx_client.request.return_value = mock_response
+
+        result = await http_client.get(
+            region='ap1',
+            workspace='testworkspace',
+            endpoint='/api/error/',
+            token='test-token',
+        )
+
+        assert result['status_code'] == 500
+        assert (
+            _detect_error_domain(result['status_code'], result['message']) == 'server'
+        )
+
+        enriched = enrich_error_response(dict(result))
+        assert enriched['recovery_hints'] == [
+            'The server encountered an internal error. Try again in a moment.',
+            'If the issue persists, check server health.',
+        ]
 
 
 class TestHTTPClientPost:

--- a/tests/test_http_client.py
+++ b/tests/test_http_client.py
@@ -41,6 +41,16 @@ def mock_httpx_client():
             delattr(http_client, '_disable_pooling')
 
 
+@pytest.fixture
+def no_retry_delay(monkeypatch):
+    """Drop the backoff sleep for tests that exhaust the retries.
+
+    monkeypatch, not assignment: http_client is a module-level singleton, so
+    the value would leak into the rest of the suite.
+    """
+    monkeypatch.setattr(http_client, 'retry_delay', 0)
+
+
 def create_mock_response(status_code=200, json_data=None, text_data='', headers=None):
     """Create a properly configured mock response."""
     # Use MagicMock instead of AsyncMock for response to avoid coroutine issues
@@ -123,7 +133,7 @@ class TestHTTPClientGet:
         assert result['status_code'] == 404
 
     @pytest.mark.asyncio
-    async def test_get_500_error(self, mock_httpx_client):
+    async def test_get_500_error(self, mock_httpx_client, no_retry_delay):
         """Test GET request with 500 error (should retry and then fail)."""
         mock_response = create_mock_response(status_code=500)
         mock_httpx_client.request.return_value = mock_response
@@ -139,14 +149,21 @@ class TestHTTPClientGet:
         # Should have retried 3 times
         assert mock_httpx_client.request.call_count == 3
 
+    @pytest.mark.parametrize(
+        ('tool_name', 'domain'),
+        [
+            ('get_server', 'server'),
+            ('execute_command', 'command'),
+            ('webftp_upload_file', 'file'),
+        ],
+    )
     @pytest.mark.asyncio
     async def test_get_500_exhaustion_enriches_across_tool_domains(
-        self, mock_httpx_client
+        self, mock_httpx_client, no_retry_delay, tool_name, domain
     ):
         """tool_name mirrors the live enrich call and outranks the message, so the
         domain varies by caller; 500 has only a (500, 'general') entry so the hints
-        converge, and a domain-specific one would split them here. One request for
-        all three — exhausting the retries really sleeps.
+        converge, and a domain-specific one would split them here.
         """
         mock_response = create_mock_response(status_code=500)
         mock_httpx_client.request.return_value = mock_response
@@ -159,23 +176,16 @@ class TestHTTPClientGet:
         )
 
         assert result['status_code'] == 500
+        assert (
+            _detect_error_domain(result['status_code'], result['message'], tool_name)
+            == domain
+        )
 
-        for tool_name, domain in (
-            ('get_server', 'server'),
-            ('execute_command', 'command'),
-            ('webftp_upload_file', 'file'),
-        ):
-            assert (
-                _detect_error_domain(
-                    result['status_code'], result['message'], tool_name
-                )
-                == domain
-            )
-            enriched = enrich_error_response(dict(result), tool_name=tool_name)
-            assert enriched['recovery_hints'] == [
-                'The server encountered an internal error. Try again in a moment.',
-                'If the issue persists, check server health.',
-            ]
+        enriched = enrich_error_response(dict(result), tool_name=tool_name)
+        assert enriched['recovery_hints'] == [
+            'The server encountered an internal error. Try again in a moment.',
+            'If the issue persists, check server health.',
+        ]
 
 
 class TestHTTPClientPost:
@@ -374,7 +384,7 @@ class TestErrorHandling:
     """Test error handling scenarios."""
 
     @pytest.mark.asyncio
-    async def test_network_timeout(self, mock_httpx_client):
+    async def test_network_timeout(self, mock_httpx_client, no_retry_delay):
         """Test network timeout handling."""
         mock_httpx_client.request.side_effect = httpx.TimeoutException(
             'Request timeout'
@@ -390,7 +400,7 @@ class TestErrorHandling:
         assert result['error'] == 'Timeout'
 
     @pytest.mark.asyncio
-    async def test_connection_error(self, mock_httpx_client):
+    async def test_connection_error(self, mock_httpx_client, no_retry_delay):
         """Test connection error handling."""
         mock_httpx_client.request.side_effect = httpx.ConnectError('Connection failed')
 

--- a/tests/test_http_client.py
+++ b/tests/test_http_client.py
@@ -140,13 +140,13 @@ class TestHTTPClientGet:
         assert mock_httpx_client.request.call_count == 3
 
     @pytest.mark.asyncio
-    async def test_get_500_exhaustion_enriches_with_server_hints(
+    async def test_get_500_exhaustion_enriches_across_tool_domains(
         self, mock_httpx_client
     ):
-        """5xx exhaustion carries status_code and a 'server'-domain message.
-
-        Both feed enrich_error_response, which every decorated tool runs over
-        its result, so changing either moves the hints the caller receives.
+        """tool_name mirrors the live enrich call and outranks the message, so the
+        domain varies by caller; 500 has only a (500, 'general') entry so the hints
+        converge, and a domain-specific one would split them here. One request for
+        all three — exhausting the retries really sleeps.
         """
         mock_response = create_mock_response(status_code=500)
         mock_httpx_client.request.return_value = mock_response
@@ -159,15 +159,23 @@ class TestHTTPClientGet:
         )
 
         assert result['status_code'] == 500
-        assert (
-            _detect_error_domain(result['status_code'], result['message']) == 'server'
-        )
 
-        enriched = enrich_error_response(dict(result))
-        assert enriched['recovery_hints'] == [
-            'The server encountered an internal error. Try again in a moment.',
-            'If the issue persists, check server health.',
-        ]
+        for tool_name, domain in (
+            ('get_server', 'server'),
+            ('execute_command', 'command'),
+            ('webftp_upload_file', 'file'),
+        ):
+            assert (
+                _detect_error_domain(
+                    result['status_code'], result['message'], tool_name
+                )
+                == domain
+            )
+            enriched = enrich_error_response(dict(result), tool_name=tool_name)
+            assert enriched['recovery_hints'] == [
+                'The server encountered an internal error. Try again in a moment.',
+                'If the issue persists, check server health.',
+            ]
 
 
 class TestHTTPClientPost:

--- a/utils/decorators.py
+++ b/utils/decorators.py
@@ -28,16 +28,13 @@ from utils.logger import get_logger
 
 logger = get_logger('decorators')
 
-# Arguments carrying a list of server UUIDs. Order is the reporting order when
-# more than one is invalid.
+# Order is the reporting order when more than one is invalid.
 _UUID_LIST_FIELDS = ('server_ids', 'servers')
 _UUID_LIST_TYPE_MSG = 'Must be a list of server UUIDs.'
 _UUID_LIST_ITEM_MSG = 'Each server ID must be in UUID format. (e.g., 550e8400-e29b-41d4-a716-446655440000)'
 
-# Trailing hint shared by the two "multiple regions available" messages.
 _SPECIFY_REGION_HINT = 'Please specify a region parameter.'
 
-# Argument names redacted from tool-entry logs.
 _SENSITIVE_LOG_KEYS = frozenset({'_token', 'password', 'secret', 'key'})
 
 
@@ -238,7 +235,7 @@ async def _check_mfa_requirement(
 
 
 def _validate_uuid_list(field: str, value: Any) -> dict[str, Any] | None:
-    """Validate a list of server UUIDs. Returns an error response, or None if valid."""
+    """Returns an error response, or None if valid."""
     if not isinstance(value, list):
         return format_validation_error(
             field,
@@ -327,8 +324,7 @@ def with_token_validation(func: Callable) -> Callable:
         if server_id is not None and not validate_server_id_format(server_id):
             return format_validation_error('server_id', server_id)
 
-        # Validate UUID list arguments if present
-        # ('servers' carries server UUIDs sent in request bodies)
+        # 'servers' carries server UUIDs sent in request bodies.
         for field in _UUID_LIST_FIELDS:
             value = arguments.get(field)
             if value is not None:

--- a/utils/decorators.py
+++ b/utils/decorators.py
@@ -225,6 +225,25 @@ async def _check_mfa_requirement(
         logger.debug('MFA pre-check failed (non-fatal): %s', e)
 
 
+def _validate_uuid_list(field: str, value: Any) -> dict[str, Any] | None:
+    """Validate a list of server UUIDs. Returns an error response, or None if valid."""
+    if not isinstance(value, list):
+        return format_validation_error(
+            field,
+            value,
+            'Must be a list of server UUIDs.',
+        )
+
+    invalid = [item for item in value if not validate_server_id_format(item)]
+    if invalid:
+        return format_validation_error(
+            field,
+            invalid,
+            'Each server ID must be in UUID format. (e.g., 550e8400-e29b-41d4-a716-446655440000)',
+        )
+    return None
+
+
 def with_token_validation(func: Callable) -> Callable:
     """Decorator to add automatic token validation to MCP tools.
 
@@ -296,43 +315,14 @@ def with_token_validation(func: Callable) -> Callable:
         if server_id is not None and not validate_server_id_format(server_id):
             return format_validation_error('server_id', server_id)
 
-        # Validate server_ids list if present
-        server_ids = arguments.get('server_ids')
-        if server_ids is not None:
-            if not isinstance(server_ids, list):
-                return format_validation_error(
-                    'server_ids',
-                    server_ids,
-                    'Must be a list of server UUIDs.',
-                )
-            invalid_ids = [
-                sid for sid in server_ids if not validate_server_id_format(sid)
-            ]
-            if invalid_ids:
-                return format_validation_error(
-                    'server_ids',
-                    invalid_ids,
-                    'Each server ID must be in UUID format. (e.g., 550e8400-e29b-41d4-a716-446655440000)',
-                )
-
-        # Validate servers list if present (server UUIDs sent in request bodies)
-        servers = arguments.get('servers')
-        if servers is not None:
-            if not isinstance(servers, list):
-                return format_validation_error(
-                    'servers',
-                    servers,
-                    'Must be a list of server UUIDs.',
-                )
-            invalid_servers = [
-                sid for sid in servers if not validate_server_id_format(sid)
-            ]
-            if invalid_servers:
-                return format_validation_error(
-                    'servers',
-                    invalid_servers,
-                    'Each server ID must be in UUID format. (e.g., 550e8400-e29b-41d4-a716-446655440000)',
-                )
+        # Validate UUID list arguments if present
+        # ('servers' carries server UUIDs sent in request bodies)
+        for field in ('server_ids', 'servers'):
+            value = arguments.get(field)
+            if value is not None:
+                validation_error = _validate_uuid_list(field, value)
+                if validation_error:
+                    return validation_error
 
         # session_id is interpolated into URL paths, so reject non-UUID values that could retarget the request.
         session_id = arguments.get('session_id')

--- a/utils/decorators.py
+++ b/utils/decorators.py
@@ -28,6 +28,18 @@ from utils.logger import get_logger
 
 logger = get_logger('decorators')
 
+# Arguments carrying a list of server UUIDs. Order is the reporting order when
+# more than one is invalid.
+_UUID_LIST_FIELDS = ('server_ids', 'servers')
+_UUID_LIST_TYPE_MSG = 'Must be a list of server UUIDs.'
+_UUID_LIST_ITEM_MSG = 'Each server ID must be in UUID format. (e.g., 550e8400-e29b-41d4-a716-446655440000)'
+
+# Trailing hint shared by the two "multiple regions available" messages.
+_SPECIFY_REGION_HINT = 'Please specify a region parameter.'
+
+# Argument names redacted from tool-entry logs.
+_SENSITIVE_LOG_KEYS = frozenset({'_token', 'password', 'secret', 'key'})
+
 
 def _get_jwt_token() -> str | None:
     """Get JWT token from FastMCP auth context if available.
@@ -133,7 +145,7 @@ def _resolve_region_jwt(
     if available_regions:
         return None, (
             f'Multiple regions available in token: {", ".join(available_regions)}. '
-            f'Please specify a region parameter.'
+            f'{_SPECIFY_REGION_HINT}'
         )
     return None, 'No regions found in JWT token.'
 
@@ -161,7 +173,7 @@ def _resolve_region_local(workspace: str | None) -> tuple[str | None, str | None
     if available_regions:
         return None, (
             f'Multiple regions available: {", ".join(sorted(available_regions))}. '
-            f'Please specify a region parameter.'
+            f'{_SPECIFY_REGION_HINT}'
         )
     return None, 'No regions configured. Please run setup first.'
 
@@ -231,7 +243,7 @@ def _validate_uuid_list(field: str, value: Any) -> dict[str, Any] | None:
         return format_validation_error(
             field,
             value,
-            'Must be a list of server UUIDs.',
+            _UUID_LIST_TYPE_MSG,
         )
 
     invalid = [item for item in value if not validate_server_id_format(item)]
@@ -239,7 +251,7 @@ def _validate_uuid_list(field: str, value: Any) -> dict[str, Any] | None:
         return format_validation_error(
             field,
             invalid,
-            'Each server ID must be in UUID format. (e.g., 550e8400-e29b-41d4-a716-446655440000)',
+            _UUID_LIST_ITEM_MSG,
         )
     return None
 
@@ -317,7 +329,7 @@ def with_token_validation(func: Callable) -> Callable:
 
         # Validate UUID list arguments if present
         # ('servers' carries server UUIDs sent in request bodies)
-        for field in ('server_ids', 'servers'):
+        for field in _UUID_LIST_FIELDS:
             value = arguments.get(field)
             if value is not None:
                 validation_error = _validate_uuid_list(field, value)
@@ -455,11 +467,7 @@ def with_logging(func: Callable) -> Callable:
         arguments = bound_args.arguments
 
         # Create log-safe arguments (exclude sensitive data)
-        log_args = {
-            k: v
-            for k, v in arguments.items()
-            if k not in ['_token', 'password', 'secret', 'key']
-        }
+        log_args = {k: v for k, v in arguments.items() if k not in _SENSITIVE_LOG_KEYS}
 
         # Log function entry
         logger.info(f'{func_name} called with: {log_args}')

--- a/utils/decorators.py
+++ b/utils/decorators.py
@@ -28,11 +28,6 @@ from utils.logger import get_logger
 
 logger = get_logger('decorators')
 
-# Order is the reporting order when more than one is invalid.
-_UUID_LIST_FIELDS = ('server_ids', 'servers')
-_UUID_LIST_TYPE_MSG = 'Must be a list of server UUIDs.'
-_UUID_LIST_ITEM_MSG = 'Each server ID must be in UUID format. (e.g., 550e8400-e29b-41d4-a716-446655440000)'
-
 _SPECIFY_REGION_HINT = 'Please specify a region parameter.'
 
 _SENSITIVE_LOG_KEYS = frozenset({'_token', 'password', 'secret', 'key'})
@@ -142,7 +137,7 @@ def _resolve_region_jwt(
     if available_regions:
         return None, (
             f'Multiple regions available in token: {", ".join(available_regions)}. '
-            f'{_SPECIFY_REGION_HINT}'
+            + _SPECIFY_REGION_HINT
         )
     return None, 'No regions found in JWT token.'
 
@@ -170,7 +165,7 @@ def _resolve_region_local(workspace: str | None) -> tuple[str | None, str | None
     if available_regions:
         return None, (
             f'Multiple regions available: {", ".join(sorted(available_regions))}. '
-            f'{_SPECIFY_REGION_HINT}'
+            + _SPECIFY_REGION_HINT
         )
     return None, 'No regions configured. Please run setup first.'
 
@@ -240,7 +235,7 @@ def _validate_uuid_list(field: str, value: Any) -> dict[str, Any] | None:
         return format_validation_error(
             field,
             value,
-            _UUID_LIST_TYPE_MSG,
+            'Must be a list of server UUIDs.',
         )
 
     invalid = [item for item in value if not validate_server_id_format(item)]
@@ -248,7 +243,8 @@ def _validate_uuid_list(field: str, value: Any) -> dict[str, Any] | None:
         return format_validation_error(
             field,
             invalid,
-            _UUID_LIST_ITEM_MSG,
+            'Each server ID must be in UUID format. '
+            '(e.g., 550e8400-e29b-41d4-a716-446655440000)',
         )
     return None
 
@@ -325,7 +321,8 @@ def with_token_validation(func: Callable) -> Callable:
             return format_validation_error('server_id', server_id)
 
         # 'servers' carries server UUIDs sent in request bodies.
-        for field in _UUID_LIST_FIELDS:
+        # Tuple order is the reporting order when both are invalid.
+        for field in ('server_ids', 'servers'):
             value = arguments.get(field)
             if value is not None:
                 validation_error = _validate_uuid_list(field, value)

--- a/utils/http_client.py
+++ b/utils/http_client.py
@@ -13,8 +13,7 @@ from utils.logger import get_logger
 
 logger = get_logger('http_client')
 
-# Values of the 'error' key on a failure response. Callers branch on these
-# strings, so they are part of the response contract, not just log text.
+# Pinned values: tests assert these verbatim; callers only check that 'error' exists.
 _ERR_HTTP = 'HTTP Error'
 _ERR_MAX_RETRIES = 'Max retries exceeded'
 _ERR_MFA_REQUIRED = 'MFA Required'
@@ -23,11 +22,9 @@ _ERR_REQUEST_EXCEPTION = 'Request Exception'
 _ERR_TIMEOUT = 'Timeout'
 _ERR_UNEXPECTED = 'Unexpected Error'
 
-# Each retry waits this many times longer than the previous one.
 _BACKOFF_MULTIPLIER = 2
 
-# GET endpoints whose responses are cached. Prefixes, matched with startswith.
-# Real-time metrics are deliberately absent.
+# Prefix tuple (str.startswith needs a tuple); real-time metrics deliberately excluded.
 _CACHEABLE_ENDPOINTS = (
     '/api/servers/servers/',
     '/api/system/info/',
@@ -182,12 +179,11 @@ class AlpaconHTTPClient:
         retry_delay = self.retry_delay
 
         async def backoff(reason: str) -> bool:
-            """Count the attempt and sleep; False once retries are exhausted."""
+            """False once retries are exhausted."""
             nonlocal retry_count, retry_delay
             retry_count += 1
             if retry_count >= self.max_retries:
-                # No sleep follows, so don't log a retry that will not happen.
-                # The caller logs the exhaustion with its own error response.
+                # Check before the log: no retry follows, and the caller logs the exhaustion.
                 return False
             logger.warning(
                 f'{reason}, retrying ({retry_count}/{self.max_retries}) in {retry_delay}s'
@@ -643,14 +639,8 @@ class AlpaconHTTPClient:
             source,
         )
 
-        # Signal middleware AND raise exception in remote (streamable-http) mode.
-        # Uses a module-level thread-safe dict keyed by token hash instead
-        # of contextvars, because MCP streamable-http runs tool handlers in
-        # a separate anyio task context where ContextVar mutations are
-        # invisible to the ASGI middleware's parent context.
-        # Only signal for JWT (Bearer) tokens — API tokens (token=...) use
-        # a different auth scheme and the middleware cannot derive a matching
-        # key from them, which would leave unconsumed entries.
+        # Token-hash dict, not contextvars: streamable-http runs handlers in a separate anyio task where ContextVar writes are invisible to the ASGI middleware.
+        # JWT only — the middleware cannot derive a matching key from API tokens, so their entries would go unconsumed.
         if auth_enabled and token and is_jwt:
             from utils.error_handler import (
                 UpstreamAuthError,

--- a/utils/http_client.py
+++ b/utils/http_client.py
@@ -322,6 +322,19 @@ class AlpaconHTTPClient:
         retry_count = 0
         retry_delay = self.retry_delay
 
+        async def backoff(reason: str) -> bool:
+            """Count the attempt and sleep; False once retries are exhausted."""
+            nonlocal retry_count, retry_delay
+            retry_count += 1
+            logger.warning(
+                f'{reason}, retrying ({retry_count}/{self.max_retries}) in {retry_delay}s'
+            )
+            if retry_count >= self.max_retries:
+                return False
+            await asyncio.sleep(retry_delay)
+            retry_delay = min(retry_delay * 2, self.max_retry_delay)
+            return True
+
         # Log request details (without sensitive data)
         logger.info(f'HTTP {method} request to {url}')
         logger.debug(
@@ -392,14 +405,16 @@ class AlpaconHTTPClient:
 
                 if e.response.status_code >= 500:
                     # Server error - retry
-                    retry_count += 1
-                    logger.warning(
-                        f'Server error, retrying ({retry_count}/{self.max_retries}) in {retry_delay}s'
-                    )
-                    if retry_count < self.max_retries:
-                        await asyncio.sleep(retry_delay)
-                        retry_delay = min(retry_delay * 2, self.max_retry_delay)
+                    if await backoff('Server error'):
                         continue
+
+                    error_response = {
+                        'error': 'Max retries exceeded',
+                        'status_code': e.response.status_code,
+                        'message': f'Server error after {self.max_retries} attempts',
+                    }
+                    logger.error(f'Server error after all retries: {error_response}')
+                    return error_response
                 else:
                     # Client error - don't retry
                     if e.response.status_code == 401:
@@ -416,36 +431,24 @@ class AlpaconHTTPClient:
 
             except httpx.TimeoutException:
                 # Timeout - retry
-                retry_count += 1
-                logger.warning(
-                    f'Request timeout, retrying ({retry_count}/{self.max_retries}) in {retry_delay}s'
-                )
-                if retry_count < self.max_retries:
-                    await asyncio.sleep(retry_delay)
-                    retry_delay = min(retry_delay * 2, self.max_retry_delay)
+                if await backoff('Request timeout'):
                     continue
-                else:
-                    error_response = {
-                        'error': 'Timeout',
-                        'message': f'Request timed out after {self.max_retries} retries',
-                    }
-                    logger.error(f'Request timeout after all retries: {error_response}')
-                    return error_response
+
+                error_response = {
+                    'error': 'Timeout',
+                    'message': f'Request timed out after {self.max_retries} retries',
+                }
+                logger.error(f'Request timeout after all retries: {error_response}')
+                return error_response
 
             except httpx.RequestError as e:
                 # Network error - retry
-                retry_count += 1
-                logger.warning(
-                    f'Network error: {e}, retrying ({retry_count}/{self.max_retries}) in {retry_delay}s'
-                )
-                if retry_count < self.max_retries:
-                    await asyncio.sleep(retry_delay)
-                    retry_delay = min(retry_delay * 2, self.max_retry_delay)
+                if await backoff(f'Network error: {e}'):
                     continue
-                else:
-                    error_response = {'error': 'Request Error', 'message': str(e)}
-                    logger.error(f'Network error after all retries: {error_response}')
-                    return error_response
+
+                error_response = {'error': 'Request Error', 'message': str(e)}
+                logger.error(f'Network error after all retries: {error_response}')
+                return error_response
 
             except Exception as e:
                 # Unexpected error - don't retry
@@ -453,12 +456,12 @@ class AlpaconHTTPClient:
                 logger.error(f'Unexpected error: {error_response}', exc_info=True)
                 return error_response
 
-        # Should not reach here, but just in case
+        # Every branch above returns, so this is only reached when max_retries <= 0
         error_response = {
             'error': 'Max retries exceeded',
             'message': f'Failed after {self.max_retries} attempts',
         }
-        logger.error(f'Unexpected fallback - max retries exceeded: {error_response}')
+        logger.error(f'Loop never ran - max_retries is {self.max_retries}')
         return error_response
 
     async def batch_request(

--- a/utils/http_client.py
+++ b/utils/http_client.py
@@ -13,6 +13,31 @@ from utils.logger import get_logger
 
 logger = get_logger('http_client')
 
+# Values of the 'error' key on a failure response. Callers branch on these
+# strings, so they are part of the response contract, not just log text.
+_ERR_HTTP = 'HTTP Error'
+_ERR_MAX_RETRIES = 'Max retries exceeded'
+_ERR_MFA_REQUIRED = 'MFA Required'
+_ERR_REQUEST = 'Request Error'
+_ERR_REQUEST_EXCEPTION = 'Request Exception'
+_ERR_TIMEOUT = 'Timeout'
+_ERR_UNEXPECTED = 'Unexpected Error'
+
+# Each retry waits this many times longer than the previous one.
+_BACKOFF_MULTIPLIER = 2
+
+# GET endpoints whose responses are cached. Prefixes, matched with startswith.
+# Real-time metrics are deliberately absent.
+_CACHEABLE_ENDPOINTS = (
+    '/api/servers/servers/',
+    '/api/system/info/',
+    '/api/system/users/',
+    '/api/system/packages/',
+    '/api/iam/users/',
+    '/api/iam/groups/',
+    '/api/iam/roles/',
+)
+
 
 class AlpaconHTTPClient:
     """Async HTTP client for Alpacon API with connection pooling and caching."""
@@ -168,7 +193,7 @@ class AlpaconHTTPClient:
                 f'{reason}, retrying ({retry_count}/{self.max_retries}) in {retry_delay}s'
             )
             await asyncio.sleep(retry_delay)
-            retry_delay = min(retry_delay * 2, self.max_retry_delay)
+            retry_delay = min(retry_delay * _BACKOFF_MULTIPLIER, self.max_retry_delay)
             return True
 
         # Log request details (without sensitive data)
@@ -245,7 +270,7 @@ class AlpaconHTTPClient:
                         continue
 
                     error_response = {
-                        'error': 'Max retries exceeded',
+                        'error': _ERR_MAX_RETRIES,
                         'status_code': e.response.status_code,
                         'message': f'Server error after {self.max_retries} attempts',
                     }
@@ -257,7 +282,7 @@ class AlpaconHTTPClient:
                         return self._handle_upstream_401(e, token=token)
 
                     error_response = {
-                        'error': 'HTTP Error',
+                        'error': _ERR_HTTP,
                         'status_code': e.response.status_code,
                         'message': str(e),
                         'response': e.response.text,
@@ -271,7 +296,7 @@ class AlpaconHTTPClient:
                     continue
 
                 error_response = {
-                    'error': 'Timeout',
+                    'error': _ERR_TIMEOUT,
                     'message': f'Request timed out after {self.max_retries} retries',
                 }
                 logger.error(f'Request timeout after all retries: {error_response}')
@@ -282,19 +307,19 @@ class AlpaconHTTPClient:
                 if await backoff(f'Network error: {e}'):
                     continue
 
-                error_response = {'error': 'Request Error', 'message': str(e)}
+                error_response = {'error': _ERR_REQUEST, 'message': str(e)}
                 logger.error(f'Network error after all retries: {error_response}')
                 return error_response
 
             except Exception as e:
                 # Unexpected error - don't retry
-                error_response = {'error': 'Unexpected Error', 'message': str(e)}
+                error_response = {'error': _ERR_UNEXPECTED, 'message': str(e)}
                 logger.error(f'Unexpected error: {error_response}', exc_info=True)
                 return error_response
 
         # Every branch above returns, so this is only reached when max_retries <= 0
         error_response = {
-            'error': 'Max retries exceeded',
+            'error': _ERR_MAX_RETRIES,
             'message': f'Failed after {self.max_retries} attempts',
         }
         logger.error(f'Loop never ran - max_retries is {self.max_retries}')
@@ -365,7 +390,7 @@ class AlpaconHTTPClient:
             if isinstance(result, Exception):
                 processed_results.append(
                     {
-                        'error': 'Request Exception',
+                        'error': _ERR_REQUEST_EXCEPTION,
                         'message': str(result),
                         'request_index': i,
                     }
@@ -538,18 +563,7 @@ class AlpaconHTTPClient:
         if method != 'GET':
             return False
 
-        # Cache server lists, system info, but not real-time metrics
-        cacheable_endpoints = [
-            '/api/servers/servers/',
-            '/api/system/info/',
-            '/api/system/users/',
-            '/api/system/packages/',
-            '/api/iam/users/',
-            '/api/iam/groups/',
-            '/api/iam/roles/',
-        ]
-
-        return any(endpoint.startswith(cacheable) for cacheable in cacheable_endpoints)
+        return endpoint.startswith(_CACHEABLE_ENDPOINTS)
 
     def _get_cached_response(self, cache_key: str) -> dict[str, Any] | None:
         """Get cached response if still valid.
@@ -671,7 +685,7 @@ class AlpaconHTTPClient:
         )
         error_msg = 'MFA verification required' if mfa_required else str(exc)
         error_response = {
-            'error': 'MFA Required' if mfa_required else 'HTTP Error',
+            'error': _ERR_MFA_REQUIRED if mfa_required else _ERR_HTTP,
             'status_code': 401,
             'message': error_msg,
             'mfa_required': mfa_required,

--- a/utils/http_client.py
+++ b/utils/http_client.py
@@ -37,24 +37,15 @@ class AlpaconHTTPClient:
             f'AlpaconHTTPClient initialized - timeout: {self.base_timeout.read}s, max_retries: {self.max_retries}, caching enabled'
         )
 
-    async def _get_client(self) -> httpx.AsyncClient:
-        """Get or create shared async client for connection pooling."""
-        # For testing compatibility, check if client pooling is disabled
-        if hasattr(self, '_disable_pooling') and self._disable_pooling:
-            return httpx.AsyncClient(timeout=self.base_timeout)
+    async def __aenter__(self):
+        """Async context manager entry."""
+        return self
 
-        async with self._client_lock:
-            if self._client is None or self._client.is_closed:
-                self._client = httpx.AsyncClient(
-                    timeout=self.base_timeout,
-                    limits=httpx.Limits(
-                        max_keepalive_connections=20,
-                        max_connections=100,
-                        keepalive_expiry=30.0,
-                    ),
-                )
-                logger.debug('Created new HTTP client with connection pooling')
-            return self._client
+    async def __aexit__(self, exc_type, exc_val, exc_tb):
+        """Async context manager exit - close client."""
+        await self._close_client()
+
+    # __del__ removed: lifespan handles cleanup via close()
 
     async def close(self):
         """Close the HTTP client and clear caches.
@@ -83,163 +74,6 @@ class AlpaconHTTPClient:
     def cache_size(self) -> int:
         """Number of entries in the response cache."""
         return len(self._cache)
-
-    def _get_cache_key(self, method: str, url: str, params: dict | None = None) -> str:
-        """Generate cache key for request."""
-        key_parts = [method, url]
-        if params:
-            key_parts.append(json.dumps(params, sort_keys=True))
-        return '|'.join(key_parts)
-
-    def _is_cacheable(self, method: str, endpoint: str) -> bool:
-        """Check if request should be cached."""
-        if method != 'GET':
-            return False
-
-        # Cache server lists, system info, but not real-time metrics
-        cacheable_endpoints = [
-            '/api/servers/servers/',
-            '/api/system/info/',
-            '/api/system/users/',
-            '/api/system/packages/',
-            '/api/iam/users/',
-            '/api/iam/groups/',
-            '/api/iam/roles/',
-        ]
-
-        return any(endpoint.startswith(cacheable) for cacheable in cacheable_endpoints)
-
-    def _get_cached_response(self, cache_key: str) -> dict[str, Any] | None:
-        """Get cached response if still valid.
-
-        Uses .get() for resilient reads to avoid KeyError if close()
-        clears the cache concurrently.
-        """
-        if time.time() > self._cache_ttl.get(cache_key, 0):
-            # Cache expired or missing
-            self._cache.pop(cache_key, None)
-            self._cache_ttl.pop(cache_key, None)
-            return None
-
-        result = self._cache.get(cache_key)
-        if result is not None:
-            logger.debug(f'Cache hit for key: {cache_key}')
-        return result
-
-    def _set_cached_response(
-        self, cache_key: str, response: dict[str, Any], ttl: float | None = None
-    ):
-        """Cache response with TTL."""
-        self._cache[cache_key] = response
-        self._cache_ttl[cache_key] = time.time() + (ttl or self.default_cache_ttl)
-        logger.debug(f'Cached response for key: {cache_key}')
-
-    @staticmethod
-    def _is_jwt(token: str) -> bool:
-        """Check if a token is a JWT (header.payload.signature format)."""
-        parts = token.split('.')
-        return len(parts) == 3 and all(parts)
-
-    @staticmethod
-    def _handle_upstream_401(
-        exc: httpx.HTTPStatusError, token: str | None = None
-    ) -> dict[str, Any]:
-        """Handle upstream API 401 responses.
-
-        Detects MFA-required errors from the Alpacon API response body
-        and triggers re-authentication in remote (streamable-http) mode
-        via two complementary mechanisms:
-
-        1. Dict-based signal: Sets a module-level flag keyed by token hash
-           that the ASGI middleware consumes after the request completes.
-        2. Exception: Raises UpstreamAuthError which propagates through
-           the call stack to the middleware's try/except handler.
-
-        The exception path is the primary mechanism (more reliable across
-        anyio task boundaries). The dict signal is a fallback for edge
-        cases where the exception might be caught by intermediate handlers.
-
-        In stdio/SSE mode (auth not enabled), only returns an error dict
-        without signaling or raising.
-        """
-        mfa_required = False
-        source = ''
-
-        try:
-            body = exc.response.json()
-            if isinstance(body, dict) and body.get('code') == 'auth_mfa_required':
-                mfa_required = True
-                source = body.get('source', '')
-        except Exception as parse_exc:
-            logger.debug('Failed to parse 401 response body as JSON: %s', parse_exc)
-
-        auth_enabled = is_auth_enabled()
-        is_jwt = bool(token and AlpaconHTTPClient._is_jwt(token))
-
-        # DEBUG: Log all decision factors for 401 handling
-        logger.warning(
-            '[DEBUG-401] auth_enabled=%s, token_present=%s, is_jwt=%s, '
-            'mfa_required=%s, source=%s',
-            auth_enabled,
-            bool(token),
-            is_jwt,
-            mfa_required,
-            source,
-        )
-
-        # Signal middleware AND raise exception in remote (streamable-http) mode.
-        # Uses a module-level thread-safe dict keyed by token hash instead
-        # of contextvars, because MCP streamable-http runs tool handlers in
-        # a separate anyio task context where ContextVar mutations are
-        # invisible to the ASGI middleware's parent context.
-        # Only signal for JWT (Bearer) tokens — API tokens (token=...) use
-        # a different auth scheme and the middleware cannot derive a matching
-        # key from them, which would leave unconsumed entries.
-        if auth_enabled and token and is_jwt:
-            from utils.error_handler import (
-                UpstreamAuthError,
-                make_auth_error_key,
-                signal_upstream_auth_error,
-            )
-
-            token_key = make_auth_error_key(token)
-            logger.warning(
-                '[DEBUG-401] Setting dict signal with token_key=%s',
-                token_key,
-            )
-            signal_upstream_auth_error(
-                token_key,
-                {
-                    'mfa_required': mfa_required,
-                    'source': source,
-                },
-            )
-            logger.warning(
-                '[DEBUG-401] Raising UpstreamAuthError (mfa_required=%s, source=%s)',
-                mfa_required,
-                source,
-            )
-            raise UpstreamAuthError(mfa_required=mfa_required, source=source)
-
-        logger.warning(
-            '[DEBUG-401] NOT signaling/raising — falling through to error dict. '
-            'auth_enabled=%s, is_jwt=%s',
-            auth_enabled,
-            is_jwt,
-        )
-        error_msg = 'MFA verification required' if mfa_required else str(exc)
-        error_response = {
-            'error': 'MFA Required' if mfa_required else 'HTTP Error',
-            'status_code': 401,
-            'message': error_msg,
-            'mfa_required': mfa_required,
-        }
-        logger.error(
-            'Upstream 401 (mfa_required=%s, source=%s), not retrying',
-            mfa_required,
-            source,
-        )
-        return error_response
 
     def get_base_url(self, region: str, workspace: str) -> str:
         """Get base URL for API calls.
@@ -671,15 +505,181 @@ class AlpaconHTTPClient:
 
         return await self.request(method='DELETE', url=full_url, token=token)
 
-    async def __aenter__(self):
-        """Async context manager entry."""
-        return self
+    async def _get_client(self) -> httpx.AsyncClient:
+        """Get or create shared async client for connection pooling."""
+        # For testing compatibility, check if client pooling is disabled
+        if hasattr(self, '_disable_pooling') and self._disable_pooling:
+            return httpx.AsyncClient(timeout=self.base_timeout)
 
-    async def __aexit__(self, exc_type, exc_val, exc_tb):
-        """Async context manager exit - close client."""
-        await self._close_client()
+        async with self._client_lock:
+            if self._client is None or self._client.is_closed:
+                self._client = httpx.AsyncClient(
+                    timeout=self.base_timeout,
+                    limits=httpx.Limits(
+                        max_keepalive_connections=20,
+                        max_connections=100,
+                        keepalive_expiry=30.0,
+                    ),
+                )
+                logger.debug('Created new HTTP client with connection pooling')
+            return self._client
 
-    # __del__ removed: lifespan handles cleanup via close()
+    def _get_cache_key(self, method: str, url: str, params: dict | None = None) -> str:
+        """Generate cache key for request."""
+        key_parts = [method, url]
+        if params:
+            key_parts.append(json.dumps(params, sort_keys=True))
+        return '|'.join(key_parts)
+
+    def _is_cacheable(self, method: str, endpoint: str) -> bool:
+        """Check if request should be cached."""
+        if method != 'GET':
+            return False
+
+        # Cache server lists, system info, but not real-time metrics
+        cacheable_endpoints = [
+            '/api/servers/servers/',
+            '/api/system/info/',
+            '/api/system/users/',
+            '/api/system/packages/',
+            '/api/iam/users/',
+            '/api/iam/groups/',
+            '/api/iam/roles/',
+        ]
+
+        return any(endpoint.startswith(cacheable) for cacheable in cacheable_endpoints)
+
+    def _get_cached_response(self, cache_key: str) -> dict[str, Any] | None:
+        """Get cached response if still valid.
+
+        Uses .get() for resilient reads to avoid KeyError if close()
+        clears the cache concurrently.
+        """
+        if time.time() > self._cache_ttl.get(cache_key, 0):
+            # Cache expired or missing
+            self._cache.pop(cache_key, None)
+            self._cache_ttl.pop(cache_key, None)
+            return None
+
+        result = self._cache.get(cache_key)
+        if result is not None:
+            logger.debug(f'Cache hit for key: {cache_key}')
+        return result
+
+    def _set_cached_response(
+        self, cache_key: str, response: dict[str, Any], ttl: float | None = None
+    ):
+        """Cache response with TTL."""
+        self._cache[cache_key] = response
+        self._cache_ttl[cache_key] = time.time() + (ttl or self.default_cache_ttl)
+        logger.debug(f'Cached response for key: {cache_key}')
+
+    @staticmethod
+    def _is_jwt(token: str) -> bool:
+        """Check if a token is a JWT (header.payload.signature format)."""
+        parts = token.split('.')
+        return len(parts) == 3 and all(parts)
+
+    @staticmethod
+    def _handle_upstream_401(
+        exc: httpx.HTTPStatusError, token: str | None = None
+    ) -> dict[str, Any]:
+        """Handle upstream API 401 responses.
+
+        Detects MFA-required errors from the Alpacon API response body
+        and triggers re-authentication in remote (streamable-http) mode
+        via two complementary mechanisms:
+
+        1. Dict-based signal: Sets a module-level flag keyed by token hash
+           that the ASGI middleware consumes after the request completes.
+        2. Exception: Raises UpstreamAuthError which propagates through
+           the call stack to the middleware's try/except handler.
+
+        The exception path is the primary mechanism (more reliable across
+        anyio task boundaries). The dict signal is a fallback for edge
+        cases where the exception might be caught by intermediate handlers.
+
+        In stdio/SSE mode (auth not enabled), only returns an error dict
+        without signaling or raising.
+        """
+        mfa_required = False
+        source = ''
+
+        try:
+            body = exc.response.json()
+            if isinstance(body, dict) and body.get('code') == 'auth_mfa_required':
+                mfa_required = True
+                source = body.get('source', '')
+        except Exception as parse_exc:
+            logger.debug('Failed to parse 401 response body as JSON: %s', parse_exc)
+
+        auth_enabled = is_auth_enabled()
+        is_jwt = bool(token and AlpaconHTTPClient._is_jwt(token))
+
+        # DEBUG: Log all decision factors for 401 handling
+        logger.warning(
+            '[DEBUG-401] auth_enabled=%s, token_present=%s, is_jwt=%s, '
+            'mfa_required=%s, source=%s',
+            auth_enabled,
+            bool(token),
+            is_jwt,
+            mfa_required,
+            source,
+        )
+
+        # Signal middleware AND raise exception in remote (streamable-http) mode.
+        # Uses a module-level thread-safe dict keyed by token hash instead
+        # of contextvars, because MCP streamable-http runs tool handlers in
+        # a separate anyio task context where ContextVar mutations are
+        # invisible to the ASGI middleware's parent context.
+        # Only signal for JWT (Bearer) tokens — API tokens (token=...) use
+        # a different auth scheme and the middleware cannot derive a matching
+        # key from them, which would leave unconsumed entries.
+        if auth_enabled and token and is_jwt:
+            from utils.error_handler import (
+                UpstreamAuthError,
+                make_auth_error_key,
+                signal_upstream_auth_error,
+            )
+
+            token_key = make_auth_error_key(token)
+            logger.warning(
+                '[DEBUG-401] Setting dict signal with token_key=%s',
+                token_key,
+            )
+            signal_upstream_auth_error(
+                token_key,
+                {
+                    'mfa_required': mfa_required,
+                    'source': source,
+                },
+            )
+            logger.warning(
+                '[DEBUG-401] Raising UpstreamAuthError (mfa_required=%s, source=%s)',
+                mfa_required,
+                source,
+            )
+            raise UpstreamAuthError(mfa_required=mfa_required, source=source)
+
+        logger.warning(
+            '[DEBUG-401] NOT signaling/raising — falling through to error dict. '
+            'auth_enabled=%s, is_jwt=%s',
+            auth_enabled,
+            is_jwt,
+        )
+        error_msg = 'MFA verification required' if mfa_required else str(exc)
+        error_response = {
+            'error': 'MFA Required' if mfa_required else 'HTTP Error',
+            'status_code': 401,
+            'message': error_msg,
+            'mfa_required': mfa_required,
+        }
+        logger.error(
+            'Upstream 401 (mfa_required=%s, source=%s), not retrying',
+            mfa_required,
+            source,
+        )
+        return error_response
 
 
 # Singleton instance

--- a/utils/http_client.py
+++ b/utils/http_client.py
@@ -160,11 +160,13 @@ class AlpaconHTTPClient:
             """Count the attempt and sleep; False once retries are exhausted."""
             nonlocal retry_count, retry_delay
             retry_count += 1
+            if retry_count >= self.max_retries:
+                # No sleep follows, so don't log a retry that will not happen.
+                # The caller logs the exhaustion with its own error response.
+                return False
             logger.warning(
                 f'{reason}, retrying ({retry_count}/{self.max_retries}) in {retry_delay}s'
             )
-            if retry_count >= self.max_retries:
-                return False
             await asyncio.sleep(retry_delay)
             retry_delay = min(retry_delay * 2, self.max_retry_delay)
             return True

--- a/utils/http_client.py
+++ b/utils/http_client.py
@@ -22,8 +22,6 @@ _ERR_REQUEST_EXCEPTION = 'Request Exception'
 _ERR_TIMEOUT = 'Timeout'
 _ERR_UNEXPECTED = 'Unexpected Error'
 
-_BACKOFF_MULTIPLIER = 2
-
 # Prefix tuple (str.startswith needs a tuple); real-time metrics deliberately excluded.
 _CACHEABLE_ENDPOINTS = (
     '/api/servers/servers/',
@@ -45,6 +43,7 @@ class AlpaconHTTPClient:
         self.max_retries = 3
         self.retry_delay = 1.0
         self.max_retry_delay = 30.0
+        self.backoff_multiplier = 2.0
 
         # Connection pooling
         self._client: httpx.AsyncClient | None = None
@@ -189,7 +188,9 @@ class AlpaconHTTPClient:
                 f'{reason}, retrying ({retry_count}/{self.max_retries}) in {retry_delay}s'
             )
             await asyncio.sleep(retry_delay)
-            retry_delay = min(retry_delay * _BACKOFF_MULTIPLIER, self.max_retry_delay)
+            retry_delay = min(
+                retry_delay * self.backoff_multiplier, self.max_retry_delay
+            )
             return True
 
         # Log request details (without sensitive data)


### PR DESCRIPTION
## Background

Two duplication sites in `utils/`, plus one layout problem that made the first one hard to see.

In `AlpaconHTTPClient.request()`, the 5xx, timeout, and network handlers each repeated the same four lines: bump `retry_count`, log the attempt, sleep, double the delay capped at `max_retry_delay`. The three copies were not byte-identical — the log messages differed and each handler ended differently — which is what let a real defect hide in the 5xx arm.

In `utils/decorators.py`, the `server_ids` and `servers` arguments were validated by two blocks that differed only in variable names: same `isinstance` list guard, same comprehension over `validate_server_id_format`, same two error strings.

Separately, `AlpaconHTTPClient` interleaved public and private members. `__aenter__` and `__aexit__` sat at the very end of the class, roughly 250 lines below the `_close_client` they call, and the four private cache helpers split `close()` from `get_base_url()`.

A third pass over the same two files turned up inline literals of the same kind: values repeated across sites, or rebuilt on every call. `_is_cacheable()` reconstructed a seven-element list of endpoint prefixes on each of the up to three calls per request, and `with_logging` rebuilt its redaction list per tool call.

## What changed

Ten commits, one concern each.

`ba7bb63` adds a local `backoff()` closure inside `request()` that owns the count/log/sleep/double sequence and returns `False` once the attempts are spent. Each handler is left with only its own exhaustion arm.

`8788207` extracts `_validate_uuid_list(field, value)` and drives both arguments through a loop over `('server_ids', 'servers')`.

`0859978` moves the exhaustion check ahead of the retry log inside `backoff()`, so the last failed attempt no longer announces a retry that will not happen.

`0960d49` regroups the class members: lifecycle (`__init__`, the async context manager pair, `close`, `_close_client`), then properties, then public API, then private helpers last. The `__del__ removed` note moves with the lifecycle block.

`29700ae` names the inline literals. In `utils/http_client.py`: the seven `error` codes, the backoff multiplier, and `_CACHEABLE_ENDPOINTS`, now a tuple so it feeds `str.startswith` directly and the `any()` generator goes away. In `utils/decorators.py`: the two UUID validation messages, the field tuple driving the loop, the sentence shared by both "multiple regions available" errors, and the redaction keys, now a `frozenset` matching the `_WORK_SESSION_GATE_CODES` shape in `utils/common.py`. `ba16afb` walks three of these back.

`24d23d2` trims the comments in these two files, keeping only the ones stating something the code cannot. Mostly the ones the earlier commits added, plus one pre-existing block: the eight lines in `_handle_upstream_401` explaining the token-hash dict opened by restating the docstring three lines above them, so they go down to two.

`4e40dcc` adds a test for the 5xx exhaustion response, which the three existing tests only assert the `error` key of. It drives the real exhaustion path and pins the status code, the domain `_detect_error_domain` resolves, and the exact hints `enrich_error_response` attaches.

`ba16afb` reverses the three constants from `29700ae` that bought nothing. `_BACKOFF_MULTIPLIER` had one call site 167 lines from its definition and was the wrong shape besides — the other three retry knobs are instance attributes, so the multiplier joins them as `self.backoff_multiplier`. The two UUID messages were already deduped by `8788207`, whose `_validate_uuid_list` is their only reader, so hoisting them moved the text ~210 lines from its sole use site without removing a duplicate; they go back inline, and `_UUID_LIST_FIELDS` follows. The two `f'{_SPECIFY_REGION_HINT}'` sites become implicit concatenation of the plain name. What survives from `29700ae` is what earns it: `_CACHEABLE_ENDPOINTS` and `_SENSITIVE_LOG_KEYS` remove a per-call rebuild, the seven `_ERR_*` are a contract catalog pinned by 17 test assertions, and `_SPECIFY_REGION_HINT` itself has two call sites.

`283c326` fixes the test `4e40dcc` added. It called `enrich_error_response` without `tool_name`, but the live path in `with_error_handling` always passes it and `_detect_error_domain` reads `tool_name` ahead of the message, so the webftp and command tools resolve to `file` and `command` rather than the `server` the message alone implies. It changes nothing today — `_HINT_REGISTRY` has only a `(500, 'general')` entry, so every domain falls through to the same hints — but adding a `(500, 'server')` or `(500, 'file')` entry would change what those tools receive while a test pinning the no-argument call kept passing. The test now walks three tool names covering the three domains and asserts both the domain each resolves to and that the hints still converge.

`2456f32` drops the backoff sleep from the four tests that exhaust the retries. `test_get_500_error`, the domain test above, `test_network_timeout`, and `test_connection_error` were 12s of an 18.5s suite, and none of them tests the timing. A `no_retry_delay` fixture zeroes `retry_delay` via `monkeypatch` — a direct write would leak, since `http_client` is a module-level singleton.

## Behavior

Two deliberate fixes, one added field with a downstream effect of its own, otherwise unchanged.

The 5xx branch had no exhaustion arm. When retries ran out it fell out of the loop into the tail fallback, which logged `Unexpected fallback` even though three tests assert exactly that path as the normal outcome (`tests/test_http_client.py:148`, `tests/integration/test_http_client_integration.py:40` and `:171`). It now returns in place, and the tail return — reachable only when `max_retries <= 0` — has its comment and log corrected to say so.

That in-place 5xx response also carries `status_code`, which the old tail response dropped. The `error` key stays `'Max retries exceeded'` because the three tests above assert on it.

The added `status_code` is not inert, and neither is the accompanying message change from `'Failed after N attempts'` to `'Server error after N attempts'`. Both are read downstream: `utils/common.py:292` lifts `status_code` into the error `unwrap_http_result` returns, and `utils/recovery_hints.py:220` reads it while `utils/decorators.py:407` runs `enrich_error_response` over every decorated tool result. The message is also an input to `_detect_error_domain`, which keys on the substring `server`. So a 5xx exhaustion that previously enriched to `['error', 'message']` with no hints now enriches to `['error', 'message', 'recovery_hints', 'status_code']` with two server hints. This is a third deliberate delta, not a payload detail: the agent now gets actionable guidance where it previously got a bare string. `tests/test_http_client.py:161` pins it, so whoever next edits `message` finds out they moved the domain detection.

The second fix is log-only. `backoff()` counted the attempt, logged `retrying (3/3) in 4.0s`, and only then checked whether the attempts were spent, so the final failure claimed a retry that never followed. The check now comes first and `backoff()` returns without logging; the three callers already log the exhaustion with the same reason, so nothing is lost. All three pre-refactor copies had the same misordering, so this is a pre-existing log defect the consolidation made visible rather than one it introduced. No return value or error payload changes.

The UUID validation loop preserves the original field order, so a call with both arguments invalid still reports `server_ids` first, and the error payload is unchanged.

`29700ae`, `24d23d2`, and `ba16afb` change no behavior. Each constant was checked to equal the literal it replaced byte for byte, and `_is_cacheable` was compared against the old `any(startswith)` form across 32 method/endpoint cases, including case differences, a missing leading slash, and a mid-string match. `24d23d2` touches only comment and docstring lines. The literals `ba16afb` puts back were checked against the parent revision the same way, and `2` becomes `2.0` only to match the float retry knobs it now sits beside — the product was already a float.

One comment introduced by `29700ae` was wrong and `24d23d2` corrects it. It described the error codes as values "callers branch on"; no production consumer does. `utils/common.py:288`, `utils/recovery_hints.py:212`, and `tools/server_tools.py:67` all test only for the presence of the `error` key. What pins the values is 17 verbatim test assertions, which is what the comment says now.

`0960d49` is pure code motion. With blank lines dropped, the 581-line multiset of `utils/http_client.py` is identical before and after — verified by comparing the two revisions directly, the same check documented in `74e90c0`. No signature, body, or import changed.

## Testing

- `uv run --extra dev python -m pytest tests -q`: 954 passed in 6.4s, down from 18.5s.
- `tests/test_http_client.py:161` is new. It drives the real 5xx exhaustion path once per domain and asserts, for each, that `status_code` is on the response, that `_detect_error_domain` resolves the domain the live path would, and that the two hints `enrich_error_response` attaches are the same across all three.
- `uv run --extra dev ruff check .`: clean. `ruff format --check .`: 82 files already formatted.
- `tests/test_input_validation.py:244-340` already covered `server_ids` (invalid, mixed, `None`, non-list) and `servers` (invalid, mixed), so the extraction is exercised unmodified.
- `tests/test_shutdown.py:59-70` tests `_close_client()` as a backward-compat alias, which is why it stays next to `close()` rather than moving to the private-helper group.
- The forward hazard the domain test guards was checked rather than assumed: injecting a `(500, 'file')` entry into `_HINT_REGISTRY` and running that test alone fails it. Without `tool_name` it kept passing.

Two literals were deliberately left inline. The PyJWT decode-options dict in `_decode_jwt_claims` looks constant, but PyJWT 2.13.0's `_merge_options` writes `verify_nbf`, `verify_iat`, `verify_sub`, and `verify_jti` back into the caller's dict when `verify_signature` is false, so a module-level constant would be mutated by the library on every call. The `401` and `500` status codes stay as integers because `http.HTTPStatus` would put an `IntEnum` into the response dict, which the log f-strings render as `<HTTPStatus.UNAUTHORIZED: 401>`.

## Checklist

- [x] The three backoff copies were compared before collapsing them; the differences are called out above rather than assumed away
- [x] The 5xx behavior change is intentional and named, not incidental, down to what the added `status_code` and the new message do to the enriched response
- [x] The retry-log fix was checked against the rest of the codebase; no other log announces an action before the guard that decides it
- [x] The constants preserve their literals byte for byte, verified against the parent revision
- [x] One inaccurate comment was found and corrected rather than carried forward
- [x] Three constants from `29700ae` were walked back once review showed they bought nothing; the ones that survive each have a stated reason
- [x] The new test mirrors the live `enrich_error_response` call rather than a shape no caller uses
- [x] Code motion verified pure by line-multiset comparison
- [x] Tests pass locally, lint and format clean
- [x] No new dependencies
