### PR TITLE
fix(common): surface server error codes instead of dropping them

### DIFF
--- a/tests/test_common.py
+++ b/tests/test_common.py
@@ -3,6 +3,7 @@
 import pytest
 
 from utils.common import (
+    _ERROR_CODE_HINT,
     _NEXT_ACTION_BY_CATEGORY,
     _WORK_SESSION_GATE_CODES,
     _WORK_SESSION_GATE_NEXT_ACTION,
@@ -122,7 +123,11 @@ class TestUnwrapHttpResultGate:
             self._envelope('some_other_error'), default_message='failed'
         )
         assert out['status'] == 'error'
-        assert 'code' not in out  # generic path does not attach a gate code
+        # Generic path does not route through the gate-response shape...
+        assert 'code' not in out
+        assert 'next_action' not in out
+        # ...but the server's error code must still surface, not be dropped.
+        assert out['error_code'] == 'some_other_error'
 
     def test_non_json_body_is_generic_error(self):
         env = {
@@ -132,14 +137,47 @@ class TestUnwrapHttpResultGate:
         }
         out = unwrap_http_result(env, default_message='failed')
         assert out['status'] == 'error'
+        assert 'error_code' not in out
 
     def test_no_response_key_is_generic_error(self):
         env = {'error': 'HTTP Error', 'status_code': 500, 'message': 'boom'}
         out = unwrap_http_result(env, default_message='failed')
         assert out['status'] == 'error'
+        assert 'error_code' not in out
+        assert out['message'] == 'boom'
 
     def test_success_envelope_returns_none(self):
         assert unwrap_http_result({'status': 'success'}, default_message='x') is None
+
+    def test_command_inline_credential_gets_actionable_hint(self):
+        out = unwrap_http_result(
+            self._envelope('command_inline_credential'), default_message='failed'
+        )
+        assert out['status'] == 'error'
+        assert out['error_code'] == 'command_inline_credential'
+        assert 'env' in out['message']
+        assert 'audit log' in out['message']
+
+    def test_unhinted_code_has_no_hint_text_appended(self):
+        out = unwrap_http_result(
+            self._envelope('some_other_error'), default_message='failed'
+        )
+        # No entry in _ERROR_CODE_HINT for this code: message is untouched.
+        assert out['message'] == 'HTTP 400'
+
+
+class TestErrorCodeHint:
+    def test_command_inline_credential_names_env_and_reason(self):
+        hint = _ERROR_CODE_HINT['command_inline_credential']
+        assert 'env' in hint
+        assert 'audit log' in hint
+        # No new opt-in param: this hint must not tell the agent to pass one.
+        assert 'credential_exposure_acknowledged' not in hint
+
+    def test_gate_codes_have_no_hint_entries(self):
+        # Gate codes are handled entirely by work_session_gate_response;
+        # _ERROR_CODE_HINT is only consulted on the generic error path.
+        assert not (set(_ERROR_CODE_HINT) & _WORK_SESSION_GATE_CODES)
 
 
 class TestResolveWorkSessionId:

--- a/utils/common.py
+++ b/utils/common.py
@@ -323,8 +323,9 @@ def unwrap_http_result(
     4xx bodies carry only ``{"code": "..."}``, no message, so without this the
     caller only ever sees a generic "Client error '400 Bad Request'" string.
     A curated subset of codes (``_ERROR_CODE_HINT``) also get an actionable
-    hint appended to the message, e.g. `command_inline_credential` (ADR 0037)
-    telling the agent to retry via the `env` parameter.
+    hint appended to the message, e.g. `command_inline_credential` (see
+    alpacax/alpacon-server#2745) telling the agent to retry via the `env`
+    parameter.
 
     Args:
         result: Raw value returned by an http_client method.
@@ -343,15 +344,17 @@ def unwrap_http_result(
     if status_code is not None:
         error_kwargs['status_code'] = status_code
 
-    gate_code = _extract_work_session_gate_code(result)
-    if gate_code is not None:
-        return work_session_gate_response(gate_code, **error_kwargs)
+    # Parse the body's `code` once; it decides both whether this is a
+    # WorkSession gate (membership in _WORK_SESSION_GATE_CODES) and, on the
+    # generic path below, what gets surfaced as `error_code`.
+    code = _extract_error_code(result)
+    if code is not None and code in _WORK_SESSION_GATE_CODES:
+        return work_session_gate_response(code, **error_kwargs)
 
     message = result.get('message', default_message)
-    error_code = _extract_error_code(result)
-    if error_code is not None:
-        error_kwargs['error_code'] = error_code
-        hint = _ERROR_CODE_HINT.get(error_code)
+    if code is not None:
+        error_kwargs['error_code'] = code
+        hint = _ERROR_CODE_HINT.get(code)
         if hint is not None:
             message = f'{message} {hint}'
 
@@ -377,15 +380,3 @@ def _extract_error_code(result: dict[str, Any]) -> str | None:
         return None
     code = body.get('code')
     return code if isinstance(code, str) else None
-
-
-def _extract_work_session_gate_code(result: dict[str, Any]) -> str | None:
-    """Return the WorkSession gate code carried by an http error envelope, if any.
-
-    Returns None when `_extract_error_code` finds no code, or the code is not a
-    recognized gate code (so the caller falls back to the generic error path).
-    """
-    code = _extract_error_code(result)
-    if code is not None and code in _WORK_SESSION_GATE_CODES:
-        return code
-    return None

--- a/utils/common.py
+++ b/utils/common.py
@@ -130,6 +130,20 @@ _WORK_SESSION_GATE_CODES: frozenset[str] = frozenset(_WORK_SESSION_GATE_NEXT_ACT
     _WORK_SESSION_PENDING_CODE
 }
 
+# Actionable hints for server error `code` values that are not WorkSession
+# gate codes (see _extract_error_code). Keyed by code so new hints can be
+# added without touching unwrap_http_result. Appended to the error message
+# so an AI agent reading the response text alone knows how to retry.
+_ERROR_CODE_HINT: dict[str, str] = {
+    'command_inline_credential': (
+        'The server rejected this command because it carries an inline '
+        'credential on the command line (e.g. `mysql -pSecret`, '
+        '`PGPASSWORD=...`, or a `user:pw@host` URL), which would otherwise be '
+        'stored in plaintext in the audit log. Move the secret into the '
+        '`env` parameter of execute_command and retry.'
+    ),
+}
+
 
 def is_auth_enabled() -> bool:
     """Check if remote (streamable-http) mode with Auth0 JWT auth is enabled.
@@ -302,6 +316,16 @@ def unwrap_http_result(
     by `utils.http_client` on 4xx/5xx; otherwise returns None so the caller
     can wrap the payload with `success_response`.
 
+    WorkSession gate codes (``_WORK_SESSION_GATE_CODES``) take the dedicated
+    ``work_session_gate_response`` path, unchanged from before. Any other
+    server `code` found in the error body is now surfaced as `error_code` in
+    the returned response instead of being silently dropped—alpacon-server's
+    4xx bodies carry only ``{"code": "..."}``, no message, so without this the
+    caller only ever sees a generic "Client error '400 Bad Request'" string.
+    A curated subset of codes (``_ERROR_CODE_HINT``) also get an actionable
+    hint appended to the message, e.g. `command_inline_credential` (ADR 0037)
+    telling the agent to retry via the `env` parameter.
+
     Args:
         result: Raw value returned by an http_client method.
         default_message: Fallback message when the upstream response has none.
@@ -323,19 +347,24 @@ def unwrap_http_result(
     if gate_code is not None:
         return work_session_gate_response(gate_code, **error_kwargs)
 
-    return error_response(
-        result.get('message', default_message),
-        **error_kwargs,
-    )
+    message = result.get('message', default_message)
+    error_code = _extract_error_code(result)
+    if error_code is not None:
+        error_kwargs['error_code'] = error_code
+        hint = _ERROR_CODE_HINT.get(error_code)
+        if hint is not None:
+            message = f'{message} {hint}'
+
+    return error_response(message, **error_kwargs)
 
 
-def _extract_work_session_gate_code(result: dict[str, Any]) -> str | None:
-    """Return the WorkSession gate code carried by an http error envelope, if any.
+def _extract_error_code(result: dict[str, Any]) -> str | None:
+    """Return the `code` field carried by an http error envelope's body, if any.
 
     alpacon-server's exception handler returns 4xx bodies shaped as
     ``{"code": "<error_code>"}``; ``utils.http_client`` carries the raw body in
-    the ``response`` key. Returns None when the body is missing, not JSON, or not
-    a recognized gate code (so the caller falls back to a generic error).
+    the ``response`` key. Returns None when the body is missing, not JSON, or
+    lacks a string `code` field.
     """
     raw = result.get('response')
     if not isinstance(raw, str):
@@ -347,6 +376,16 @@ def _extract_work_session_gate_code(result: dict[str, Any]) -> str | None:
     if not isinstance(body, dict):
         return None
     code = body.get('code')
-    if isinstance(code, str) and code in _WORK_SESSION_GATE_CODES:
+    return code if isinstance(code, str) else None
+
+
+def _extract_work_session_gate_code(result: dict[str, Any]) -> str | None:
+    """Return the WorkSession gate code carried by an http error envelope, if any.
+
+    Returns None when `_extract_error_code` finds no code, or the code is not a
+    recognized gate code (so the caller falls back to the generic error path).
+    """
+    code = _extract_error_code(result)
+    if code is not None and code in _WORK_SESSION_GATE_CODES:
         return code
     return None


### PR DESCRIPTION
## 문제

alpacon-server는 4xx 에러를 `{"code": "<error_code>"}` 본문으로만 반환하고 메시지는 실어주지 않는다. 그런데 `utils/common.py`의 `unwrap_http_result`는 본문 JSON에서 `code`를 꺼내는 로직을 **work-session 게이트 코드일 때만** 태웠고, 그 외의 코드는 그냥 버려졌다. 그 결과 AI 에이전트는 실제 서버 에러 코드 대신 `Client error '400 Bad Request' for url ...` 같은 무의미한 메시지만 보게 된다.

특히 서버에 최근 머지된 인라인 credential 게이트(alpacon-server#2745, ADR 0037)는 명령줄에 secret이 실리면(`mysql -pSecret`, `PGPASSWORD=...`, `postgresql://user:pw@host` 등) `command_inline_credential` 코드로 400을 반환하는데, 이 코드가 사라지니 에이전트가 왜 막혔는지, 어떻게 재시도해야 하는지 전혀 알 수 없었다.

## 수정

- `unwrap_http_result`가 게이트 코드가 아닌 경우에도 본문에서 `code`를 뽑아 `error_code`로 응답에 포함하도록 함. 본문이 없거나 JSON이 아니거나 `code` 필드가 없으면 기존과 동일하게 동작(회귀 없음).
- 코드 파싱 로직은 `_extract_error_code` 헬퍼로 분리하고, 기존 `_extract_work_session_gate_code`는 이를 재사용하도록 정리(중복 제거).
- `command_inline_credential`에 한해 "env 파라미터로 secret을 옮겨 재시도하라"는 actionable 힌트를 메시지에 덧붙임. 코드 → 힌트 매핑은 `_ERROR_CODE_HINT` dict로 두어 향후 다른 코드도 추가하기 쉽게 함. `credential_exposure_acknowledged` 같은 새 파라미터는 추가하지 않음(후속 논의 대상).

## 검증

- 신규 테스트(`tests/test_common.py`): 임의 코드의 `error_code` 표면화, `command_inline_credential` 힌트 포함 여부, 본문 없음/비JSON 폴백, work-session 게이트 코드 무회귀, 힌트 없는 코드는 메시지 불변.
- 기존 테스트 중 "게이트가 아닌 코드는 버려진다"를 검증하던 케이스는 새 동작(코드가 `error_code`로 표면화)에 맞게 갱신.
- 전체 스위트 `uv run pytest -q` → 990 passed.
- `ruff check`, `ruff format --check`, `mypy` 모두 통과.

Refs alpacax/alpacon-server#2745