### PR TITLE
Pin mcp below 2.0 to unblock CI

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -540,7 +540,7 @@ Workflow guides that teach an agent the Alpacon operating discipline (Work Sessi
 ## Dependencies
 
 **Runtime dependencies** (from `pyproject.toml`):
-- `mcp>=1.9.4`: Model Context Protocol framework
+- `mcp>=1.28.1,<2`: Model Context Protocol framework (upper bound: 2.0 renamed `mcp.server.fastmcp` to `mcp.server.mcpserver`; see #144)
 - `httpx>=0.27.1`: Async HTTP client
 - `PyJWT[crypto]>=2.10.1`: JWT token verification
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -40,7 +40,8 @@ classifiers = [
     "Environment :: Console",
 ]
 dependencies = [
-    "mcp>=1.28.1",
+    # mcp 2.0 renamed mcp.server.fastmcp to mcp.server.mcpserver; pinned until migrated
+    "mcp>=1.28.1,<2",
     "httpx>=0.27.1",
     "PyJWT[crypto]>=2.10.1",
 ]

--- a/uv.lock
+++ b/uv.lock
@@ -40,7 +40,7 @@ requires-dist = [
     { name = "flake8", marker = "extra == 'dev'", specifier = ">=6.0.0" },
     { name = "httpx", specifier = ">=0.27.1" },
     { name = "isort", marker = "extra == 'dev'", specifier = ">=5.12.0" },
-    { name = "mcp", specifier = ">=1.28.1" },
+    { name = "mcp", specifier = ">=1.28.1,<2" },
     { name = "mypy", marker = "extra == 'dev'", specifier = ">=1.0.0" },
     { name = "pyjwt", extras = ["crypto"], specifier = ">=2.10.1" },
     { name = "pytest", marker = "extra == 'dev'", specifier = ">=7.0.0" },
@@ -596,10 +596,10 @@ resolution-markers = [
     "python_full_version < '3.14' and sys_platform != 'win32'",
 ]
 dependencies = [
-    { name = "annotated-types", marker = "python_full_version < '3.14'" },
-    { name = "pydantic-core", version = "2.33.2", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.14'" },
-    { name = "typing-extensions", version = "4.14.0", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.14'" },
-    { name = "typing-inspection", version = "0.4.1", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.14'" },
+    { name = "annotated-types" },
+    { name = "pydantic-core", version = "2.33.2", source = { registry = "https://pypi.org/simple" } },
+    { name = "typing-extensions", version = "4.14.0", source = { registry = "https://pypi.org/simple" } },
+    { name = "typing-inspection", version = "0.4.1", source = { registry = "https://pypi.org/simple" } },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/00/dd/4325abf92c39ba8623b5af936ddb36ffcfe0beae70405d456ab1fb2f5b8c/pydantic-2.11.7.tar.gz", hash = "sha256:d989c3c6cb79469287b1569f7447a17848c998458d49ebe294e975b9baf0f0db", size = 788350, upload-time = "2025-06-14T08:33:17.137Z" }
 wheels = [
@@ -615,10 +615,10 @@ resolution-markers = [
     "python_full_version >= '3.14' and sys_platform != 'win32'",
 ]
 dependencies = [
-    { name = "annotated-types", marker = "python_full_version >= '3.14'" },
-    { name = "pydantic-core", version = "2.46.4", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.14'" },
-    { name = "typing-extensions", version = "4.16.0", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.14'" },
-    { name = "typing-inspection", version = "0.4.2", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.14'" },
+    { name = "annotated-types" },
+    { name = "pydantic-core", version = "2.46.4", source = { registry = "https://pypi.org/simple" } },
+    { name = "typing-extensions", version = "4.16.0", source = { registry = "https://pypi.org/simple" } },
+    { name = "typing-inspection", version = "0.4.2", source = { registry = "https://pypi.org/simple" } },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/18/a5/b60d21ac674192f8ab0ba4e9fd860690f9b4a6e51ca5df118733b487d8d6/pydantic-2.13.4.tar.gz", hash = "sha256:c40756b57adaa8b1efeeced5c196f3f3b7c435f90e84ea7f443901bec8099ef6", size = 844775, upload-time = "2026-05-06T13:43:05.343Z" }
 wheels = [
@@ -634,7 +634,7 @@ resolution-markers = [
     "python_full_version < '3.14' and sys_platform != 'win32'",
 ]
 dependencies = [
-    { name = "typing-extensions", version = "4.14.0", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.14'" },
+    { name = "typing-extensions", version = "4.14.0", source = { registry = "https://pypi.org/simple" } },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/ad/88/5f2260bdfae97aabf98f1778d43f69574390ad787afb646292a638c923d4/pydantic_core-2.33.2.tar.gz", hash = "sha256:7cb8bc3605c29176e1b105350d2e6474142d7c1bd1d9327c4a9bdb46bf827acc", size = 435195, upload-time = "2025-04-23T18:33:52.104Z" }
 wheels = [
@@ -680,7 +680,7 @@ resolution-markers = [
     "python_full_version >= '3.14' and sys_platform != 'win32'",
 ]
 dependencies = [
-    { name = "typing-extensions", version = "4.16.0", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.14'" },
+    { name = "typing-extensions", version = "4.16.0", source = { registry = "https://pypi.org/simple" } },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/9d/56/921726b776ace8d8f5db44c4ef961006580d91dc52b803c489fafd1aa249/pydantic_core-2.46.4.tar.gz", hash = "sha256:62f875393d7f270851f20523dd2e29f082bcc82292d66db2b64ea71f64b6e1c1", size = 471464, upload-time = "2026-05-06T13:37:06.98Z" }
 wheels = [
@@ -1068,7 +1068,7 @@ resolution-markers = [
     "python_full_version < '3.14' and sys_platform != 'win32'",
 ]
 dependencies = [
-    { name = "typing-extensions", version = "4.14.0", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.14'" },
+    { name = "typing-extensions", version = "4.14.0", source = { registry = "https://pypi.org/simple" } },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/f8/b1/0c11f5058406b3af7609f121aaa6b609744687f1d158b3c3a5bf4cc94238/typing_inspection-0.4.1.tar.gz", hash = "sha256:6ae134cc0203c33377d43188d4064e9b357dba58cff3185f22924610e70a9d28", size = 75726, upload-time = "2025-05-21T18:55:23.885Z" }
 wheels = [
@@ -1084,7 +1084,7 @@ resolution-markers = [
     "python_full_version >= '3.14' and sys_platform != 'win32'",
 ]
 dependencies = [
-    { name = "typing-extensions", version = "4.16.0", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.14'" },
+    { name = "typing-extensions", version = "4.16.0", source = { registry = "https://pypi.org/simple" } },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/55/e3/70399cb7dd41c10ac53367ae42139cf4b1ca5f36bb3dc6c9d33acdb43655/typing_inspection-0.4.2.tar.gz", hash = "sha256:ba561c48a67c5958007083d386c3295464928b01faa735ab8547c5692e87f464", size = 75949, upload-time = "2025-10-01T02:14:41.687Z" }
 wheels = [


### PR DESCRIPTION
## Background

The `mcp` Python SDK released [2.0.0](https://github.com/modelcontextprotocol/python-sdk/releases/tag/v2.0.0) on 2026-07-28, which drops the `mcp.server.fastmcp` package. Inspecting the 2.0.0 wheel, the package was renamed to `mcp.server.mcpserver` (its `__init__.py` docstring reads "MCPServer - A more ergonomic interface for MCP servers") and `mcp/server/fastmcp/` is gone. The release notes put it as "`FastMCP` is now `MCPServer`" and state the decorator API itself is unchanged.

The same notes prescribe exactly this fix for projects that are not ready yet: "If your project is not ready to migrate, keep a `<2` upper bound on your requirement (for example `mcp>=1.28,<2`)."

`pyproject.toml` declared `mcp>=1.28.1` with no upper bound, and the Test workflow installs with `uv pip install -e .[dev]`, which ignores `uv.lock`. So CI resolved 2.0.0 on the next run and `server.py:9` failed:

```
server.py:9: in <module>
    from mcp.server.fastmcp import FastMCP
E   ModuleNotFoundError: No module named 'mcp.server.fastmcp'
...
Interrupted: 21 errors during collection
```

Every test module that reaches `server.py` failed at collection. Nothing in this repo changed; the break came from upstream.

## Changes

`pyproject.toml`: `mcp>=1.28.1` to `mcp>=1.28.1,<2`, with a one-line comment naming the rename so the bound is not removed by accident. `uv.lock` re-generated with `uv lock`. The floor is unchanged; `mcp>=1.28.1` is what `main` already declared, set by 4d459b7 ("fix(deps): resolve Dependabot security alerts").

`CLAUDE.md`: the Dependencies section listed `mcp>=1.9.4` under a heading that says the values come from `pyproject.toml`. It was two steps stale — it missed 4d459b7 raising the floor to 1.28.1, and it would now also miss the bound. Updated to `mcp>=1.28.1,<2`.

The lockfile diff is 26 lines, but only one of them is the specifier. The other 24 drop `marker = "python_full_version ..."` from the `dependencies` entries of the pydantic packages, and that is uv-version churn rather than an effect of the bound. Isolating it: editing an unrelated specifier (`httpx`, leaving `mcp` alone) produces the same 26 lines and the same 12 marker removals, while a `pyproject.toml` edit that leaves `requires-dist` untouched produces none — so any re-resolution triggers it, regardless of what changed. Re-locking this exact change with uv 0.11.21 gives a 2-line diff and no marker removals, against 26 lines on uv 0.11.32, so the committed lock was written in the older format. `mcp` itself stays at 1.28.1 in the lock and the pydantic versions are unchanged, so nothing about the resolution changes semantically. Happy to re-lock on 0.11.21 to keep the diff at the specifier line if reviewers prefer the smaller diff.

## Testing

In a clean venv built the way CI builds one:

- `uv pip install --dry-run -e ".[dev]"` resolves `mcp==1.29.0`, not 2.0.0
- The 1.29.0 wheel still ships `mcp/server/fastmcp/{__init__,exceptions,server}.py`
- Full suite: 952 passed, 2 failed

The 2 failures (`tests/test_basic.py::test_import_main`, `tests/test_simple_integration.py::TestMCPServerConfiguration::test_main_entry_point`) reproduce on `main` without this change and are local-only. The repo root ships a committed `__init__.py`, so pytest walks the package boundary up past the repo root and prepends the repo's parent directory to `sys.path`; on my machine the clone directory is named `main`, so `import main` resolves to that directory package instead of `main.py`. CI clones into `alpacon-mcp`, so the name collision does not occur there.

## Follow-up

This only holds the 1.x line, and the 1.x line is now in maintenance mode: per the release notes it lives on the [`v1.x` branch](https://github.com/modelcontextprotocol/python-sdk/tree/v1.x) and receives critical bug fixes and security patches only. So the pin buys time, not an indefinite stay.

Migrating to the 2.0 API (`server.py`, `utils/decorators.py`, resource/prompt registration, the http/sse entry points, and the ASGI auth middleware) is tracked in #144, which is also where the `<2` bound should be dropped. #144 additionally notes that CI installing from `pyproject.toml` rather than `uv.lock` is what let an upstream major release reach the test job at all.

Upstream references for that work: [What's new in v2](https://py.sdk.modelcontextprotocol.io/whats-new/) and the [migration guide](https://py.sdk.modelcontextprotocol.io/migration/), which lists the breaking changes with before-and-after code. Beyond the rename, the notes flag several things worth checking against this repo: `httpx` and `httpx-sse` are replaced by `httpx2>=2.5.0` (we import `httpx` directly in `utils/http_client.py` and elsewhere), `mcp/types.py` becomes the separate `mcp_types` package with `mcp.types` kept as a permanent alias, `pydantic` moves to `>=2.12.0`, `pydantic-settings` is dropped, the websocket transports and `mcp.shared.session` are removed, and Streamable HTTP servers reject request bodies over 4 MiB with HTTP 413.
