### PR TITLE
fix(workspace): remove the notification tools, whose endpoint no longer exists

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   - `get_workspace_security` and `list_workspace_mfa_methods` require JWT (OAuth/SSO) authentication and short-circuit a static API token before any request, and are SaaS-only (a clear not-available message on on-premise 404)
   - The list fields on the update tools (`notification_channels`, `enabled_extensions`, `allowed_domains`) replace the whole array rather than appending; documented the read-merge-write pattern
 
+### Removed
+- `get_workspace_notifications` and `update_workspace_notifications`, along with the
+  `alpacon://workspace-settings/notifications/{region}/{workspace}` resource. The upstream
+  `/api/workspaces/notifications/-/` endpoint no longer exists — the `NotificationSettings`
+  model, serializer, viewset and route were deleted server-side (alpacon-server #2832)
+  because the two fields had no runtime consumer, so both tools returned 404. Server
+  disconnection still raises an alert in the notification bell; that path is unaffected,
+  as are the `notification_channels` parameters on `create_alert_rule`/`update_alert_rule`,
+  which belong to the unrelated metrics `AlertRule`.
+
 ### Documentation
 - Documented the hosted remote MCP server (`https://mcp.alpacon.io/mcp`, streamable-http transport)
   - Added a "Remote MCP server (hosted, no install)" section to `README.md` with per-client setup for Claude Code, Claude Desktop, Cursor, and VS Code

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,8 +22,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Removed
 - `get_workspace_notifications` and `update_workspace_notifications`, along with the
   `alpacon://workspace-settings/notifications/{region}/{workspace}` resource. The upstream
-  `/api/workspaces/notifications/-/` endpoint no longer exists — the `NotificationSettings`
-  model, serializer, viewset and route were deleted server-side (alpacon-server #2832)
+  `/api/workspaces/notifications/-/` endpoint no longer exists—the `NotificationSettings`
+  model, serializer, viewset and route were deleted server-side (alpacax/alpacon-server#2832)
   because the two fields had no runtime consumer, so both tools returned 404. Server
   disconnection still raises an alert in the notification bell; that path is unaffected,
   as are the `notification_channels` parameters on `create_alert_rule`/`update_alert_rule`,

--- a/README.md
+++ b/README.md
@@ -507,9 +507,7 @@ These tools need a JWT/OAuth session (hosted server), a browser session, or a lo
 - **get_workspace_access_control**: Get access control settings (read-only)
 - **get_workspace_security**: Get authentication/security settings (JWT/SSO auth only, SaaS only)
 - **list_workspace_mfa_methods**: List allowed MFA methods (JWT/SSO auth only, SaaS only)
-- **get_workspace_notifications**: Get notification settings
 - **get_workspace_preferences**: Get workspace-wide preferences
-- **update_workspace_notifications**: Update notification settings (partial)
 - **update_workspace_preferences**: Update workspace-wide preferences (partial)
 - **health_check**: MCP server health, version, and authentication mode
 

--- a/docs/api-reference.md
+++ b/docs/api-reference.md
@@ -775,27 +775,11 @@ List the MFA methods allowed for the workspace (`allowed_mfa_methods`, `passkey_
 
 **Note:** Like `get_workspace_security`, this requires JWT (OAuth/SSO) authentication (a static API token is rejected up front) and the route is SaaS-only.
 
-### `get_workspace_notifications`
-Get the workspace notification settings: `disconnection_notification` and `notification_channels`.
-
-**Parameters:**
-- `workspace` (string): Workspace name
-- `region` (string, optional): Region name; resolved from the workspace when omitted
-
 ### `get_workspace_preferences`
 Get the workspace-wide preferences: timezone, locale, `front_url`, `invite_ttl`, `enabled_extensions`, `websh_session_timeout`, `auto_agent_upgrade`, `package_proxy`, `billing_email`, `allowed_domains`. Workspace-global configuration, not per-user.
 
 **Parameters:**
 - `workspace` (string): Workspace name
-- `region` (string, optional): Region name; resolved from the workspace when omitted
-
-### `update_workspace_notifications`
-Update workspace notification settings. Only the fields you provide are sent (partial update).
-
-**Parameters:**
-- `workspace` (string): Workspace name
-- `disconnection_notification` (boolean, optional): Notify when a server disconnects/goes offline
-- `notification_channels` (array, optional): Channel types to notify through (`email`, `webhook`, `push`). Replaces the whole list (not additive); read via `get_workspace_notifications` and merge before sending
 - `region` (string, optional): Region name; resolved from the workspace when omitted
 
 ### `update_workspace_preferences`
@@ -840,7 +824,7 @@ Most read tools are also exposed as read-only MCP resources under the `alpacon:/
 - `alpacon://audit/{activity|server-logs|webftp-logs|session-analyses}/{region}/{workspace}`
 - `alpacon://certs/...`, `alpacon://tokens/...`, `alpacon://webhooks/...`, `alpacon://event-subscriptions/...`, `alpacon://acls/{command|server|file}/...`, `alpacon://webftp/{sessions|uploads|downloads}/...`, `alpacon://packages/{system|python}/...`, `alpacon://events/...`, `alpacon://commands/...`, `alpacon://registration-tokens/...`
 - `alpacon://workspaces`, `alpacon://workspaces/{region}`, `alpacon://current-user/{region}/{workspace}`
-- `alpacon://workspace-settings/{access-control|security|mfa-methods|notifications|preferences}/{region}/{workspace}`
+- `alpacon://workspace-settings/{access-control|security|mfa-methods|preferences}/{region}/{workspace}`
 
 A resource is registered only when its backing tool module is enabled, so a narrow `--toolsets` selection drops the matching resources too.
 

--- a/tests/test_workspace_tools.py
+++ b/tests/test_workspace_tools.py
@@ -13,11 +13,9 @@ from tests.conftest import HTTP_ERROR_ENVELOPE
 from tools.workspace_tools import (
     get_current_user,
     get_workspace_access_control,
-    get_workspace_notifications,
     get_workspace_preferences,
     get_workspace_security,
     list_workspace_mfa_methods,
-    update_workspace_notifications,
     update_workspace_preferences,
 )
 
@@ -479,40 +477,6 @@ class TestListWorkspaceMfaMethods:
         assert result['data']['allowed_mfa_methods'] == ['totp']
 
 
-class TestGetWorkspaceNotifications:
-    """Test get_workspace_notifications function."""
-
-    @pytest.mark.asyncio
-    async def test_success(self, mock_http_client, mock_token):
-        mock_http_client.get.return_value = {
-            'disconnection_notification': True,
-            'notification_channels': ['email'],
-        }
-
-        result = await get_workspace_notifications(
-            workspace='testworkspace', region='ap1'
-        )
-
-        assert result['status'] == 'success'
-        assert result['data']['notification_channels'] == ['email']
-        mock_http_client.get.assert_called_once_with(
-            region='ap1',
-            workspace='testworkspace',
-            endpoint='/api/workspaces/notifications/-/',
-            token='test-token',
-        )
-
-    @pytest.mark.asyncio
-    async def test_http_error(self, mock_http_client, mock_token):
-        mock_http_client.get.return_value = HTTP_ERROR_ENVELOPE
-
-        result = await get_workspace_notifications(
-            workspace='testworkspace', region='ap1'
-        )
-
-        assert result['status'] == 'error'
-
-
 class TestGetWorkspacePreferences:
     """Test get_workspace_preferences function."""
 
@@ -543,81 +507,6 @@ class TestGetWorkspacePreferences:
 
         result = await get_workspace_preferences(
             workspace='testworkspace', region='ap1'
-        )
-
-        assert result['status'] == 'error'
-
-
-class TestUpdateWorkspaceNotifications:
-    """Test update_workspace_notifications function."""
-
-    @pytest.mark.asyncio
-    async def test_partial_update_only_sends_provided_fields(
-        self, mock_http_client, mock_token
-    ):
-        mock_http_client.patch.return_value = {
-            'disconnection_notification': False,
-            'notification_channels': ['email'],
-        }
-
-        result = await update_workspace_notifications(
-            workspace='testworkspace',
-            disconnection_notification=False,
-            region='ap1',
-        )
-
-        assert result['status'] == 'success'
-        mock_http_client.patch.assert_called_once_with(
-            region='ap1',
-            workspace='testworkspace',
-            endpoint='/api/workspaces/notifications/-/',
-            token='test-token',
-            data={'disconnection_notification': False},
-        )
-
-    @pytest.mark.asyncio
-    async def test_update_multiple_fields(self, mock_http_client, mock_token):
-        mock_http_client.patch.return_value = {
-            'disconnection_notification': True,
-            'notification_channels': ['email', 'webhook'],
-        }
-
-        result = await update_workspace_notifications(
-            workspace='testworkspace',
-            disconnection_notification=True,
-            notification_channels=['email', 'webhook'],
-            region='ap1',
-        )
-
-        assert result['status'] == 'success'
-        mock_http_client.patch.assert_called_once_with(
-            region='ap1',
-            workspace='testworkspace',
-            endpoint='/api/workspaces/notifications/-/',
-            token='test-token',
-            data={
-                'disconnection_notification': True,
-                'notification_channels': ['email', 'webhook'],
-            },
-        )
-
-    @pytest.mark.asyncio
-    async def test_no_fields_provided_returns_error(self, mock_http_client, mock_token):
-        result = await update_workspace_notifications(
-            workspace='testworkspace', region='ap1'
-        )
-
-        assert result['status'] == 'error'
-        assert result['region'] == 'ap1'
-        assert result['workspace'] == 'testworkspace'
-        mock_http_client.patch.assert_not_called()
-
-    @pytest.mark.asyncio
-    async def test_http_error(self, mock_http_client, mock_token):
-        mock_http_client.patch.return_value = HTTP_ERROR_ENVELOPE
-
-        result = await update_workspace_notifications(
-            workspace='testworkspace', disconnection_notification=True, region='ap1'
         )
 
         assert result['status'] == 'error'

--- a/tools/resources.py
+++ b/tools/resources.py
@@ -412,11 +412,6 @@ RESOURCES: list[tuple[str, str, str]] = [
         'alpacon://workspace-settings/mfa-methods/{region}/{workspace}',
     ),
     (
-        'workspace_settings_notifications',
-        'workspace_tools.get_workspace_notifications',
-        'alpacon://workspace-settings/notifications/{region}/{workspace}',
-    ),
-    (
         'workspace_settings_preferences',
         'workspace_tools.get_workspace_preferences',
         'alpacon://workspace-settings/preferences/{region}/{workspace}',

--- a/tools/workspace_tools.py
+++ b/tools/workspace_tools.py
@@ -383,55 +383,11 @@ async def list_workspace_mfa_methods(
 
 @mcp_tool_handler(
     description=(
-        'Get the workspace notification settings: disconnection_notification and the '
-        'notification_channels used to deliver workspace-level alerts. '
-        'Related: update_workspace_notifications, list_webhooks, list_event_subscriptions.'
-    ),
-    annotations=READ_ONLY,
-    meta={
-        'anthropic/searchHint': 'workspace notifications settings disconnection channels',
-    },
-)
-async def get_workspace_notifications(
-    workspace: str, region: str = '', **kwargs
-) -> dict[str, Any]:
-    """Get the workspace notification settings.
-
-    Args:
-        workspace: Workspace name. Required parameter
-        region: Region (ap1, us1, eu1). Auto-detected if not provided
-
-    Returns:
-        Workspace notification settings response
-    """
-    token = kwargs.get('token')
-
-    result = await http_client.get(
-        region=region,
-        workspace=workspace,
-        endpoint='/api/workspaces/notifications/-/',
-        token=token,
-    )
-
-    err = unwrap_http_result(
-        result,
-        default_message='Failed to get workspace notification settings',
-        region=region,
-        workspace=workspace,
-    )
-    if err:
-        return err
-
-    return success_response(data=result, region=region, workspace=workspace)
-
-
-@mcp_tool_handler(
-    description=(
         'Get the workspace-wide preferences: timezone, locale (country/language), '
         'front_url, invite_ttl, enabled_extensions, websh_session_timeout, '
         'auto_agent_upgrade, package_proxy, billing_email, and allowed_domains. '
         'This is workspace-global configuration, not a per-user preference. '
-        'Related: update_workspace_preferences, get_workspace_notifications.'
+        'Related: update_workspace_preferences.'
     ),
     annotations=READ_ONLY,
     meta={
@@ -462,75 +418,6 @@ async def get_workspace_preferences(
     err = unwrap_http_result(
         result,
         default_message='Failed to get workspace preferences',
-        region=region,
-        workspace=workspace,
-    )
-    if err:
-        return err
-
-    return success_response(data=result, region=region, workspace=workspace)
-
-
-@mcp_tool_handler(
-    description=(
-        'Update workspace notification settings. Only the fields you provide are sent '
-        '(partial update). Fields: disconnection_notification (bool, notify when a server '
-        'disconnects/goes offline), notification_channels (list of channel types to notify '
-        'through: email, webhook, push). '
-        'Warning: notification_channels REPLACES the whole list, it does not append. To add '
-        'a channel, first read the current list via get_workspace_notifications, merge, then '
-        'send the full list — otherwise the omitted channels are dropped. '
-        'Related: get_workspace_notifications.'
-    ),
-    annotations=IDEMPOTENT_WRITE,
-    meta={
-        'anthropic/searchHint': 'workspace notifications update modify settings',
-    },
-)
-async def update_workspace_notifications(
-    workspace: str,
-    disconnection_notification: bool | None = None,
-    notification_channels: list[str] | None = None,
-    region: str = '',
-    **kwargs,
-) -> dict[str, Any]:
-    """Update the workspace notification settings (partial update).
-
-    Args:
-        workspace: Workspace name. Required parameter
-        disconnection_notification: Notify when a server disconnects (optional)
-        notification_channels: Channel types to notify through, e.g. email/webhook/push.
-            Replaces the whole list (not additive); read via get_workspace_notifications
-            and merge before sending to avoid dropping existing channels (optional)
-        region: Region (ap1, us1, eu1). Auto-detected if not provided
-
-    Returns:
-        Workspace notification update response
-    """
-    token = kwargs.get('token')
-
-    update_data: dict[str, Any] = {}
-    if disconnection_notification is not None:
-        update_data['disconnection_notification'] = disconnection_notification
-    if notification_channels is not None:
-        update_data['notification_channels'] = notification_channels
-
-    if not update_data:
-        return error_response(
-            'No update data provided', region=region, workspace=workspace
-        )
-
-    result = await http_client.patch(
-        region=region,
-        workspace=workspace,
-        endpoint='/api/workspaces/notifications/-/',
-        token=token,
-        data=update_data,
-    )
-
-    err = unwrap_http_result(
-        result,
-        default_message='Failed to update workspace notification settings',
         region=region,
         workspace=workspace,
     )


### PR DESCRIPTION
Refs alpacax/alpacon-server#2832 — the fifth repo in that removal, missed when it shipped.

## Why

`get_workspace_notifications` and `update_workspace_notifications` call `/api/workspaces/notifications/-/`. **That endpoint is gone.** The entire `NotificationSettings` model, serializer, viewset and route were deleted from alpacon-server because its two fields had no runtime consumer; the console page and the CLI commands went at the same time.

Confirmed rather than inferred: `workspaces/migrations/0054_delete_notificationsettings.py` on that repo's `main` is a `DeleteModel`, and the replacement viewset's docstring records that the workspace singleton "was removed as dead code by #2832".

So both tools now return **404**, and neither had an effect even before that — writing the fields changed nothing.

## Removed

- both tool functions and their handlers (`tools/workspace_tools.py`), plus the cross-references to them in surviving tools' docstrings
- the `workspace_settings_notifications` resource entry — the tools were **also resource-exposed**, so `alpacon://workspace-settings/notifications/...` goes with them
- 6 tests, the two README bullets, and the two doc sections — including the resource-URI brace list at `docs/api-reference.md:843`, which lists the sub-resources inline

## What is deliberately untouched

**`AlertRule`'s `notification_channels`** on `create_alert_rule` / `update_alert_rule` is a completely unrelated field that happens to share the name. `tools/alert_tools.py` is not in this diff at all, and `docs/examples.md:230` is an alert-rule example, not a workspace one.

**Server disconnection still raises an alert in the notification bell.** That path is untouched.

**CHANGELOG history.** Lines 15-16 describe these tools being added. They sit under `## [Unreleased]`, but `git tag --contains` puts that commit in **v0.8.0** (tagged 2026-07-29) — the heading is stale, since the last version section is `[0.4.3]` while the repo has tagged through 0.8.0. Treated as released history and left byte-for-byte, with a `### Removed` entry added instead.

> Worth a separate decision: `[Unreleased]` now reads "Added X" and "Removed X" together, which only makes sense once you know the heading is lying. Retitling it to `[0.8.0]` and backfilling 0.5.0–0.7.0 is the clean fix, but that is CHANGELOG maintenance rather than part of this removal.

## Verification

- `ruff check .` → `All checks passed!` · `ruff format --check .` → `96 files already formatted`
- `pytest tests/` → **1082 passed**
- `mypy --ignore-missing-imports --no-strict-optional .` → 8 errors, **all in `utils/oauth.py`**, which is not in this diff. Pre-existing; CI runs mypy with `continue-on-error: true`.

**On what the test run proves:** it passes partly *because* the 6 tests covering the removed tools are gone, which is close to tautological, and I am not offering it as evidence the removal is correct. What it does show is that nothing else depended on those symbols or on the resource registration — no import errors, no toolset/resource count assertions broke.

The real evidence is the server-side `DeleteModel` plus the dangling-reference sweep: `grep -rn "get_workspace_notifications\|update_workspace_notifications\|workspaces/notifications"` returns hits **only** in CHANGELOG (the kept history and the new entry) — zero in code, tests, README or docs. `disconnection_notification` returns nothing anywhere.

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0132tX6w2ET78zpfYowjWkKk