### PR TITLE
ci: check formatting and pin the ruff version

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -20,6 +20,9 @@ jobs:
 
     env:
       UV_PYTHON: python${{ matrix.python-version }}
+      # Formatter output differs between releases; keep in step with the rev
+      # in .pre-commit-config.yaml.
+      RUFF_VERSION: "0.15.13"
 
     steps:
     - uses: actions/checkout@v6
@@ -45,8 +48,11 @@ jobs:
 
     - name: Lint with ruff
       run: |
-        uv pip install ruff
+        uv pip install ruff==${{ env.RUFF_VERSION }}
         uv run --no-sync ruff check .
+
+    - name: Check formatting with ruff
+      run: uv run --no-sync ruff format --check .
 
     - name: Type check with mypy
       run: |

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,6 +1,6 @@
 repos:
   - repo: https://github.com/astral-sh/ruff-pre-commit
-    rev: v0.9.7
+    rev: v0.15.13
     hooks:
       - id: ruff
         args: [--fix]

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -58,8 +58,9 @@ Thank you for your interest in contributing to the Alpacon MCP server! This guid
    # Check a token against the API (prompts for region and workspace)
    python main.py test
 
-   # Lint and type check
+   # Lint, formatting, and type check
    ruff check .
+   ruff format --check .
    mypy --ignore-missing-imports --no-strict-optional .
    ```
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -72,7 +72,7 @@ We use the following tools for code quality:
 - **ruff** for linting, import sorting, and formatting
 - **mypy** for type checking
 
-Both run as pre-commit hooks, and CI runs `ruff check`, `mypy`, and `pytest` under a coverage floor set in `.github/workflows/test.yml`.
+Both run as pre-commit hooks, and CI runs `ruff check`, `ruff format --check`, `mypy`, and `pytest` under a coverage floor set in `.github/workflows/test.yml`.
 
 ```bash
 # Format code

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -413,7 +413,7 @@ ruff format .
 mypy --ignore-missing-imports --no-strict-optional .
 ```
 
-CI runs the same three: `ruff check`, `mypy`, and `pytest` under a coverage floor. `.github/workflows/test.yml` holds the current threshold.
+CI runs the same checks: `ruff check`, `ruff format --check`, `mypy`, and `pytest` under a coverage floor. `.github/workflows/test.yml` holds the current threshold.
 
 ### Custom configuration
 


### PR DESCRIPTION
## Background

The pre-commit config runs two ruff hooks, `ruff` and `ruff-format`, but `.github/workflows/test.yml` ran only `ruff check`. The two subcommands look at different things. The linter reads what the code means — unused imports, import order (`I`), security patterns (`S`), naming (`N`), bugbear (`B`). The formatter reads how it looks — line breaks, indentation, quote style, spacing. Neither substitutes for the other. `pyproject.toml:118` disables E501 with the comment `# line too long (formatter handles this)`, and since CI never ran the formatter, nothing in the pipeline was checking line length at all. Any commit that skipped the hooks carried its formatting through review untouched.

The ruff version was also unmanaged. The hook was pinned at `v0.9.7` while CI installed whatever `uv pip install ruff` resolved to on the day the job ran.

## Changes

`.github/workflows/test.yml` gains a `Check formatting with ruff` step running `ruff format --check .`, and the install in the lint step is pinned to `ruff==${{ env.RUFF_VERSION }}` with `RUFF_VERSION: "0.15.13"` declared on the job. Formatter output changes between releases, so without a pin a ruff release turns open PRs red without anyone touching the code.

`.pre-commit-config.yaml` moves the ruff rev from `v0.9.7` to `v0.15.13` to name the same release the workflow pins. The two pins are tied together only by the comment above `RUFF_VERSION`; nothing enforces it, and a mismatch surfaces as a CI failure on a tree that passed locally.

`CONTRIBUTING.md` and `docs/installation.md` list `ruff format --check` among the checks CI runs, and step 4 of the setup in `CONTRIBUTING.md` now runs it next to `ruff check` and `mypy`, so a contributor following the setup verbatim exercises every gate CI blocks on.

The format check is a separate step rather than a second line in the lint step so the Actions summary names which check failed.

## Markdown is deliberately out of scope

#168 was filed on the premise that `ruff format` reaches into fenced Python inside markdown and that the pre-commit hook rewrites `CONTRIBUTING.md` and `docs/troubleshooting.md` on every commit. That premise does not hold:

- The upstream hook declares `types_or: [python, pyi, jupyter]` (astral-sh/ruff-pre-commit `v0.15.13`, `.pre-commit-hooks.yaml`). It has never passed a markdown file to ruff.
- Ruff can format markdown, but only under `--preview`. Without it: `error: Failed to format README.md: Markdown formatting is experimental, enable preview mode.`
- That formatter reformats the document, not only its fenced Python — line breaks, list markers, tables.

Putting 14 markdown files under an experimental formatter means the documentation set gets rewritten whenever ruff changes it, and the pre-commit hook cannot check markdown, so the failure would appear only in CI with no local command to reproduce it. A markdown check is worth revisiting once the feature leaves preview and the hook covers it.

## Testing

The repository is already clean at the pinned version, so this PR reformats nothing:

```
$ ruff check .
All checks passed!

$ ruff format --check .
82 files already formatted
```

CI on this PR is the real check — it runs the new step across Python 3.12, 3.13, and 3.14.

## Follow-ups

`CONTRIBUTING.md:35` and `docs/installation.md:399` still say `uv tool install ruff` with no version, so a contributor can install a release whose formatter disagrees with the CI pin. That belongs with #166, which moves `ruff` and `pre-commit` into the dev extra.

Closes #168

