### PR TITLE
fix(oauth): sign and verify the OAuth state parameter

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -216,7 +216,7 @@ python main_sse.py
 - HTTP-based transport for hosting a remote MCP server
 - Authenticates clients with Auth0 JWT (browser OAuth)—no `token.json` or API token on the client
 - `main_http.py` validates `AUTH0_DOMAIN` and `AUTH0_CLIENT_ID` at startup; the OAuth proxy endpoints additionally require `AUTH0_CLIENT_SECRET`, and accept an optional `AUTH0_AUDIENCE` (default `https://alpacon.io/access/`)
-- The OAuth `state` parameter is signed and expires after 10 minutes. The signing key is derived from `AUTH0_CLIENT_SECRET` by default; set the optional `ALPACON_MCP_STATE_SECRET` to use an explicit key instead
+- The OAuth `state` parameter is signed and expires after 10 minutes. The signing key is derived from `AUTH0_CLIENT_SECRET` by default; set the optional `ALPACON_MCP_STATE_SECRET` to use an explicit key instead. It must be hex decoding to at least 32 bytes, matching what the derived key always is—generate it with `openssl rand -hex 32` rather than typing a passphrase, because the state travels in URLs and proxy logs and a guessable key is an offline brute-force target. A value that is not hex, or is shorter, is rejected when the OAuth endpoints first sign or verify a state
 - Alpacon operates a managed instance at `https://mcp.alpacon.io/mcp`
 
 ```bash

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -216,6 +216,7 @@ python main_sse.py
 - HTTP-based transport for hosting a remote MCP server
 - Authenticates clients with Auth0 JWT (browser OAuth)—no `token.json` or API token on the client
 - `main_http.py` validates `AUTH0_DOMAIN` and `AUTH0_CLIENT_ID` at startup; the OAuth proxy endpoints additionally require `AUTH0_CLIENT_SECRET`, and accept an optional `AUTH0_AUDIENCE` (default `https://alpacon.io/access/`)
+- The OAuth `state` parameter is signed and expires after 10 minutes. The signing key is derived from `AUTH0_CLIENT_SECRET` by default; set the optional `ALPACON_MCP_STATE_SECRET` to use an explicit key instead
 - Alpacon operates a managed instance at `https://mcp.alpacon.io/mcp`
 
 ```bash

--- a/tests/test_oauth.py
+++ b/tests/test_oauth.py
@@ -60,25 +60,38 @@ def _set_oauth_env():
         yield
 
 
+class MockMCPServer:
+    """Stands in for FastMCP, collecting whatever register_oauth_routes registers."""
+
+    def __init__(self):
+        self.routes = []
+
+    def custom_route(self, path, methods=None):
+        def decorator(func):
+            self.routes.append(Route(path, func, methods=methods))
+            return func
+
+        return decorator
+
+
 @pytest.fixture
 def oauth_app():
     """Create a minimal Starlette app with OAuth routes registered."""
-    routes = []
-
-    class MockMCPServer:
-        def custom_route(self, path, methods=None):
-            def decorator(func):
-                routes.append(Route(path, func, methods=methods))
-                return func
-
-            return decorator
-
     mock_server = MockMCPServer()
-
     register_oauth_routes(mock_server)
+    return TestClient(
+        Starlette(routes=mock_server.routes), raise_server_exceptions=False
+    )
 
-    app = Starlette(routes=routes)
-    return TestClient(app, raise_server_exceptions=False)
+
+def _forge_state_under_valid_signature():
+    """A state whose payload was swapped out after signing, keeping the signature."""
+    signed = _sign_state({'redirect_uri': TRUSTED_REDIRECT_URI})
+    _, _, signature = signed.rpartition('.')
+    forged = base64.urlsafe_b64encode(
+        json.dumps({'redirect_uri': EVIL_REDIRECT_URI, 'exp': FAR_FUTURE_EXP}).encode()
+    ).decode()
+    return f'{forged}.{signature}'
 
 
 def _mock_auth0_response(status_code=200, json_data=None):
@@ -110,10 +123,6 @@ class TestStateSecret:
         assert _get_state_secret() == _get_state_secret()
 
     def test_registration_logs_state_secret_source(self, caplog):
-        class MockMCPServer:
-            def custom_route(self, path, methods=None):
-                return lambda func: func
-
         with caplog.at_level('INFO'):
             register_oauth_routes(MockMCPServer())
 
@@ -134,14 +143,7 @@ class TestStateEnvelope:
         assert payload['exp'] <= int(time.time()) + _STATE_TTL_SECONDS
 
     def test_tampered_payload_is_rejected(self):
-        signed = _sign_state({'redirect_uri': TRUSTED_REDIRECT_URI, 'state': ''})
-        _, _, sig = signed.rpartition('.')
-        forged = base64.urlsafe_b64encode(
-            json.dumps(
-                {'redirect_uri': EVIL_REDIRECT_URI, 'exp': FAR_FUTURE_EXP}
-            ).encode()
-        ).decode()
-        assert _verify_state(f'{forged}.{sig}') is None
+        assert _verify_state(_forge_state_under_valid_signature()) is None
 
     def test_unsigned_state_is_rejected(self):
         unsigned = base64.urlsafe_b64encode(
@@ -538,16 +540,6 @@ class TestOAuthToken:
 
     def test_token_fails_without_client_secret(self):
         """Token endpoint should return 500 when AUTH0_CLIENT_SECRET is missing."""
-        routes = []
-
-        class MockMCPServer:
-            def custom_route(self, path, methods=None):
-                def decorator(func):
-                    routes.append(Route(path, func, methods=methods))
-                    return func
-
-                return decorator
-
         env_without_secret = {
             'AUTH0_DOMAIN': TEST_AUTH0_DOMAIN,
             'AUTH0_CLIENT_ID': TEST_CLIENT_ID,
@@ -561,7 +553,7 @@ class TestOAuthToken:
             # Unset AUTH0_CLIENT_SECRET if present
             with patch.dict('os.environ', {'AUTH0_CLIENT_SECRET': ''}, clear=False):
                 register_oauth_routes(mock_server)
-                app = Starlette(routes=routes)
+                app = Starlette(routes=mock_server.routes)
                 client = TestClient(app, raise_server_exceptions=False)
                 response = client.post(
                     '/oauth/token',
@@ -805,16 +797,9 @@ class TestOAuthCallback:
 
     def test_callback_rejects_tampered_state(self, oauth_app):
         """Swapping the payload under a valid signature must be rejected."""
-        signed = _sign_state({'redirect_uri': TRUSTED_REDIRECT_URI})
-        _, _, sig = signed.rpartition('.')
-        forged = base64.urlsafe_b64encode(
-            json.dumps(
-                {'redirect_uri': EVIL_REDIRECT_URI, 'exp': FAR_FUTURE_EXP}
-            ).encode()
-        ).decode()
         response = oauth_app.get(
             '/oauth/callback',
-            params={'code': 'auth-code', 'state': f'{forged}.{sig}'},
+            params={'code': 'auth-code', 'state': _forge_state_under_valid_signature()},
             follow_redirects=False,
         )
         assert response.status_code == 400

--- a/tests/test_oauth.py
+++ b/tests/test_oauth.py
@@ -7,11 +7,27 @@ error handling).
 """
 
 import base64
+import hashlib
+import hmac
 import json
+import time
 from unittest.mock import AsyncMock, MagicMock, patch
+from urllib.parse import parse_qs, urlparse
 
 import pytest
+from starlette.applications import Starlette
+from starlette.routing import Route
 from starlette.testclient import TestClient
+
+from utils.oauth import (
+    _STATE_SECRET_INFO,
+    _STATE_TTL_SECONDS,
+    _build_state,
+    _get_state_secret,
+    _sign_state,
+    _verify_state,
+    register_oauth_routes,
+)
 
 # Test configuration constants
 TEST_AUTH0_DOMAIN = 'test.us.auth0.com'
@@ -40,9 +56,6 @@ def _set_oauth_env():
 @pytest.fixture
 def oauth_app():
     """Create a minimal Starlette app with OAuth routes registered."""
-    from starlette.applications import Starlette
-    from starlette.routing import Route
-
     routes = []
 
     class MockMCPServer:
@@ -54,8 +67,6 @@ def oauth_app():
             return decorator
 
     mock_server = MockMCPServer()
-
-    from utils.oauth import register_oauth_routes
 
     register_oauth_routes(mock_server)
 
@@ -79,30 +90,19 @@ class TestStateSecret:
     """Tests for state signing key derivation."""
 
     def test_explicit_env_secret_wins(self):
-        from utils.oauth import _get_state_secret
-
         with patch.dict('os.environ', {'ALPACON_MCP_STATE_SECRET': 'explicit-key'}):
             assert _get_state_secret() == b'explicit-key'
 
     def test_derives_from_client_secret_when_env_unset(self):
-        import hashlib
-        import hmac
-
-        from utils.oauth import _STATE_SECRET_INFO, _get_state_secret
-
         expected = hmac.new(
             TEST_CLIENT_SECRET.encode(), _STATE_SECRET_INFO, hashlib.sha256
         ).digest()
         assert _get_state_secret() == expected
 
     def test_derived_secret_is_deterministic(self):
-        from utils.oauth import _get_state_secret
-
         assert _get_state_secret() == _get_state_secret()
 
     def test_registration_logs_state_secret_source(self, caplog):
-        from utils.oauth import register_oauth_routes
-
         class MockMCPServer:
             def custom_route(self, path, methods=None):
                 return lambda func: func
@@ -117,24 +117,16 @@ class TestStateEnvelope:
     """Tests for state signing and verification."""
 
     def test_round_trip_preserves_payload(self):
-        from utils.oauth import _sign_state, _verify_state
-
         signed = _sign_state({'redirect_uri': 'https://claude.ai/cb', 'state': 'xyz'})
         payload = _verify_state(signed)
         assert payload['redirect_uri'] == 'https://claude.ai/cb'
         assert payload['state'] == 'xyz'
 
     def test_sign_adds_expiry(self):
-        import time
-
-        from utils.oauth import _STATE_TTL_SECONDS, _sign_state, _verify_state
-
         payload = _verify_state(_sign_state({'state': 'xyz'}))
         assert payload['exp'] <= int(time.time()) + _STATE_TTL_SECONDS
 
     def test_tampered_payload_is_rejected(self):
-        from utils.oauth import _sign_state, _verify_state
-
         signed = _sign_state({'redirect_uri': 'https://claude.ai/cb', 'state': ''})
         _, _, sig = signed.rpartition('.')
         forged = base64.urlsafe_b64encode(
@@ -145,37 +137,27 @@ class TestStateEnvelope:
         assert _verify_state(f'{forged}.{sig}') is None
 
     def test_unsigned_state_is_rejected(self):
-        from utils.oauth import _verify_state
-
         unsigned = base64.urlsafe_b64encode(
             json.dumps({'redirect_uri': 'https://evil.com/cb'}).encode()
         ).decode()
         assert _verify_state(unsigned) is None
 
     def test_wrong_signature_is_rejected(self):
-        from utils.oauth import _sign_state, _verify_state
-
         encoded, _, _ = _sign_state({'state': 'xyz'}).rpartition('.')
         assert _verify_state(f'{encoded}.bm90LWEtc2ln') is None
 
     def test_expired_state_is_rejected(self):
-        from utils.oauth import _sign_state, _verify_state
-
         with patch('utils.oauth.time.time', return_value=1000):
             signed = _sign_state({'state': 'xyz'})
         with patch('utils.oauth.time.time', return_value=99999999):
             assert _verify_state(signed) is None
 
     def test_malformed_state_is_rejected(self):
-        from utils.oauth import _verify_state
-
         assert _verify_state('not-a-state') is None
         assert _verify_state('') is None
 
     def test_non_ascii_state_is_rejected(self):
         """hmac.compare_digest raises TypeError on non-ASCII str, so compare bytes."""
-        from utils.oauth import _verify_state
-
         assert _verify_state('payload.서명') is None
 
 
@@ -183,15 +165,11 @@ class TestBuildState:
     """Tests for state payload assembly."""
 
     def test_carries_redirect_uri_and_client_state(self):
-        from utils.oauth import _build_state, _verify_state
-
         decoded = _verify_state(_build_state('https://claude.ai/cb', 'xyz'))
         assert decoded['redirect_uri'] == 'https://claude.ai/cb'
         assert decoded['state'] == 'xyz'
 
     def test_carries_extra_flow_fields(self):
-        from utils.oauth import _build_state, _verify_state
-
         decoded = _verify_state(
             _build_state('', '', stage='mfa', original_scope='openid')
         )
@@ -250,8 +228,6 @@ class TestOAuthAuthorize:
 
     def test_authorize_overrides_redirect_uri_to_server_callback(self, oauth_app):
         """redirect_uri sent to Auth0 should be the MCP server's own callback."""
-        from urllib.parse import parse_qs, urlparse
-
         response = oauth_app.get(
             '/oauth/authorize',
             params={
@@ -267,8 +243,6 @@ class TestOAuthAuthorize:
 
     def test_authorize_stores_client_redirect_uri_in_state(self, oauth_app):
         """Client's original redirect_uri should be encoded in the state param."""
-        from urllib.parse import parse_qs, urlparse
-
         client_uri = 'http://localhost:52048/callback'
         response = oauth_app.get(
             '/oauth/authorize',
@@ -283,8 +257,6 @@ class TestOAuthAuthorize:
         parsed = urlparse(location)
         params = parse_qs(parsed.query)
         composite_state = params['state'][0]
-        from utils.oauth import _verify_state
-
         state_data = _verify_state(composite_state)
         assert state_data['redirect_uri'] == client_uri
         assert state_data['state'] == 'original-state'
@@ -453,8 +425,6 @@ class TestOAuthAuthorize:
         )
         assert response.status_code == 302
         location = response.headers['location']
-        from urllib.parse import parse_qs, urlparse
-
         parsed = urlparse(location)
         params = parse_qs(parsed.query)
         # Should redirect to MFA audience with enroll scope
@@ -465,8 +435,6 @@ class TestOAuthAuthorize:
         assert 'read:authenticators' in scope_value
         # State should contain stage='mfa'
         state = params.get('state', [''])[0]
-        from utils.oauth import _verify_state
-
         state_data = _verify_state(state)
         assert state_data.get('stage') == 'mfa'
 
@@ -483,8 +451,6 @@ class TestOAuthAuthorize:
         )
         assert response.status_code == 302
         location = response.headers['location']
-        from urllib.parse import parse_qs, urlparse
-
         parsed = urlparse(location)
         params = parse_qs(parsed.query)
         audience = params.get('audience', [''])[0]
@@ -565,9 +531,6 @@ class TestOAuthToken:
 
     def test_token_fails_without_client_secret(self):
         """Token endpoint should return 500 when AUTH0_CLIENT_SECRET is missing."""
-        from starlette.applications import Starlette
-        from starlette.routing import Route
-
         routes = []
 
         class MockMCPServer:
@@ -590,8 +553,6 @@ class TestOAuthToken:
         with patch.dict('os.environ', env_without_secret, clear=False):
             # Unset AUTH0_CLIENT_SECRET if present
             with patch.dict('os.environ', {'AUTH0_CLIENT_SECRET': ''}, clear=False):
-                from utils.oauth import register_oauth_routes
-
                 register_oauth_routes(mock_server)
                 app = Starlette(routes=routes)
                 client = TestClient(app, raise_server_exceptions=False)
@@ -801,8 +762,6 @@ class TestOAuthFallbackRoutes:
 
 def _make_composite_state(redirect_uri='', state='', **extra):
     """Helper to create signed composite state as the authorize endpoint does."""
-    from utils.oauth import _sign_state
-
     return _sign_state({'redirect_uri': redirect_uri, 'state': state, **extra})
 
 
@@ -839,8 +798,6 @@ class TestOAuthCallback:
 
     def test_callback_rejects_tampered_state(self, oauth_app):
         """Swapping the payload under a valid signature must be rejected."""
-        from utils.oauth import _sign_state
-
         signed = _sign_state({'redirect_uri': 'https://claude.ai/cb'})
         _, _, sig = signed.rpartition('.')
         forged = base64.urlsafe_b64encode(
@@ -977,8 +934,6 @@ class TestOAuthCallback:
 
         assert response.status_code == 302
         location = response.headers['location']
-        from urllib.parse import parse_qs, urlparse
-
         parsed = urlparse(location)
         params = parse_qs(parsed.query)
 
@@ -994,8 +949,6 @@ class TestOAuthCallback:
 
         # State should contain stage='regular'
         state = params.get('state', [''])[0]
-        from utils.oauth import _verify_state
-
         state_data = _verify_state(state)
         assert state_data.get('stage') == 'regular'
         assert state_data.get('redirect_uri') == 'http://localhost:8080/callback'

--- a/tests/test_oauth.py
+++ b/tests/test_oauth.py
@@ -111,8 +111,19 @@ class TestStateSecret:
     """Tests for state signing key derivation."""
 
     def test_explicit_env_secret_wins(self):
-        with patch.dict('os.environ', {_STATE_SECRET_ENV: 'explicit-key'}):
-            assert _get_state_secret() == b'explicit-key'
+        with patch.dict('os.environ', {_STATE_SECRET_ENV: 'a1' * 32}):
+            assert _get_state_secret() == b'\xa1' * 32
+
+    def test_rejects_non_hex_explicit_secret(self):
+        # A typed passphrase is the weak key this check exists to keep out.
+        with patch.dict('os.environ', {_STATE_SECRET_ENV: 'correct-horse-battery'}):
+            with pytest.raises(ValueError, match='must be hex'):
+                _get_state_secret()
+
+    def test_rejects_short_explicit_secret(self):
+        with patch.dict('os.environ', {_STATE_SECRET_ENV: 'a1' * 31}):
+            with pytest.raises(ValueError, match='at least 32 bytes'):
+                _get_state_secret()
 
     def test_derives_from_client_secret_when_env_unset(self):
         expected = hmac.new(

--- a/tests/test_oauth.py
+++ b/tests/test_oauth.py
@@ -316,6 +316,20 @@ class TestOAuthAuthorize:
         assert data['error'] == 'invalid_request'
         assert 'trusted' in data['error_description']
 
+    def test_authorize_reports_malformed_state_secret(self, oauth_app):
+        """Signing is the first place a bad key raises; the message must survive."""
+        with patch.dict('os.environ', {_STATE_SECRET_ENV: 'correct-horse-battery'}):
+            response = oauth_app.get(
+                '/oauth/authorize',
+                params={
+                    'response_type': 'code',
+                    'redirect_uri': 'http://localhost:52048/callback',
+                },
+                follow_redirects=False,
+            )
+        assert response.status_code == 500
+        assert 'must be hex' in response.json()['error']
+
     def test_authorize_allows_claude_ai_redirect_uri(self, oauth_app):
         """Claude web redirect_uri should be allowed as a trusted domain."""
         response = oauth_app.get(

--- a/tests/test_oauth.py
+++ b/tests/test_oauth.py
@@ -75,6 +75,130 @@ def _mock_auth0_response(status_code=200, json_data=None):
     return mock_client
 
 
+class TestStateSecret:
+    """Tests for state signing key derivation."""
+
+    def test_explicit_env_secret_wins(self):
+        from utils.oauth import _get_state_secret
+
+        with patch.dict('os.environ', {'ALPACON_MCP_STATE_SECRET': 'explicit-key'}):
+            assert _get_state_secret() == b'explicit-key'
+
+    def test_derives_from_client_secret_when_env_unset(self):
+        import hashlib
+        import hmac
+
+        from utils.oauth import _STATE_SECRET_INFO, _get_state_secret
+
+        expected = hmac.new(
+            TEST_CLIENT_SECRET.encode(), _STATE_SECRET_INFO, hashlib.sha256
+        ).digest()
+        assert _get_state_secret() == expected
+
+    def test_derived_secret_is_deterministic(self):
+        from utils.oauth import _get_state_secret
+
+        assert _get_state_secret() == _get_state_secret()
+
+    def test_registration_logs_state_secret_source(self, caplog):
+        from utils.oauth import register_oauth_routes
+
+        class MockMCPServer:
+            def custom_route(self, path, methods=None):
+                return lambda func: func
+
+        with caplog.at_level('INFO'):
+            register_oauth_routes(MockMCPServer())
+
+        assert 'derived from client secret' in caplog.text
+
+
+class TestStateEnvelope:
+    """Tests for state signing and verification."""
+
+    def test_round_trip_preserves_payload(self):
+        from utils.oauth import _sign_state, _verify_state
+
+        signed = _sign_state({'redirect_uri': 'https://claude.ai/cb', 'state': 'xyz'})
+        payload = _verify_state(signed)
+        assert payload['redirect_uri'] == 'https://claude.ai/cb'
+        assert payload['state'] == 'xyz'
+
+    def test_sign_adds_expiry(self):
+        import time
+
+        from utils.oauth import _STATE_TTL_SECONDS, _sign_state, _verify_state
+
+        payload = _verify_state(_sign_state({'state': 'xyz'}))
+        assert payload['exp'] <= int(time.time()) + _STATE_TTL_SECONDS
+
+    def test_tampered_payload_is_rejected(self):
+        from utils.oauth import _sign_state, _verify_state
+
+        signed = _sign_state({'redirect_uri': 'https://claude.ai/cb', 'state': ''})
+        _, _, sig = signed.rpartition('.')
+        forged = base64.urlsafe_b64encode(
+            json.dumps(
+                {'redirect_uri': 'https://evil.com/cb', 'exp': 9999999999}
+            ).encode()
+        ).decode()
+        assert _verify_state(f'{forged}.{sig}') is None
+
+    def test_unsigned_state_is_rejected(self):
+        from utils.oauth import _verify_state
+
+        unsigned = base64.urlsafe_b64encode(
+            json.dumps({'redirect_uri': 'https://evil.com/cb'}).encode()
+        ).decode()
+        assert _verify_state(unsigned) is None
+
+    def test_wrong_signature_is_rejected(self):
+        from utils.oauth import _sign_state, _verify_state
+
+        encoded, _, _ = _sign_state({'state': 'xyz'}).rpartition('.')
+        assert _verify_state(f'{encoded}.bm90LWEtc2ln') is None
+
+    def test_expired_state_is_rejected(self):
+        from utils.oauth import _sign_state, _verify_state
+
+        with patch('utils.oauth.time.time', return_value=1000):
+            signed = _sign_state({'state': 'xyz'})
+        with patch('utils.oauth.time.time', return_value=99999999):
+            assert _verify_state(signed) is None
+
+    def test_malformed_state_is_rejected(self):
+        from utils.oauth import _verify_state
+
+        assert _verify_state('not-a-state') is None
+        assert _verify_state('') is None
+
+    def test_non_ascii_state_is_rejected(self):
+        """hmac.compare_digest raises TypeError on non-ASCII str, so compare bytes."""
+        from utils.oauth import _verify_state
+
+        assert _verify_state('payload.서명') is None
+
+
+class TestBuildState:
+    """Tests for state payload assembly."""
+
+    def test_carries_redirect_uri_and_client_state(self):
+        from utils.oauth import _build_state, _verify_state
+
+        decoded = _verify_state(_build_state('https://claude.ai/cb', 'xyz'))
+        assert decoded['redirect_uri'] == 'https://claude.ai/cb'
+        assert decoded['state'] == 'xyz'
+
+    def test_carries_extra_flow_fields(self):
+        from utils.oauth import _build_state, _verify_state
+
+        decoded = _verify_state(
+            _build_state('', '', stage='mfa', original_scope='openid')
+        )
+        assert decoded['stage'] == 'mfa'
+        assert decoded['original_scope'] == 'openid'
+
+
 class TestOAuthMetadata:
     """Tests for /.well-known/oauth-authorization-server endpoint."""
 
@@ -159,7 +283,9 @@ class TestOAuthAuthorize:
         parsed = urlparse(location)
         params = parse_qs(parsed.query)
         composite_state = params['state'][0]
-        state_data = json.loads(base64.urlsafe_b64decode(composite_state))
+        from utils.oauth import _verify_state
+
+        state_data = _verify_state(composite_state)
         assert state_data['redirect_uri'] == client_uri
         assert state_data['state'] == 'original-state'
 
@@ -339,7 +465,9 @@ class TestOAuthAuthorize:
         assert 'read:authenticators' in scope_value
         # State should contain stage='mfa'
         state = params.get('state', [''])[0]
-        state_data = json.loads(base64.urlsafe_b64decode(state.encode()).decode())
+        from utils.oauth import _verify_state
+
+        state_data = _verify_state(state)
         assert state_data.get('stage') == 'mfa'
 
     def test_authorize_without_mfa_scope_uses_regular_audience(self, oauth_app):
@@ -672,9 +800,10 @@ class TestOAuthFallbackRoutes:
 
 
 def _make_composite_state(redirect_uri='', state='', **extra):
-    """Helper to create composite state as the authorize endpoint does."""
-    data = {'redirect_uri': redirect_uri, 'state': state, **extra}
-    return base64.urlsafe_b64encode(json.dumps(data).encode()).decode()
+    """Helper to create signed composite state as the authorize endpoint does."""
+    from utils.oauth import _sign_state
+
+    return _sign_state({'redirect_uri': redirect_uri, 'state': state, **extra})
 
 
 class TestOAuthCallback:
@@ -693,6 +822,60 @@ class TestOAuthCallback:
         assert location.startswith('http://localhost:52048/callback')
         assert 'code=auth-code' in location
         assert 'state=xyz' in location
+
+    def test_callback_rejects_unsigned_state(self, oauth_app):
+        """A state we never signed must not steer the redirect."""
+        unsigned = base64.urlsafe_b64encode(
+            json.dumps({'redirect_uri': 'https://claude.ai/cb', 'state': 'x'}).encode()
+        ).decode()
+        response = oauth_app.get(
+            '/oauth/callback',
+            params={'code': 'auth-code', 'state': unsigned},
+            follow_redirects=False,
+        )
+        assert response.status_code == 400
+        assert response.json()['error'] == 'invalid_request'
+        assert 'location' not in response.headers
+
+    def test_callback_rejects_tampered_state(self, oauth_app):
+        """Swapping the payload under a valid signature must be rejected."""
+        from utils.oauth import _sign_state
+
+        signed = _sign_state({'redirect_uri': 'https://claude.ai/cb'})
+        _, _, sig = signed.rpartition('.')
+        forged = base64.urlsafe_b64encode(
+            json.dumps(
+                {'redirect_uri': 'https://evil.com/cb', 'exp': 9999999999}
+            ).encode()
+        ).decode()
+        response = oauth_app.get(
+            '/oauth/callback',
+            params={'code': 'auth-code', 'state': f'{forged}.{sig}'},
+            follow_redirects=False,
+        )
+        assert response.status_code == 400
+        assert 'location' not in response.headers
+
+    def test_callback_rejects_expired_state(self, oauth_app):
+        """A state past its expiry must be rejected."""
+        with patch('utils.oauth.time.time', return_value=1000):
+            expired = _make_composite_state('http://localhost:52048/callback', 'xyz')
+        response = oauth_app.get(
+            '/oauth/callback',
+            params={'code': 'auth-code', 'state': expired},
+            follow_redirects=False,
+        )
+        assert response.status_code == 400
+
+    def test_callback_reports_missing_config_instead_of_crashing(self, oauth_app):
+        """Missing client secret: same JSON 500 as other handlers, not a stack trace."""
+        with patch.dict('os.environ', {'AUTH0_CLIENT_SECRET': ''}):
+            response = oauth_app.get(
+                '/oauth/callback',
+                params={'code': 'auth-code', 'state': 'aGVsbG8.c2ln'},
+            )
+        assert response.status_code == 500
+        assert 'AUTH0_CLIENT_SECRET' in response.json()['error']
 
     def test_callback_returns_json_without_redirect_uri(self, oauth_app):
         """Without a client redirect_uri in state, return JSON as fallback."""
@@ -737,16 +920,14 @@ class TestOAuthCallback:
         assert response.status_code == 400
         assert response.json()['error'] == 'access_denied'
 
-    def test_callback_handles_invalid_state_gracefully(self, oauth_app):
-        """Invalid composite state should not crash — echoes raw state back."""
+    def test_callback_rejects_opaque_state(self, oauth_app):
+        """A state that is not one of ours is rejected, not echoed back."""
         response = oauth_app.get(
             '/oauth/callback',
             params={'code': 'auth-code', 'state': 'opaque-state-value'},
         )
-        assert response.status_code == 200
-        data = response.json()
-        assert data['code'] == 'auth-code'
-        assert data['state'] == 'opaque-state-value'
+        assert response.status_code == 400
+        assert response.json()['error'] == 'invalid_request'
 
     def test_callback_does_not_redirect_to_untrusted_uri(self, oauth_app):
         """Callback must not redirect to an untrusted redirect_uri from state."""
@@ -813,7 +994,9 @@ class TestOAuthCallback:
 
         # State should contain stage='regular'
         state = params.get('state', [''])[0]
-        state_data = json.loads(base64.urlsafe_b64decode(state.encode()).decode())
+        from utils.oauth import _verify_state
+
+        state_data = _verify_state(state)
         assert state_data.get('stage') == 'regular'
         assert state_data.get('redirect_uri') == 'http://localhost:8080/callback'
         assert state_data.get('state') == 'orig-state'

--- a/tests/test_oauth.py
+++ b/tests/test_oauth.py
@@ -35,6 +35,13 @@ TEST_CLIENT_ID = 'test-client-id'
 TEST_CLIENT_SECRET = 'test-client-secret'
 TEST_RESOURCE_URL = 'https://mcp.test.alpacon.io'
 
+# Redirect targets used across the state tests
+TRUSTED_REDIRECT_URI = 'https://claude.ai/cb'
+EVIL_REDIRECT_URI = 'https://evil.com/cb'
+
+# An exp far enough ahead that a forged payload is never rejected as expired
+FAR_FUTURE_EXP = 9999999999
+
 # Environment variables needed for OAuth config
 OAUTH_ENV = {
     'AUTH0_DOMAIN': TEST_AUTH0_DOMAIN,
@@ -117,9 +124,9 @@ class TestStateEnvelope:
     """Tests for state signing and verification."""
 
     def test_round_trip_preserves_payload(self):
-        signed = _sign_state({'redirect_uri': 'https://claude.ai/cb', 'state': 'xyz'})
+        signed = _sign_state({'redirect_uri': TRUSTED_REDIRECT_URI, 'state': 'xyz'})
         payload = _verify_state(signed)
-        assert payload['redirect_uri'] == 'https://claude.ai/cb'
+        assert payload['redirect_uri'] == TRUSTED_REDIRECT_URI
         assert payload['state'] == 'xyz'
 
     def test_sign_adds_expiry(self):
@@ -127,18 +134,18 @@ class TestStateEnvelope:
         assert payload['exp'] <= int(time.time()) + _STATE_TTL_SECONDS
 
     def test_tampered_payload_is_rejected(self):
-        signed = _sign_state({'redirect_uri': 'https://claude.ai/cb', 'state': ''})
+        signed = _sign_state({'redirect_uri': TRUSTED_REDIRECT_URI, 'state': ''})
         _, _, sig = signed.rpartition('.')
         forged = base64.urlsafe_b64encode(
             json.dumps(
-                {'redirect_uri': 'https://evil.com/cb', 'exp': 9999999999}
+                {'redirect_uri': EVIL_REDIRECT_URI, 'exp': FAR_FUTURE_EXP}
             ).encode()
         ).decode()
         assert _verify_state(f'{forged}.{sig}') is None
 
     def test_unsigned_state_is_rejected(self):
         unsigned = base64.urlsafe_b64encode(
-            json.dumps({'redirect_uri': 'https://evil.com/cb'}).encode()
+            json.dumps({'redirect_uri': EVIL_REDIRECT_URI}).encode()
         ).decode()
         assert _verify_state(unsigned) is None
 
@@ -165,8 +172,8 @@ class TestBuildState:
     """Tests for state payload assembly."""
 
     def test_carries_redirect_uri_and_client_state(self):
-        decoded = _verify_state(_build_state('https://claude.ai/cb', 'xyz'))
-        assert decoded['redirect_uri'] == 'https://claude.ai/cb'
+        decoded = _verify_state(_build_state(TRUSTED_REDIRECT_URI, 'xyz'))
+        assert decoded['redirect_uri'] == TRUSTED_REDIRECT_URI
         assert decoded['state'] == 'xyz'
 
     def test_carries_extra_flow_fields(self):
@@ -785,7 +792,7 @@ class TestOAuthCallback:
     def test_callback_rejects_unsigned_state(self, oauth_app):
         """A state we never signed must not steer the redirect."""
         unsigned = base64.urlsafe_b64encode(
-            json.dumps({'redirect_uri': 'https://claude.ai/cb', 'state': 'x'}).encode()
+            json.dumps({'redirect_uri': TRUSTED_REDIRECT_URI, 'state': 'x'}).encode()
         ).decode()
         response = oauth_app.get(
             '/oauth/callback',
@@ -798,11 +805,11 @@ class TestOAuthCallback:
 
     def test_callback_rejects_tampered_state(self, oauth_app):
         """Swapping the payload under a valid signature must be rejected."""
-        signed = _sign_state({'redirect_uri': 'https://claude.ai/cb'})
+        signed = _sign_state({'redirect_uri': TRUSTED_REDIRECT_URI})
         _, _, sig = signed.rpartition('.')
         forged = base64.urlsafe_b64encode(
             json.dumps(
-                {'redirect_uri': 'https://evil.com/cb', 'exp': 9999999999}
+                {'redirect_uri': EVIL_REDIRECT_URI, 'exp': FAR_FUTURE_EXP}
             ).encode()
         ).decode()
         response = oauth_app.get(
@@ -888,7 +895,7 @@ class TestOAuthCallback:
 
     def test_callback_does_not_redirect_to_untrusted_uri(self, oauth_app):
         """Callback must not redirect to an untrusted redirect_uri from state."""
-        composite = _make_composite_state('https://evil.com/cb', 'xyz')
+        composite = _make_composite_state(EVIL_REDIRECT_URI, 'xyz')
         response = oauth_app.get(
             '/oauth/callback',
             params={'code': 'auth-code', 'state': composite},

--- a/tests/test_oauth.py
+++ b/tests/test_oauth.py
@@ -20,6 +20,7 @@ from starlette.routing import Route
 from starlette.testclient import TestClient
 
 from utils.oauth import (
+    _STATE_SECRET_ENV,
     _STATE_SECRET_INFO,
     _STATE_TTL_SECONDS,
     _build_state,
@@ -110,7 +111,7 @@ class TestStateSecret:
     """Tests for state signing key derivation."""
 
     def test_explicit_env_secret_wins(self):
-        with patch.dict('os.environ', {'ALPACON_MCP_STATE_SECRET': 'explicit-key'}):
+        with patch.dict('os.environ', {_STATE_SECRET_ENV: 'explicit-key'}):
             assert _get_state_secret() == b'explicit-key'
 
     def test_derives_from_client_secret_when_env_unset(self):

--- a/utils/oauth.py
+++ b/utils/oauth.py
@@ -15,6 +15,7 @@ import hmac
 import json
 import os
 import time
+from http import HTTPStatus
 
 import httpx
 
@@ -22,6 +23,13 @@ from utils.logger import get_logger
 
 logger = get_logger('oauth')
 
+
+# Explicit state signing key; when unset, the key is derived from the client secret.
+_STATE_SECRET_ENV = 'ALPACON_MCP_STATE_SECRET'
+
+# Stage tags carried through the state in the two-stage MFA flow.
+_STAGE_MFA = 'mfa'
+_STAGE_REGULAR = 'regular'
 
 # Domain-separates the state key from other keys derived from the client secret.
 _STATE_SECRET_INFO = b'alpacon-mcp-oauth-state-v1'
@@ -138,7 +146,7 @@ def _get_state_secret() -> bytes:
     provisioning; the derived key is identical across replicas, so state
     verifies without shared server-side storage.
     """
-    explicit = os.getenv('ALPACON_MCP_STATE_SECRET', '')
+    explicit = os.getenv(_STATE_SECRET_ENV, '')
     if explicit:
         return explicit.encode()
 
@@ -344,7 +352,7 @@ def register_oauth_routes(mcp_server):
             mfa_params['state'] = _build_state(
                 client_redirect_uri,
                 original_state,
-                stage='mfa',
+                stage=_STAGE_MFA,
                 original_scope=scope,
                 authorize_params=stage2_authorize_params,
             )
@@ -658,7 +666,10 @@ def register_oauth_routes(mcp_server):
             except ValueError as e:
                 # Without an explicit state secret, verification needs the OAuth
                 # config; surface misconfiguration as the other handlers do.
-                return JSONResponse({'error': str(e)}, status_code=500)
+                return JSONResponse(
+                    {'error': str(e)},
+                    status_code=HTTPStatus.INTERNAL_SERVER_ERROR,
+                )
             if state_data is None:
                 logger.warning('Callback rejected an invalid or expired state')
                 return JSONResponse(
@@ -709,7 +720,7 @@ def register_oauth_routes(mcp_server):
             )
 
         # --- Two-stage MFA flow: Stage 1 callback ---
-        if stage == 'mfa':
+        if stage == _STAGE_MFA:
             logger.info(
                 'Stage 1 complete: MFA authorization code received, '
                 'exchanging and proceeding to Stage 2 (regular audience)'
@@ -764,7 +775,7 @@ def register_oauth_routes(mcp_server):
                 'redirect_uri': f'{server_url}/oauth/callback',
                 'scope': original_scope or 'openid profile email offline_access',
                 'state': _build_state(
-                    client_redirect_uri, original_state, stage='regular'
+                    client_redirect_uri, original_state, stage=_STAGE_REGULAR
                 ),
             }
             # Replay PKCE and other client params preserved from Stage 1
@@ -843,6 +854,6 @@ def register_oauth_routes(mcp_server):
         'OAuth proxy routes registered (including /token, /authorize, '
         '/register fallbacks) - state secret: %s',
         'explicit env'
-        if os.getenv('ALPACON_MCP_STATE_SECRET')
+        if os.getenv(_STATE_SECRET_ENV)
         else 'derived from client secret',
     )

--- a/utils/oauth.py
+++ b/utils/oauth.py
@@ -282,13 +282,11 @@ def register_oauth_routes(mcp_server):
         """
         from urllib.parse import urlencode
 
-        from starlette.responses import RedirectResponse
+        from starlette.responses import JSONResponse, RedirectResponse
 
         try:
             config = _get_oauth_config()
         except ValueError as e:
-            from starlette.responses import JSONResponse
-
             return JSONResponse({'error': str(e)}, status_code=500)
 
         # Forward all query parameters to Auth0
@@ -332,8 +330,6 @@ def register_oauth_routes(mcp_server):
         # open redirect attacks while supporting Claude web, ChatGPT, etc.
         client_redirect_uri = params.get('redirect_uri', '')
         if client_redirect_uri and not _is_allowed_redirect_url(client_redirect_uri):
-            from starlette.responses import JSONResponse
-
             return JSONResponse(
                 {
                     'error': 'invalid_request',
@@ -346,46 +342,62 @@ def register_oauth_routes(mcp_server):
 
         original_state = params.get('state', '')
 
-        if mfa_requested:
-            # Two-stage OAuth flow: Stage 1 — redirect to Auth0 MFA audience
-            # to force MFA verification. After MFA completion, the callback
-            # handler will redirect again to the regular audience (Stage 2).
-            mfa_params = {
-                'response_type': 'code',
-                'client_id': config['client_id'],
-                'audience': config['mfa_audience'],
-                'redirect_uri': f'{server_url}/oauth/callback',
-                'scope': 'enroll read:authenticators',
-            }
+        # _build_state signs with the configured key, so a malformed
+        # ALPACON_MCP_STATE_SECRET raises here — on the endpoint an operator
+        # reaches before the callback. Carry the message instead of a bare 500.
+        try:
+            if mfa_requested:
+                # Two-stage OAuth flow: Stage 1 — redirect to Auth0 MFA audience
+                # to force MFA verification. After MFA completion, the callback
+                # handler will redirect again to the regular audience (Stage 2).
+                mfa_params = {
+                    'response_type': 'code',
+                    'client_id': config['client_id'],
+                    'audience': config['mfa_audience'],
+                    'redirect_uri': f'{server_url}/oauth/callback',
+                    'scope': 'enroll read:authenticators',
+                }
 
-            # Preserve PKCE and other client authorize params for Stage 2.
-            # The MCP client's PKCE code_challenge must be replayed when
-            # redirecting to the regular audience so the final code exchange
-            # succeeds with the client's code_verifier.
-            stage2_authorize_params = {}
-            for key in ('code_challenge', 'code_challenge_method', 'nonce', 'resource'):
-                if key in params:
-                    stage2_authorize_params[key] = params[key]
+                # Preserve PKCE and other client authorize params for Stage 2.
+                # The MCP client's PKCE code_challenge must be replayed when
+                # redirecting to the regular audience so the final code exchange
+                # succeeds with the client's code_verifier.
+                stage2_authorize_params = {}
+                for key in (
+                    'code_challenge',
+                    'code_challenge_method',
+                    'nonce',
+                    'resource',
+                ):
+                    if key in params:
+                        stage2_authorize_params[key] = params[key]
 
-            mfa_params['state'] = _build_state(
-                client_redirect_uri,
-                original_state,
-                stage=_STAGE_MFA,
-                original_scope=scope,
-                authorize_params=stage2_authorize_params,
+                mfa_params['state'] = _build_state(
+                    client_redirect_uri,
+                    original_state,
+                    stage=_STAGE_MFA,
+                    original_scope=scope,
+                    authorize_params=stage2_authorize_params,
+                )
+
+                auth0_url = (
+                    f'{config["auth0_base_url"]}/authorize?{urlencode(mfa_params)}'
+                )
+                logger.info(
+                    'Stage 1: Redirecting to Auth0 MFA audience for MFA verification'
+                )
+            else:
+                # Standard single-stage OAuth flow (no MFA required)
+                params['redirect_uri'] = f'{server_url}/oauth/callback'
+                params['state'] = _build_state(client_redirect_uri, original_state)
+
+                auth0_url = f'{config["auth0_base_url"]}/authorize?{urlencode(params)}'
+                logger.info('Redirecting to Auth0 authorize endpoint')
+        except ValueError as e:
+            return JSONResponse(
+                {'error': str(e)}, status_code=HTTPStatus.INTERNAL_SERVER_ERROR
             )
 
-            auth0_url = f'{config["auth0_base_url"]}/authorize?{urlencode(mfa_params)}'
-            logger.info(
-                'Stage 1: Redirecting to Auth0 MFA audience for MFA verification'
-            )
-        else:
-            # Standard single-stage OAuth flow (no MFA required)
-            params['redirect_uri'] = f'{server_url}/oauth/callback'
-            params['state'] = _build_state(client_redirect_uri, original_state)
-
-            auth0_url = f'{config["auth0_base_url"]}/authorize?{urlencode(params)}'
-            logger.info('Redirecting to Auth0 authorize endpoint')
         return RedirectResponse(url=auth0_url, status_code=302)
 
     @mcp_server.custom_route('/oauth/token', methods=['POST'])

--- a/utils/oauth.py
+++ b/utils/oauth.py
@@ -9,8 +9,12 @@ which bypasses MCP authentication — appropriate for OAuth flow endpoints.
 """
 
 import base64
+import binascii
+import hashlib
+import hmac
 import json
 import os
+import time
 
 import httpx
 
@@ -18,6 +22,12 @@ from utils.logger import get_logger
 
 logger = get_logger('oauth')
 
+
+# Domain-separates the state key from other keys derived from the client secret.
+_STATE_SECRET_INFO = b'alpacon-mcp-oauth-state-v1'
+
+# Covers an Auth0 login plus MFA; keeps a leaked state only briefly usable.
+_STATE_TTL_SECONDS = 600
 
 _ALLOWED_LOOPBACK_HOSTS = ('localhost', '127.0.0.1', '::1')
 
@@ -121,6 +131,68 @@ def _get_oauth_config() -> dict[str, str]:
         'mfa_audience': mfa_audience,
         'auth0_base_url': f'https://{domain}',
     }
+
+
+def _get_state_secret() -> bytes:
+    """Falls back to deriving from AUTH0_CLIENT_SECRET so no extra secret needs
+    provisioning; the derived key is identical across replicas, so state
+    verifies without shared server-side storage.
+    """
+    explicit = os.getenv('ALPACON_MCP_STATE_SECRET', '')
+    if explicit:
+        return explicit.encode()
+
+    client_secret = _get_oauth_config()['client_secret']
+    return hmac.new(client_secret.encode(), _STATE_SECRET_INFO, hashlib.sha256).digest()
+
+
+def _sign_state(payload: dict) -> str:
+    """Serialise a state payload with an expiry and an HMAC signature."""
+    body = {**payload, 'exp': int(time.time()) + _STATE_TTL_SECONDS}
+    encoded = base64.urlsafe_b64encode(
+        json.dumps(body, separators=(',', ':')).encode()
+    ).decode()
+    signature = base64.urlsafe_b64encode(
+        hmac.new(_get_state_secret(), encoded.encode(), hashlib.sha256).digest()
+    ).decode()
+    return f'{encoded}.{signature}'
+
+
+def _verify_state(state: str) -> dict | None:
+    """Return the state payload, or None when it is forged or expired.
+
+    The signature covers the encoded payload rather than the raw JSON so it can
+    be checked before anything is decoded.
+    """
+    encoded, _, signature = state.rpartition('.')
+    if not encoded or not signature:
+        return None
+
+    expected = base64.urlsafe_b64encode(
+        hmac.new(_get_state_secret(), encoded.encode(), hashlib.sha256).digest()
+    )
+    # Compare bytes: compare_digest raises TypeError on non-ASCII str input.
+    if not hmac.compare_digest(expected, signature.encode()):
+        return None
+
+    try:
+        payload = json.loads(base64.urlsafe_b64decode(encoded.encode()).decode())
+    except (json.JSONDecodeError, UnicodeDecodeError, binascii.Error):
+        return None
+
+    if not isinstance(payload, dict):
+        return None
+
+    expires_at = payload.get('exp')
+    if not isinstance(expires_at, int) or expires_at < int(time.time()):
+        return None
+
+    return payload
+
+
+def _build_state(redirect_uri: str, state: str, **extra) -> str:
+    """Pack everything the callback needs to recover into one signed state value."""
+    return _sign_state({'redirect_uri': redirect_uri, 'state': state, **extra})
 
 
 def register_oauth_routes(mcp_server):
@@ -269,16 +341,13 @@ def register_oauth_routes(mcp_server):
                 if key in params:
                     stage2_authorize_params[key] = params[key]
 
-            state_data = json.dumps(
-                {
-                    'redirect_uri': client_redirect_uri,
-                    'state': original_state,
-                    'stage': 'mfa',
-                    'original_scope': scope,
-                    'authorize_params': stage2_authorize_params,
-                }
+            mfa_params['state'] = _build_state(
+                client_redirect_uri,
+                original_state,
+                stage='mfa',
+                original_scope=scope,
+                authorize_params=stage2_authorize_params,
             )
-            mfa_params['state'] = base64.urlsafe_b64encode(state_data.encode()).decode()
 
             auth0_url = f'{config["auth0_base_url"]}/authorize?{urlencode(mfa_params)}'
             logger.info(
@@ -286,16 +355,8 @@ def register_oauth_routes(mcp_server):
             )
         else:
             # Standard single-stage OAuth flow (no MFA required)
-            state_data = json.dumps(
-                {
-                    'redirect_uri': client_redirect_uri,
-                    'state': original_state,
-                }
-            )
-            composite_state = base64.urlsafe_b64encode(state_data.encode()).decode()
-
             params['redirect_uri'] = f'{server_url}/oauth/callback'
-            params['state'] = composite_state
+            params['state'] = _build_state(client_redirect_uri, original_state)
 
             auth0_url = f'{config["auth0_base_url"]}/authorize?{urlencode(params)}'
             logger.info('Redirecting to Auth0 authorize endpoint')
@@ -589,25 +650,29 @@ def register_oauth_routes(mcp_server):
         stage = ''
         original_scope = ''
         authorize_params: dict = {}
+        # An absent state is not rejected: Auth0 error callbacks can arrive
+        # without one, and it names no redirect target a forgery could steer.
         if composite_state:
             try:
-                state_data = json.loads(
-                    base64.urlsafe_b64decode(composite_state.encode()).decode()
+                state_data = _verify_state(composite_state)
+            except ValueError as e:
+                # Without an explicit state secret, verification needs the OAuth
+                # config; surface misconfiguration as the other handlers do.
+                return JSONResponse({'error': str(e)}, status_code=500)
+            if state_data is None:
+                logger.warning('Callback rejected an invalid or expired state')
+                return JSONResponse(
+                    {
+                        'error': 'invalid_request',
+                        'error_description': 'Invalid or expired state parameter',
+                    },
+                    status_code=400,
                 )
-                client_redirect_uri = state_data.get('redirect_uri', '')
-                original_state = state_data.get('state', '')
-                stage = state_data.get('stage', '')
-                original_scope = state_data.get('original_scope', '')
-                authorize_params = state_data.get('authorize_params', {})
-            except (
-                json.JSONDecodeError,
-                UnicodeDecodeError,
-                base64.binascii.Error,
-            ) as e:
-                logger.warning(f'Failed to decode composite state: {e}')
-                # Fall back to treating the raw state as the original opaque state
-                # so it can be echoed back to the client per OAuth spec.
-                original_state = composite_state
+            client_redirect_uri = state_data.get('redirect_uri', '')
+            original_state = state_data.get('state', '')
+            stage = state_data.get('stage', '')
+            original_scope = state_data.get('original_scope', '')
+            authorize_params = state_data.get('authorize_params', {})
 
         # Defense-in-depth: re-validate redirect_uri from state is allowed.
         # The authorize endpoint already validates this, but an attacker could craft
@@ -692,21 +757,15 @@ def register_oauth_routes(mcp_server):
             # Stage 2: redirect to Auth0 with regular audience.
             # The Auth0 SSO session will skip the login prompt since
             # the user just authenticated (with MFA) moments ago.
-            stage2_state = json.dumps(
-                {
-                    'redirect_uri': client_redirect_uri,
-                    'state': original_state,
-                    'stage': 'regular',
-                }
-            )
-
             stage2_params = {
                 'response_type': 'code',
                 'client_id': config['client_id'],
                 'audience': config['audience'],
                 'redirect_uri': f'{server_url}/oauth/callback',
                 'scope': original_scope or 'openid profile email offline_access',
-                'state': base64.urlsafe_b64encode(stage2_state.encode()).decode(),
+                'state': _build_state(
+                    client_redirect_uri, original_state, stage='regular'
+                ),
             }
             # Replay PKCE and other client params preserved from Stage 1
             # so the final code exchange succeeds with the client's verifier.
@@ -781,5 +840,9 @@ def register_oauth_routes(mcp_server):
         return await oauth_register(request)
 
     logger.info(
-        'OAuth proxy routes registered (including /token, /authorize, /register fallbacks)'
+        'OAuth proxy routes registered (including /token, /authorize, '
+        '/register fallbacks) - state secret: %s',
+        'explicit env'
+        if os.getenv('ALPACON_MCP_STATE_SECRET')
+        else 'derived from client secret',
     )

--- a/utils/oauth.py
+++ b/utils/oauth.py
@@ -34,6 +34,10 @@ _STAGE_REGULAR = 'regular'
 # Domain-separates the state key from other keys derived from the client secret.
 _STATE_SECRET_INFO = b'alpacon-mcp-oauth-state-v1'
 
+# Matches the 32 bytes the derived key always has, so an explicit key cannot be
+# weaker than leaving the variable unset.
+_STATE_SECRET_MIN_BYTES = 32
+
 # Covers an Auth0 login plus MFA; keeps a leaked state only briefly usable.
 _STATE_TTL_SECONDS = 600
 
@@ -148,7 +152,21 @@ def _get_state_secret() -> bytes:
     """
     explicit = os.getenv(_STATE_SECRET_ENV, '')
     if explicit:
-        return explicit.encode()
+        # The state travels in URLs and proxy logs, so the key is an offline
+        # brute-force target; hex-only input keeps a typed passphrase out.
+        try:
+            key = bytes.fromhex(explicit)
+        except ValueError:
+            raise ValueError(
+                f'{_STATE_SECRET_ENV} must be hex; '
+                f'generate one with openssl rand -hex {_STATE_SECRET_MIN_BYTES}'
+            ) from None
+        if len(key) < _STATE_SECRET_MIN_BYTES:
+            raise ValueError(
+                f'{_STATE_SECRET_ENV} must decode to at least '
+                f'{_STATE_SECRET_MIN_BYTES} bytes'
+            )
+        return key
 
     client_secret = _get_oauth_config()['client_secret']
     return hmac.new(client_secret.encode(), _STATE_SECRET_INFO, hashlib.sha256).digest()


### PR DESCRIPTION
## Summary

The OAuth `state` was unsigned base64 JSON, so calling `/oauth/callback` with a forged state could steer the authorization code to an arbitrary redirect_uri. The state is now an HMAC-SHA256 signed envelope with a 10-minute expiry, and the callback rejects any state that fails verification with 400.

## Background

The callback trusts the `redirect_uri` inside the state and redirects the authorization code to it. Previously it only decoded the state without verifying a signature, and a lenient path echoed the raw string back on decode failure, letting forged states through.

## Changes

- `utils/oauth.py`: signing key derivation (`_get_state_secret`) — falls back to deriving from `AUTH0_CLIENT_SECRET` via HMAC when `ALPACON_MCP_STATE_SECRET` is unset. The derived key is identical across replicas, so no shared storage is needed. An explicit `ALPACON_MCP_STATE_SECRET` must be hex decoding to at least 32 bytes, so it cannot be weaker than the derived key it replaces (review feedback).
- `_sign_state`/`_verify_state`: `encoded.signature` envelope, constant-time comparison, 10-minute `exp`. The three producers (standard, MFA stage 1, stage 2) all go through one `_build_state` helper.
- Callback: a state that fails verification gets 400 `invalid_request`. A callback without any state is still accepted (Auth0 error callbacks can arrive bare, and an absent state names no redirect target to steer). Missing config surfaces as the same JSON 500 the other handlers return.
- Authorize: the state-building branch is wrapped in the handler's `ValueError` guard, so a malformed `ALPACON_MCP_STATE_SECRET` returns the message rather than a bare 500. Signing is where an operator hits the bad key first, and only the callback carried the diagnostic before (review feedback).
- `docs/configuration.md`: documents `ALPACON_MCP_STATE_SECRET`, its hex and 32-byte requirement, and `openssl rand -hex 32` as the way to generate one.

Cleanup, limited to what this branch introduced:

- Function-scoped imports in the tests hoisted to module level.
- Only the literals this branch added are named (`_STATE_SECRET_ENV`, the `mfa`/`regular` stage tags, `HTTPStatus` for the new callback response). Naming the pre-existing literals is split out to #151.
- The test mock server stub and the forged-state builder are each defined once instead of being copy-pasted per test.
- The tests patch the environment through `_STATE_SECRET_ENV` rather than repeating the env var name (review feedback).

## Safety

- A leaked state cannot be forged, and the expiry limits the replay window to 10 minutes.
- The state is a public value that reaches URLs, browser history, Referer headers, and proxy logs, which makes the signing key an offline brute-force target with no rate limit in front of it. Review demonstrated a five-character key recovered from a single observed state in about two minutes of single-core Python, so the explicit key is bounded on format rather than on character count — a 32-character typed passphrase passes a length check while its keyspace does not. This does not guarantee entropy (`'00' * 32` still passes); it removes the typed-secret failure mode the demonstration exercised.
- Stage-2 replay parameters keep the existing allowlist validation (defense in depth).
- Backward compatibility: an unsigned state issued right before deployment gets a 400 right after, but the client restarts from authorize and recovers immediately via the SSO session.

## Testing

Full `pytest` suite: 1007 passed (75 oauth tests, including the new signing, forgery, expiry, missing-config, weak-explicit-key, and malformed-key-on-authorize cases). ruff and mypy clean.


