### PR TITLE
fix(utils): stop pointing at the dead ALPACON_CONFIG_FILE

### DIFF
--- a/utils/token_manager.py
+++ b/utils/token_manager.py
@@ -17,8 +17,10 @@ class TokenManager:
         """Initialize token manager.
 
         Args:
-            config_file: Full path to config file. If None, uses ALPACON_MCP_CONFIG_FILE
-                        env var or defaults to global config (~/.alpacon-mcp/token.json)
+            config_file: Full path to config file. If None, resolution order is
+                        ALPACON_MCP_CONFIG_FILE, then ~/.alpacon-mcp/token.json,
+                        then ./config/token.json, defaulting to the global path
+                        when neither file exists.
         """
         if config_file:
             # Use specific config file path, expand ~ to home directory

--- a/utils/token_manager.py
+++ b/utils/token_manager.py
@@ -17,8 +17,8 @@ class TokenManager:
         """Initialize token manager.
 
         Args:
-            config_file: Full path to config file. If None, uses ALPACON_CONFIG_FILE env var
-                        or defaults to global config (~/.alpacon-mcp/token.json)
+            config_file: Full path to config file. If None, uses ALPACON_MCP_CONFIG_FILE
+                        env var or defaults to global config (~/.alpacon-mcp/token.json)
         """
         if config_file:
             # Use specific config file path, expand ~ to home directory

--- a/utils/token_manager.py
+++ b/utils/token_manager.py
@@ -314,19 +314,6 @@ class TokenManager:
             'token_file': str(self.token_file),
         }
 
-    def get_config_info(self) -> dict[str, Any]:
-        """Get configuration directory information.
-
-        Returns:
-            Configuration directory details
-        """
-        return {
-            'config_dir': str(self.config_dir),
-            'token_file': str(self.token_file),
-            'token_file_exists': self.token_file.exists(),
-            'env_config_file': os.getenv('ALPACON_CONFIG_FILE'),
-        }
-
 
 # Global token manager instance
 _global_token_manager = None


### PR DESCRIPTION
## Background

`utils/token_manager.py` refers to `ALPACON_CONFIG_FILE` in two places, and nothing in the tree resolves that name. The only name the config lookup honors is `ALPACON_MCP_CONFIG_FILE`.

The rename is where it started. Commit `7cd0cbf` ("security: Remove token.json from git tracking and improve security configuration", 2025-09-25) changed exactly one line of `utils/token_manager.py`:

```
-            env_config_file = os.getenv("ALPACON_CONFIG_FILE")
+            env_config_file = os.getenv("ALPACON_MCP_CONFIG_FILE")
```

It fixed the site that reads the value and left the other two occurrences in the same file on the old name.

**The docstring (line 20).** `TokenManager.__init__` documents a variable it does not read. Follow it, export `ALPACON_CONFIG_FILE`, and line 30 gets `None` and falls through to the default `~/.alpacon-mcp/token.json`. No warning, no error, nothing logged, so there is no signal as to why the config was ignored. `docs/troubleshooting.md:374` already warns that the unprefixed name has no effect, so the docstring was the only side disagreeing.

**The diagnostic (line 327).** `env_config_file` in `get_config_info()` reads the old name, so it is always `None`. It answers `None` even when `ALPACON_MCP_CONFIG_FILE` is set and names the file currently in use. The field that exists to diagnose config resolution reports the opposite of the truth.

## Changes

| Commit | Change |
|---|---|
| `a6b4222` `docs(utils)` | point the docstring at `ALPACON_MCP_CONFIG_FILE` |
| `e167257` `refactor(utils)` | delete `get_config_info()` |
| `2c4858b` `docs(utils)` | spell out the full config resolution order — added after review, see below |

Each commit passes on its own.

Three reasons the second is a deletion rather than a rename.

First, nothing calls it. Before the deletion, a repo-wide grep for `get_config_info` returned the definition alone (`utils/token_manager.py:317`), and it is not exposed as an MCP tool.

Second, it is left over from a cleanup rather than kept for something planned. At the initial commit, `tools/auth_tools.py` wrapped it as the `auth://config` MCP resource:

```python
@mcp.resource(
    uri="auth://config",
    name="Config Information",
    description="Check current configuration directory information (development/production mode)",
    mime_type="application/json"
)
def auth_config_info() -> Dict[str, any]:
    return {
        "content": token_manager.get_config_info()
    }
```

Commit `29e4f01` ("Clean up unused authentication modules", 2025-09-25) deleted `tools/auth_tools.py` outright, taking the resource with it and leaving the method behind. `auth://config` greps to zero hits in the current tree — no code, no tests, no docs — so the resource removal itself was clean and this uncalled method is what stayed.

Third, correcting the name would leave a right answer nobody asks for. Of the four fields returned, `config_dir` and `token_file` are already in `get_auth_status()` directly above, in the same shape. That leaves `token_file_exists` and `env_config_file` as the only unique ones, and one of those two is the bug.

Reverting `e167257` brings it back if it turns out to be wanted.

### Added after review

`2c4858b` is outside the scope this branch set for itself. Issue #162 names two occurrences of the dead variable and nothing else, and the gap it closes predates this PR. It is here because review raised it against a line this PR had already rewritten, and leaving it would have made the branch's own claim half true: the docstring would agree with the code about the env var while still misdescribing what happens when that env var is unset.

The docstring named `~/.alpacon-mcp/token.json` as the only fallback. `__init__` also takes `./config/token.json` when the global file is absent (lines 44-46), so a run that picked up the local file had nothing in the docstring to explain why. `docs/troubleshooting.md:100` already lists the full order and the docstring now matches it.

One step from that doc line is deliberately left out. `ALPACON_MCP_<REGION>_<WORKSPACE>_TOKEN` comes first in the document's discovery order, but it applies when a token is read (`utils/token_manager.py:157`), not when the config file path is chosen, which is all `__init__` decides.

## Testing

- `pytest` → `1125 passed, 7 warnings in 6.58s`
- `python -c "from server import mcp; print('ok')"` → `ok`
- `ruff check .` → `All checks passed!` · `ruff format --check .` → `82 files already formatted`
- `mypy --ignore-missing-imports --no-strict-optional .` → `Found 8 errors in 1 file (checked 82 source files)`. All 8 are in `utils/oauth.py`, which is not in this diff. Pre-existing, and CI runs mypy with `continue-on-error: true`.

On what the test run proves: it is narrow. The deleted method had no tests, so passing means nothing depended on the symbol — it is not evidence that deleting it is correct. The evidence for that is the two greps above: zero callers of `get_config_info`, zero references to `auth://config`.

Closes #162
