### PR TITLE
build(deps): bump click to 8.4.2 in the lockfile

### DIFF
--- a/uv.lock
+++ b/uv.lock
@@ -187,14 +187,14 @@ wheels = [
 
 [[package]]
 name = "click"
-version = "8.2.1"
+version = "8.4.2"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "colorama", marker = "sys_platform == 'win32'" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/60/6c/8ca2efa64cf75a977a0d7fac081354553ebe483345c734fb6b6515d96bbc/click-8.2.1.tar.gz", hash = "sha256:27c491cc05d968d271d5a1db13e3b5a184636d9d930f148c50b038f0d0646202", size = 286342, upload-time = "2025-05-20T23:19:49.832Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/76/d4/81420972a676e8ffea40450d8c8c92943e7218a78fe9b64359836cc9876b/click-8.4.2.tar.gz", hash = "sha256:9a6cea6e60b17ebe0a44c5cc636d94f09bd66142c1cd7d8b4cd731c4917a15f6", size = 338000, upload-time = "2026-06-24T17:45:15.148Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/85/32/10bb5764d90a8eee674e9dc6f4db6a0ab47c8c4d0d83c27f7c39ac415a4d/click-8.2.1-py3-none-any.whl", hash = "sha256:61a3265b914e850b85317d0b3109c7f8cd35a670f963866005d6ef1d5175a12b", size = 102215, upload-time = "2025-05-20T23:19:47.796Z" },
+    { url = "https://files.pythonhosted.org/packages/fb/e2/79c688af8b210d232694e31e59da9f6ec747bae31c3f5946e4e9b98860d5/click-8.4.2-py3-none-any.whl", hash = "sha256:e6f9f66136c816745b9d65817da91d61d957fb16e02e4dcd0552553c5a197b76", size = 119243, upload-time = "2026-06-24T17:45:13.73Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Background

`pip-audit` on the exported lockfile reports one vulnerability:

```
Name  Version ID              Fix Versions
----- ------- --------------- ------------
click 8.2.1   PYSEC-2026-2132 8.3.3
```

PYSEC-2026-2132 is a command injection in `click.edit()` affecting click 8.3.2 and below. Nothing in this repo imports click; it arrives through `uvicorn` (runtime, via `mcp`) and `black` (dev), so the exposure is indirect. Resolving `pyproject.toml` from scratch already picks 8.4.2 — only `uv.lock` was behind.

## Changes

`uv lock --upgrade-package click` — click 8.2.1 to 8.4.2. No other package moved.

## Testing

- `pip-audit` on a fresh resolve for Python 3.12, 3.13, and 3.14 (the CI matrix): no known vulnerabilities in all three, and the three resolutions are identical.
- `pip-audit` on the updated lockfile export: `No known vulnerabilities found`.
- `pytest`: 1037 passed, 2 failed. Both failures (`tests/test_basic.py::test_import_main`, `tests/test_simple_integration.py::TestMCPServerConfiguration::test_main_entry_point`) reproduce on the pre-change lockfile and are unrelated to this bump.