### PR TITLE
fix(oauth): type the shared nonce cookie attributes as a TypedDict

### DIFF
--- a/utils/oauth.py
+++ b/utils/oauth.py
@@ -19,6 +19,7 @@ import secrets
 import time
 from functools import wraps
 from http import HTTPStatus
+from typing import Literal, TypedDict
 from urllib.parse import parse_qs, urlencode, urlparse, urlunparse
 
 import httpx
@@ -51,11 +52,19 @@ _STATE_TTL_SECONDS = 600
 # Domain, so the cookie cannot be planted by a sibling host.
 _NONCE_COOKIE_NAME = '__Host-alpacon_oauth_nonce'
 
+
+class _NonceCookieAttrs(TypedDict):
+    path: str
+    secure: bool
+    httponly: bool
+    samesite: Literal['lax', 'strict', 'none']
+
+
 # Shared by set and delete: the delete has to repeat Path, or it addresses a
 # different cookie, and Secure, or the browser rejects the whole Set-Cookie
 # under a __Host- name and the cookie survives. SameSite stays Lax because
 # Strict drops the cookie on the top-level return from Auth0.
-_NONCE_COOKIE_ATTRS = {
+_NONCE_COOKIE_ATTRS: _NonceCookieAttrs = {
     'path': '/',
     'secure': True,
     'httponly': True,

--- a/utils/oauth.py
+++ b/utils/oauth.py
@@ -54,8 +54,8 @@ _NONCE_COOKIE_NAME = '__Host-alpacon_oauth_nonce'
 
 
 class _NonceCookieAttrs(TypedDict):
-    path: str
-    secure: bool
+    path: Literal['/']
+    secure: Literal[True]
     httponly: bool
     samesite: Literal['lax', 'strict', 'none']
 


### PR DESCRIPTION
## Background

`_NONCE_COOKIE_ATTRS` in `utils/oauth.py` is a bare dict literal, so mypy infers its values as `dict[str, object]`. Unpacking it in `_set_nonce_cookie` and `_clear_nonce_cookie` produces one `arg-type` error per key (`path`, `secure`, `httponly`, `samesite`) at each of the two call sites, eight in total.

The mypy step in `.github/workflows/test.yml:55` is `continue-on-error: true`, so CI stays green. A local pre-commit hook running mypy is not, and it blocks every commit that touches the file.

## Changes

Added a `_NonceCookieAttrs` TypedDict and annotated `_NONCE_COOKIE_ATTRS` with it. `samesite` is narrowed to the `Literal['lax', 'strict', 'none']` starlette expects.

`path` and `secure` are pinned to `Literal['/']` and `Literal[True]`, following review. The `__Host-` prefix makes the browser require both, and that invariant previously lived only in the comment below the constant, so `'secure': False` type-checked clean. `httponly` stays `bool` because `__Host-` does not require HttpOnly — that one is our own policy, not a browser rule.

No call site changes: `Literal[True]` is a subtype of `bool` and `Literal['/']` of `str`, so both still satisfy starlette's `set_cookie` and `delete_cookie` signatures. The dict values are untouched, so the emitted Set-Cookie header is unchanged.

The class sits above the comment rather than below it: the comment explains why set and delete share these values, so it belongs with the constant.

## Testing

- `mypy --ignore-missing-imports --no-strict-optional .`: `Success: no issues found in 82 source files`, down from `Found 8 errors in 1 file`
- Negative check on the pinned values: setting `'path': '/oauth'` and `'secure': False` now fails with two `typeddict-item` errors; reverting them is clean again
- `ruff check .`: `All checks passed!`
- `pytest tests/`: `1125 passed, 7 warnings in 7.21s`

Closes #167
